### PR TITLE
Fix parse error for bool/number to not return 500

### DIFF
--- a/server/evaluator.go
+++ b/server/evaluator.go
@@ -296,6 +296,7 @@ func matchesNumber(c storage.EvaluationConstraint, v string) (bool, error) {
 		return false, errs.ErrInvalidf("parsing number from %q", v)
 	}
 
+	// TODO: we should consider parsing this at creation time since it doesn't change and it doesnt make sense to allow invalid constraint values
 	value, err := strconv.ParseFloat(c.Value, 64)
 	if err != nil {
 		return false, errs.ErrInvalidf("parsing number from %q", c.Value)

--- a/server/evaluator.go
+++ b/server/evaluator.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"hash/crc32"
 	"sort"
 	"strconv"
@@ -294,12 +293,12 @@ func matchesNumber(c storage.EvaluationConstraint, v string) (bool, error) {
 
 	n, err := strconv.ParseFloat(v, 64)
 	if err != nil {
-		return false, fmt.Errorf("parsing number from %q", v)
+		return false, errs.ErrInvalidf("parsing number from %q", v)
 	}
 
 	value, err := strconv.ParseFloat(c.Value, 64)
 	if err != nil {
-		return false, fmt.Errorf("parsing number from %q", c.Value)
+		return false, errs.ErrInvalidf("parsing number from %q", c.Value)
 	}
 
 	switch c.Operator {
@@ -335,7 +334,7 @@ func matchesBool(c storage.EvaluationConstraint, v string) (bool, error) {
 
 	value, err := strconv.ParseBool(v)
 	if err != nil {
-		return false, fmt.Errorf("parsing boolean from %q", v)
+		return false, errs.ErrInvalidf("parsing boolean from %q", v)
 	}
 
 	switch c.Operator {

--- a/server/evaluator_test.go
+++ b/server/evaluator_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/flipt/errors"
+	errs "go.flipt.io/flipt/errors"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 	"go.flipt.io/flipt/storage"
 	"go.uber.org/zap/zaptest"
@@ -1952,6 +1953,8 @@ func Test_matchesNumber(t *testing.T) {
 
 			if wantErr {
 				require.Error(t, err)
+				var ierr errs.ErrInvalid
+				require.ErrorAs(t, err, &ierr)
 				return
 			}
 
@@ -2074,6 +2077,8 @@ func Test_matchesBool(t *testing.T) {
 
 			if wantErr {
 				require.Error(t, err)
+				var ierr errs.ErrInvalid
+				require.ErrorAs(t, err, &ierr)
 				return
 			}
 

--- a/server/evaluator_test.go
+++ b/server/evaluator_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.flipt.io/flipt/errors"
 	errs "go.flipt.io/flipt/errors"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 	"go.flipt.io/flipt/storage"
@@ -84,7 +83,7 @@ func TestBatchEvaluate_FlagNotFoundExcluded(t *testing.T) {
 	}
 	store.On("GetFlag", mock.Anything, "foo").Return(enabledFlag, nil)
 	store.On("GetFlag", mock.Anything, "bar").Return(disabled, nil)
-	store.On("GetFlag", mock.Anything, "NotFoundFlag").Return(&flipt.Flag{}, errors.ErrNotFoundf("flag %q", "NotFoundFlag"))
+	store.On("GetFlag", mock.Anything, "NotFoundFlag").Return(&flipt.Flag{}, errs.ErrNotFoundf("flag %q", "NotFoundFlag"))
 
 	store.On("GetEvaluationRules", mock.Anything, "foo").Return([]*storage.EvaluationRule{}, nil)
 
@@ -132,7 +131,7 @@ func TestBatchEvaluate_FlagNotFound(t *testing.T) {
 	}
 	store.On("GetFlag", mock.Anything, "foo").Return(enabledFlag, nil)
 	store.On("GetFlag", mock.Anything, "bar").Return(disabled, nil)
-	store.On("GetFlag", mock.Anything, "NotFoundFlag").Return(&flipt.Flag{}, errors.ErrNotFoundf("flag %q", "NotFoundFlag"))
+	store.On("GetFlag", mock.Anything, "NotFoundFlag").Return(&flipt.Flag{}, errs.ErrNotFoundf("flag %q", "NotFoundFlag"))
 
 	store.On("GetEvaluationRules", mock.Anything, "foo").Return([]*storage.EvaluationRule{}, nil)
 
@@ -172,7 +171,7 @@ func TestEvaluate_FlagNotFound(t *testing.T) {
 		}
 	)
 
-	store.On("GetFlag", mock.Anything, "foo").Return(&flipt.Flag{}, errors.ErrNotFoundf("flag %q", "foo"))
+	store.On("GetFlag", mock.Anything, "foo").Return(&flipt.Flag{}, errs.ErrNotFoundf("flag %q", "foo"))
 
 	resp, err := s.Evaluate(context.TODO(), &flipt.EvaluationRequest{
 		EntityId: "1",

--- a/storage/sql/db_test.go
+++ b/storage/sql/db_test.go
@@ -278,12 +278,13 @@ func TestParse(t *testing.T) {
 			driver  = tt.driver
 			url     = tt.dsn
 			wantErr = tt.wantErr
+			opts    = tt.options
 		)
 
 		t.Run(tt.name, func(t *testing.T) {
 			d, u, err := parse(config.Config{
 				Database: cfg,
-			}, tt.options)
+			}, opts)
 
 			if wantErr {
 				require.Error(t, err)

--- a/ui/src/components/Flags/DebugConsole.vue
+++ b/ui/src/components/Flags/DebugConsole.vue
@@ -58,6 +58,7 @@ export default {
   data() {
     return {
       invalidRequest: false,
+      isError: false,
       request: clone(DEFAULT_REQUEST),
       response: {},
     };
@@ -66,7 +67,7 @@ export default {
     responseClass() {
       if (isEmpty(this.response)) {
         return "";
-      } else if (this.response.error) {
+      } else if (this.isError) {
         return "is-danger";
       } else {
         return "is-success";
@@ -92,6 +93,7 @@ export default {
       this.request.entityId = uuidv4();
       this.request.flagKey = this.flag.key;
       this.response = {};
+      this.isError = false;
     },
     evaluate() {
       Api.post("/evaluate", this.request)
@@ -99,7 +101,16 @@ export default {
           this.response = response.data;
         })
         .catch((error) => {
-          this.response = { error: error.response.data.error };
+          this.isError = true;
+          if (error.response) {
+            this.response = {
+              error: error.response.data.message,
+            };
+          } else {
+            this.response = {
+              error: error.message,
+            };
+          }
         });
     },
   },

--- a/ui/src/components/Flags/DebugConsole.vue
+++ b/ui/src/components/Flags/DebugConsole.vue
@@ -58,7 +58,6 @@ export default {
   data() {
     return {
       invalidRequest: false,
-      isError: false,
       request: clone(DEFAULT_REQUEST),
       response: {},
     };
@@ -67,7 +66,7 @@ export default {
     responseClass() {
       if (isEmpty(this.response)) {
         return "";
-      } else if (this.isError) {
+      } else if (this.response.error) {
         return "is-danger";
       } else {
         return "is-success";
@@ -93,7 +92,6 @@ export default {
       this.request.entityId = uuidv4();
       this.request.flagKey = this.flag.key;
       this.response = {};
-      this.isError = false;
     },
     evaluate() {
       Api.post("/evaluate", this.request)
@@ -101,7 +99,6 @@ export default {
           this.response = response.data;
         })
         .catch((error) => {
-          this.isError = true;
           if (error.response) {
             this.response = {
               error: error.response.data.message,


### PR DESCRIPTION
Fixes: #1046 

Now returns a 400 Bad Request from the API when a value cannot be parsed at the type expected.

Also, updates the DebugConsole UI to show the error message and correctly style the response.

![Screen Shot 2022-09-30 at 9 50 38 AM](https://user-images.githubusercontent.com/209477/193285551-fee4e29e-5de6-44d8-8dcc-691243dcecc6.jpg)
![Screen Shot 2022-09-30 at 9 50 44 AM](https://user-images.githubusercontent.com/209477/193285596-fef85eeb-ac72-4122-919a-ce31857f0165.jpg)
