### PR TITLE
JSON log output

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -150,5 +150,4 @@ tasks:
     vars:
       COVERAGE_FILE: coverage.txt
       TEST_PATTERN: .
-      TEST_FLAGS: -v
       TEST_OPTS: -race

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -662,10 +662,10 @@ func run(ctx context.Context, logger *zap.Logger) error {
 
 			fmt.Println()
 		} else {
-			logger.Info("api starting", zap.String("address", apiAddr))
+			logger.Info("api available", zap.String("address", apiAddr))
 
 			if cfg.UI.Enabled {
-				logger.Info("ui starting", zap.String("address", uiAddr))
+				logger.Info("ui available", zap.String("address", uiAddr))
 			}
 		}
 

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -662,7 +662,7 @@ func run(ctx context.Context, logger *zap.Logger) error {
 
 			fmt.Println()
 		} else {
-			logger.Info(fmt.Sprintf("api: %s", apiAddr))
+			logger.Info("api starting", zap.String("address", apiAddr))
 
 			if cfg.UI.Enabled {
 				logger.Info(fmt.Sprintf("ui: %s", uiAddr))

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	"github.com/google/go-github/v32/github"
-	"github.com/mattn/go-isatty"
 	"github.com/phyber/negroni-gzip/gzip"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -245,12 +244,7 @@ func run(ctx context.Context, logger *zap.Logger) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	tty := isatty.IsTerminal(os.Stdout.Fd())
-
-	if tty {
-		color.Cyan(banner)
-		fmt.Println()
-	}
+	color.Cyan("%s\n", banner)
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
@@ -649,15 +643,13 @@ func run(ctx context.Context, logger *zap.Logger) error {
 
 		logger.Debug("starting http server")
 
-		if tty {
-			color.Green("\nAPI: %s://%s:%d/api/v1", cfg.Server.Protocol, cfg.Server.Host, httpPort)
+		color.Green("\nAPI: %s://%s:%d/api/v1", cfg.Server.Protocol, cfg.Server.Host, httpPort)
 
-			if cfg.UI.Enabled {
-				color.Green("UI: %s://%s:%d", cfg.Server.Protocol, cfg.Server.Host, httpPort)
-			}
-
-			fmt.Println()
+		if cfg.UI.Enabled {
+			color.Green("UI: %s://%s:%d", cfg.Server.Protocol, cfg.Server.Host, httpPort)
 		}
+
+		fmt.Println()
 
 		if cfg.Server.Protocol == config.HTTPS {
 			httpServer.TLSConfig = &tls.Config{

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -665,7 +665,7 @@ func run(ctx context.Context, logger *zap.Logger) error {
 			logger.Info("api starting", zap.String("address", apiAddr))
 
 			if cfg.UI.Enabled {
-				logger.Info(fmt.Sprintf("ui: %s", uiAddr))
+				logger.Info("ui starting", zap.String("address", uiAddr))
 			}
 		}
 

--- a/config/config.go
+++ b/config/config.go
@@ -32,9 +32,34 @@ type Config struct {
 }
 
 type LogConfig struct {
-	Level string `json:"level,omitempty"`
-	File  string `json:"file,omitempty"`
+	Level    string      `json:"level,omitempty"`
+	File     string      `json:"file,omitempty"`
+	Encoding LogEncoding `json:"encoding,omitempty"`
 }
+
+type LogEncoding uint8
+
+func (e LogEncoding) String() string {
+	return logEncodingToString[e]
+}
+
+const (
+	_ LogEncoding = iota
+	LogEncodingConsole
+	LogEncodingJSON
+)
+
+var (
+	logEncodingToString = map[LogEncoding]string{
+		LogEncodingConsole: "console",
+		LogEncodingJSON:    "json",
+	}
+
+	stringToLogEncoding = map[string]LogEncoding{
+		"console": LogEncodingConsole,
+		"json":    LogEncodingJSON,
+	}
+)
 
 type UIConfig struct {
 	Enabled bool `json:"enabled"`
@@ -189,7 +214,8 @@ var (
 func Default() *Config {
 	return &Config{
 		Log: LogConfig{
-			Level: "INFO",
+			Level:    "INFO",
+			Encoding: LogEncodingConsole,
 		},
 
 		UI: UIConfig{
@@ -248,8 +274,9 @@ func Default() *Config {
 
 const (
 	// Logging
-	logLevel = "log.level"
-	logFile  = "log.file"
+	logLevel    = "log.level"
+	logFile     = "log.file"
+	logEncoding = "log.encoding"
 
 	// UI
 	uiEnabled = "ui.enabled"
@@ -323,6 +350,10 @@ func Load(path string) (*Config, error) {
 
 	if viper.IsSet(logFile) {
 		cfg.Log.File = viper.GetString(logFile)
+	}
+
+	if viper.IsSet(logEncoding) {
+		cfg.Log.Encoding = stringToLogEncoding[viper.GetString(logEncoding)]
 	}
 
 	// UI

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -197,8 +197,9 @@ func TestLoad(t *testing.T) {
 			expected: func() *Config {
 				cfg := Default()
 				cfg.Log = LogConfig{
-					Level: "WARN",
-					File:  "testLogFile.txt",
+					Level:    "WARN",
+					File:     "testLogFile.txt",
+					Encoding: LogEncodingJSON,
 				}
 				cfg.UI = UIConfig{
 					Enabled: false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -106,6 +106,36 @@ func TestDatabaseProtocol(t *testing.T) {
 	}
 }
 
+func TestLogEncoding(t *testing.T) {
+	tests := []struct {
+		name     string
+		encoding LogEncoding
+		want     string
+	}{
+		{
+			name:     "console",
+			encoding: LogEncodingConsole,
+			want:     "console",
+		},
+		{
+			name:     "json",
+			encoding: LogEncodingJSON,
+			want:     "json",
+		},
+	}
+
+	for _, tt := range tests {
+		var (
+			encoding = tt.encoding
+			want     = tt.want
+		)
+
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, want, encoding.String())
+		})
+	}
+}
+
 func TestLoad(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/config/testdata/advanced.yml
+++ b/config/testdata/advanced.yml
@@ -1,6 +1,7 @@
 log:
   level: WARN
   file: "testLogFile.txt"
+  encoding: "json"
 
 ui:
   enabled: false


### PR DESCRIPTION
Fixes #992 

![CleanShot 2022-09-13 at 09 53 56](https://user-images.githubusercontent.com/209477/189919812-4cf81d64-eea3-4411-9c31-bf9200958081.png)

1. Adds support for encoding log output as JSON using either `FLIPT_LOG_ENCODING` env var or setting `log.encoding` via yaml
2. Only prints banner and api/ui addrs as text if we're running in console mode

/cc @GeorgeMac 

## TODO

- [ ] Update docs