### PR TITLE
fix: initialize shutdown context timeout after interrupt

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -533,7 +533,10 @@ func run(ctx context.Context, logger *zap.Logger) error {
 		grpcServer = grpc.NewServer(grpcOpts...)
 
 		// register grpcServer graceful stop on shutdown
-		shutdownFuncs = append(shutdownFuncs, func(context.Context) { grpcServer.GracefulStop() })
+		shutdownFuncs = append(shutdownFuncs, func(context.Context) {
+			grpcServer.GracefulStop()
+			logger.Info("grpc server shutdown gracefully")
+		})
 
 		pb.RegisterFliptServer(grpcServer, srv)
 		grpc_prometheus.EnableHandlingTimeHistogram()
@@ -660,7 +663,10 @@ func run(ctx context.Context, logger *zap.Logger) error {
 		}
 
 		// register httpServer graceful stop on shutdown
-		shutdownFuncs = append(shutdownFuncs, func(ctx context.Context) { _ = httpServer.Shutdown(ctx) })
+		shutdownFuncs = append(shutdownFuncs, func(ctx context.Context) {
+			_ = httpServer.Shutdown(ctx)
+			logger.Info("http server shutdown gracefully")
+		})
 
 		logger.Debug("starting http server")
 
@@ -708,7 +714,6 @@ func run(ctx context.Context, logger *zap.Logger) error {
 			return fmt.Errorf("http server: %w", err)
 		}
 
-		logger.Info("server shutdown gracefully")
 		return nil
 	})
 


### PR DESCRIPTION
Just a quick fix for an observation.

The shutdown context and 5 second timeout was getting initialized on Flipt start.
Meaning, the shutdown context was likely (unless Flipt was stopped immediately) to be well and truly cancelled before any interrupt is sent.

This moves the initialization of the 5-second timeout context to be after any interrupt is received.
Ensuring at-least five seconds grace period is given on shutdown (maybe this should be configurable too at some point).