### PR TITLE
Swap to http.Method* Constants

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -608,7 +608,7 @@ func run(ctx context.Context, logger *zap.Logger) error {
 		if cfg.Cors.Enabled {
 			cors := cors.New(cors.Options{
 				AllowedOrigins:   cfg.Cors.AllowedOrigins,
-				AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+				AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
 				AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 				ExposedHeaders:   []string{"Link"},
 				AllowCredentials: true,


### PR DESCRIPTION
Such a minor thing, but swapping the HTTP method strings to the available constants.