### PR TITLE
feat(logging): forward grpc internal logging to zap

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -461,6 +461,16 @@ func run(ctx context.Context, logger *zap.Logger) error {
 
 		opentracing.SetGlobalTracer(tracer)
 
+		{
+			// forward internal gRPC logging to zap
+			grpcLogLevel, err := zapcore.ParseLevel(cfg.Log.GRPCLevel)
+			if err != nil {
+				return fmt.Errorf("parsing grpc log level (%q): %w", cfg.Log.GRPCLevel, err)
+			}
+
+			grpc_zap.ReplaceGrpcLoggerV2(logger.WithOptions(zap.IncreaseLevel(grpcLogLevel)))
+		}
+
 		interceptors := []grpc.UnaryServerInterceptor{
 			grpc_recovery.UnaryServerInterceptor(),
 			grpc_ctxtags.UnaryServerInterceptor(),

--- a/config/config.go
+++ b/config/config.go
@@ -32,9 +32,10 @@ type Config struct {
 }
 
 type LogConfig struct {
-	Level    string      `json:"level,omitempty"`
-	File     string      `json:"file,omitempty"`
-	Encoding LogEncoding `json:"encoding,omitempty"`
+	Level     string      `json:"level,omitempty"`
+	File      string      `json:"file,omitempty"`
+	Encoding  LogEncoding `json:"encoding,omitempty"`
+	GRPCLevel string      `json:"grpc_level,omitempty"`
 }
 
 type LogEncoding uint8
@@ -214,8 +215,9 @@ var (
 func Default() *Config {
 	return &Config{
 		Log: LogConfig{
-			Level:    "INFO",
-			Encoding: LogEncodingConsole,
+			Level:     "INFO",
+			Encoding:  LogEncodingConsole,
+			GRPCLevel: "ERROR",
 		},
 
 		UI: UIConfig{
@@ -274,9 +276,10 @@ func Default() *Config {
 
 const (
 	// Logging
-	logLevel    = "log.level"
-	logFile     = "log.file"
-	logEncoding = "log.encoding"
+	logLevel     = "log.level"
+	logFile      = "log.file"
+	logEncoding  = "log.encoding"
+	logGRPCLevel = "log.grpc_level"
 
 	// UI
 	uiEnabled = "ui.enabled"
@@ -354,6 +357,10 @@ func Load(path string) (*Config, error) {
 
 	if viper.IsSet(logEncoding) {
 		cfg.Log.Encoding = stringToLogEncoding[viper.GetString(logEncoding)]
+	}
+
+	if viper.IsSet(logGRPCLevel) {
+		cfg.Log.GRPCLevel = viper.GetString(logGRPCLevel)
 	}
 
 	// UI

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -227,9 +227,10 @@ func TestLoad(t *testing.T) {
 			expected: func() *Config {
 				cfg := Default()
 				cfg.Log = LogConfig{
-					Level:    "WARN",
-					File:     "testLogFile.txt",
-					Encoding: LogEncodingJSON,
+					Level:     "WARN",
+					File:      "testLogFile.txt",
+					Encoding:  LogEncodingJSON,
+					GRPCLevel: "ERROR",
 				}
 				cfg.UI = UIConfig{
 					Enabled: false,

--- a/config/testdata/default.yml
+++ b/config/testdata/default.yml
@@ -1,5 +1,6 @@
 # log:
 #   level: INFO
+#   grpc_level: ERROR
 
 # ui:
 #   enabled: true


### PR DESCRIPTION
This continues on from a discussion in the original logrus to zap PR: https://github.com/flipt-io/flipt/pull/1020

This forwards all gRPC internal logging into zap.

Originally, I tried to use `grpc_zap.ReplaceGrpcLoggerV2` in the first PR, which led to lots of gRPC chatter in the logs.
This was because the default zap level for all Flipt logs was INFO and gRPC has a lot of INFO chatter.

Normally, the default severity level for gRPC is `ERROR`. Which is why you don't see this.

My first attempt to improve this tapped into the env var `GRPC_GO_LOG_SEVERITY_LEVEL`.
However, this had the interesting effect of both forwarding logs to zap *and* printing gRPC logs in their native log format to stdout/stderr.

Instead, I have now introduced a new flipt compatible `log.grpc_level` option.
This option defaults to `ERROR` level. So that the default behaviour is as expected.
However, the grpc log level can always be increased independently up to the main flipt log-level (but not exceed).

see: `FLIPT_LOG_GRPC_LEVEL`

Normal behaviour is as expected:

<img width="1594" alt="Screenshot 2022-09-13 at 09 35 07" src="https://user-images.githubusercontent.com/1253326/189853467-4fb04c16-3fea-4c9f-a5c8-fe3c9677c9bd.png">

Increased gRPC log-level forwards to zap:

<img width="1594" alt="Screenshot 2022-09-13 at 09 27 40" src="https://user-images.githubusercontent.com/1253326/189853606-83741ee2-f135-4249-979d-98060add3367.png">


Signed-off-by: George MacRorie <me@georgemac.com>