### PR TITLE
Use netgo when building

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
     goarch:
       - amd64
     flags:
-      - -tags=assets
+      - -tags=assets,netgo
       - -trimpath
 
 sboms:


### PR DESCRIPTION
Re: #993 

Add `netgo` build tag when building Flipt release

Backport for v1.9 (will create 1.9.1). Will do the same for v1.10 (1.10.1)

