### PR TITLE
Run snapshot workflow on release branch

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,6 +1,9 @@
 name: Release (Snapshot)
 on:
   workflow_dispatch:
+pull_request:
+  branches:
+    - release/*
 
 jobs:
   snapshot:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Page token based pagination for `list` methods for forward compatibility with
   future versions of the API [#936](https://github.com/flipt-io/flipt/issues/936)
+- Support for CockroachDB :tada: [#1064](https://github.com/flipt-io/flipt/pull/1064)
 
 ### Changed
 


### PR DESCRIPTION
- Run snapshot workflow on `release/*` branches
- Update Changelog to include support for CockroachDB that was added