### PR TITLE
refactor(storage/sql): embed migrations into flipt binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,6 @@ archives:
       - LICENSE
       - README.md
       - CHANGELOG.md
-      - ./config/migrations/
       - ./config/default.yml
 
 checksum:
@@ -60,7 +59,6 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     extra_files:
-      - config/migrations/
       - config/default.yml
 
   - dockerfile: ./build/Dockerfile
@@ -75,7 +73,6 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
     extra_files:
-      - config/migrations/
       - config/default.yml
 
 docker_manifests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Deprecated
+
+- Deprecated both `db.migrations.path` and `db.migrations_path` [#1096](https://github.com/flipt-io/flipt/pull/1096)
+
 ## [v1.13.0](https://github.com/markphelps/flipt/releases/tag/v1.13.0) - 2022-10-17
 
 ### Added

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -38,6 +38,13 @@ Description.
 
 `offset` has been deprecated in favor of `page_token`/`next_page_token` for `ListFlagRequest`, `ListSegmentRequest` and `ListRuleRequest`. See: [#936](https://github.com/flipt-io/flipt/issues/936).
 
+### db.migrations.path and db.migrations_path
+
+> since [v1.14.0](https://github.com/markphelps/flipt/releases/tag/v1.10.0)
+
+These options are no longer considered during Flipt execution.
+Database migrations are embedded directly within the Flipt binary.
+
 ### cache.memory.enabled
 
 > since [v1.10.0](https://github.com/markphelps/flipt/releases/tag/v1.10.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN mkdir -p /etc/flipt && \
     mkdir -p /var/opt/flipt
 
 COPY --from=build /home/flipt/bin/flipt /
-COPY config/migrations/ /etc/flipt/config/migrations/
 COPY config/*.yml /etc/flipt/config/
 
 RUN addgroup flipt && \

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,8 +32,6 @@ tasks:
     cmds:
       - task: default
         vars: { OUTPUT: "./pkg" }
-      - mkdir -p ./pkg/config/migrations
-      - cp -R ./config/migrations/ ./pkg/config/migrations/
       - cp ./config/*.yml ./pkg/config/
     vars:
       GIT_COMMIT:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,6 @@ RUN mkdir -p /etc/flipt && \
     mkdir -p /var/opt/flipt
 
 COPY $BINARY /
-COPY config/migrations/ /etc/flipt/config/migrations/
 COPY config/*.yml /etc/flipt/config/
 
 RUN addgroup flipt && \

--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -33,7 +33,7 @@ func runExport(ctx context.Context, logger *zap.Logger) error {
 		cancel()
 	}()
 
-	db, driver, err := sql.Open(*cfg, logger)
+	db, driver, err := sql.Open(*cfg)
 	if err != nil {
 		return fmt.Errorf("opening db: %w", err)
 	}

--- a/cmd/flipt/import.go
+++ b/cmd/flipt/import.go
@@ -37,7 +37,7 @@ func runImport(ctx context.Context, logger *zap.Logger, args []string) error {
 		cancel()
 	}()
 
-	db, driver, err := sql.Open(*cfg, logger)
+	db, driver, err := sql.Open(*cfg)
 	if err != nil {
 		return fmt.Errorf("opening db: %w", err)
 	}

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -411,7 +411,7 @@ func run(ctx context.Context, logger *zap.Logger) error {
 			_ = lis.Close()
 		}()
 
-		db, driver, err := sql.Open(*cfg, logger)
+		db, driver, err := sql.Open(*cfg)
 		if err != nil {
 			return fmt.Errorf("opening db: %w", err)
 		}

--- a/config/default.yml
+++ b/config/default.yml
@@ -30,8 +30,6 @@
 
 # db:
 #   url: file:/var/opt/flipt/flipt.db
-#   migrations:
-#     path: /etc/flipt/config/migrations
 #   max_idle_conn: 2
 #   max_open_conn: 0 # unlimited
 #   conn_max_lifetime: 0 # unlimited

--- a/config/local.yml
+++ b/config/local.yml
@@ -27,5 +27,3 @@ log:
 
 db:
   url: file:flipt.db
-  migrations:
-    path: ./config/migrations

--- a/config/migrations/migrations.go
+++ b/config/migrations/migrations.go
@@ -1,0 +1,6 @@
+package migrations
+
+import "embed"
+
+//go:embed *
+var FS embed.FS

--- a/config/production.yml
+++ b/config/production.yml
@@ -13,5 +13,3 @@ server:
 
 db:
   url: postgres://postgres@localhost:5432/flipt?sslmode=disable
-  migrations:
-    path: ./config/migrations

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -200,9 +200,8 @@ func defaultConfig() *Config {
 		},
 
 		Database: DatabaseConfig{
-			URL:            "file:/var/opt/flipt/flipt.db",
-			MigrationsPath: "/etc/flipt/config/migrations",
-			MaxIdleConn:    2,
+			URL:         "file:/var/opt/flipt/flipt.db",
+			MaxIdleConn: 2,
 		},
 
 		Meta: MetaConfig{
@@ -239,6 +238,24 @@ func TestLoad(t *testing.T) {
 				cfg.Cache.Backend = CacheMemory
 				cfg.Cache.TTL = -1
 				cfg.Warnings = append(cfg.Warnings, deprecatedMsgMemoryEnabled, deprecatedMsgMemoryExpiration)
+				return cfg
+			},
+		},
+		{
+			name: "deprecated - database migrations path",
+			path: "./testdata/deprecated/database_migrations_path.yml",
+			expected: func() *Config {
+				cfg := defaultConfig()
+				cfg.Warnings = append(cfg.Warnings, deprecatedMsgDatabaseMigrations)
+				return cfg
+			},
+		},
+		{
+			name: "deprecated - database migrations path legacy",
+			path: "./testdata/deprecated/database_migrations_path_legacy.yml",
+			expected: func() *Config {
+				cfg := defaultConfig()
+				cfg.Warnings = append(cfg.Warnings, deprecatedMsgDatabaseMigrations)
 				return cfg
 			},
 		},
@@ -286,14 +303,13 @@ func TestLoad(t *testing.T) {
 			expected: func() *Config {
 				cfg := defaultConfig()
 				cfg.Database = DatabaseConfig{
-					Protocol:       DatabaseMySQL,
-					Host:           "localhost",
-					Port:           3306,
-					User:           "flipt",
-					Password:       "s3cr3t!",
-					Name:           "flipt",
-					MigrationsPath: "/etc/flipt/config/migrations",
-					MaxIdleConn:    2,
+					Protocol:    DatabaseMySQL,
+					Host:        "localhost",
+					Port:        3306,
+					User:        "flipt",
+					Password:    "s3cr3t!",
+					Name:        "flipt",
+					MaxIdleConn: 2,
 				}
 				return cfg
 			},
@@ -374,7 +390,6 @@ func TestLoad(t *testing.T) {
 					},
 				}
 				cfg.Database = DatabaseConfig{
-					MigrationsPath:  "./config/migrations",
 					URL:             "postgres://postgres@localhost:5432/flipt?sslmode=disable",
 					MaxIdleConn:     10,
 					MaxOpenConn:     50,

--- a/internal/config/deprecate.go
+++ b/internal/config/deprecate.go
@@ -2,6 +2,7 @@ package config
 
 const (
 	// deprecation messages
-	deprecatedMsgMemoryEnabled    = `'cache.memory.enabled' is deprecated and will be removed in a future version. Please use 'cache.backend' and 'cache.enabled' instead.`
-	deprecatedMsgMemoryExpiration = `'cache.memory.expiration' is deprecated and will be removed in a future version. Please use 'cache.ttl' instead.`
+	deprecatedMsgMemoryEnabled      = `'cache.memory.enabled' is deprecated and will be removed in a future version. Please use 'cache.backend' and 'cache.enabled' instead.`
+	deprecatedMsgMemoryExpiration   = `'cache.memory.expiration' is deprecated and will be removed in a future version. Please use 'cache.ttl' instead.`
+	deprecatedMsgDatabaseMigrations = `'db.migrations_path' is deprecated and will be removed in a future version. Migrations are embedded within Flipt and are no longer required on disk.`
 )

--- a/internal/config/deprecate.go
+++ b/internal/config/deprecate.go
@@ -4,5 +4,5 @@ const (
 	// deprecation messages
 	deprecatedMsgMemoryEnabled      = `'cache.memory.enabled' is deprecated and will be removed in a future version. Please use 'cache.backend' and 'cache.enabled' instead.`
 	deprecatedMsgMemoryExpiration   = `'cache.memory.expiration' is deprecated and will be removed in a future version. Please use 'cache.ttl' instead.`
-	deprecatedMsgDatabaseMigrations = `'db.migrations_path' is deprecated and will be removed in a future version. Migrations are embedded within Flipt and are no longer required on disk.`
+	deprecatedMsgDatabaseMigrations = `'db.migrations_path' is deprecated and will be removed in a future version. Migrations are now embedded within Flipt and are no longer required on disk.`
 )

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -32,8 +32,6 @@ tracing:
 
 db:
   url: postgres://postgres@localhost:5432/flipt?sslmode=disable
-  migrations:
-    path: ./config/migrations
   max_idle_conn: 10
   max_open_conn: 50
   conn_max_lifetime: 30m

--- a/internal/config/testdata/default.yml
+++ b/internal/config/testdata/default.yml
@@ -25,5 +25,3 @@
 
 # db:
 #   url: file:/var/opt/flipt/flipt.db
-#   migrations:
-#     path: /etc/flipt/config/migrations

--- a/internal/config/testdata/deprecated/database_migrations_path.yml
+++ b/internal/config/testdata/deprecated/database_migrations_path.yml
@@ -1,0 +1,2 @@
+db:
+  migrations_path: "../config/migrations"

--- a/internal/config/testdata/deprecated/database_migrations_path_legacy.yml
+++ b/internal/config/testdata/deprecated/database_migrations_path_legacy.yml
@@ -1,0 +1,3 @@
+db:
+  migrations:
+    path: "../config/migrations"

--- a/internal/config/testdata/server/https_missing_cert_file.yml
+++ b/internal/config/testdata/server/https_missing_cert_file.yml
@@ -25,5 +25,3 @@ server:
 
 # db:
 #   url: file:/var/opt/flipt/flipt.db
-#   migrations:
-#     path: /etc/flipt/config/migrations

--- a/internal/config/testdata/server/https_missing_cert_key.yml
+++ b/internal/config/testdata/server/https_missing_cert_key.yml
@@ -26,5 +26,3 @@ server:
 
 # db:
 #   url: file:/var/opt/flipt/flipt.db
-#   migrations:
-#     path: /etc/flipt/config/migrations

--- a/internal/config/testdata/server/https_not_found_cert_file.yml
+++ b/internal/config/testdata/server/https_not_found_cert_file.yml
@@ -27,5 +27,3 @@ server:
 
 # db:
 #   url: file:/var/opt/flipt/flipt.db
-#   migrations:
-#     path: /etc/flipt/config/migrations

--- a/internal/config/testdata/server/https_not_found_cert_key.yml
+++ b/internal/config/testdata/server/https_not_found_cert_key.yml
@@ -27,5 +27,3 @@ server:
 
 # db:
 #   url: file:/var/opt/flipt/flipt.db
-#   migrations:
-#     path: /etc/flipt/config/migrations

--- a/internal/storage/sql/db_internal_test.go
+++ b/internal/storage/sql/db_internal_test.go
@@ -1,0 +1,293 @@
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/config"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     config.DatabaseConfig
+		dsn     string
+		driver  Driver
+		options []Option
+		wantErr bool
+	}{
+		{
+			name: "sqlite url",
+			cfg: config.DatabaseConfig{
+				URL: "file:flipt.db",
+			},
+			driver: SQLite,
+			dsn:    "flipt.db?_fk=true&cache=shared",
+		},
+		{
+			name: "sqlite",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseSQLite,
+				Host:     "flipt.db",
+			},
+			driver: SQLite,
+			dsn:    "flipt.db?_fk=true&cache=shared",
+		},
+		{
+			name: "postgres url",
+			cfg: config.DatabaseConfig{
+				URL: "postgres://postgres@localhost:5432/flipt?sslmode=disable",
+			},
+			driver: Postgres,
+			dsn:    "dbname=flipt host=localhost port=5432 sslmode=disable user=postgres",
+		},
+		{
+			name: "postgres no disable sslmode",
+			cfg: config.DatabaseConfig{
+				URL: "postgres://postgres@localhost:5432/flipt",
+			},
+			driver: Postgres,
+			dsn:    "dbname=flipt host=localhost port=5432 user=postgres",
+		},
+		{
+			name: "postgres disable sslmode via opts",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabasePostgres,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     5432,
+				User:     "postgres",
+			},
+			options: []Option{WithSSLDisabled},
+			driver:  Postgres,
+			dsn:     "dbname=flipt host=localhost port=5432 sslmode=disable user=postgres",
+		},
+		{
+			name: "postgres no port",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabasePostgres,
+				Name:     "flipt",
+				Host:     "localhost",
+				User:     "postgres",
+			},
+			driver: Postgres,
+			dsn:    "dbname=flipt host=localhost user=postgres",
+		},
+		{
+			name: "postgres no password",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabasePostgres,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     5432,
+				User:     "postgres",
+			},
+			driver: Postgres,
+			dsn:    "dbname=flipt host=localhost port=5432 user=postgres",
+		},
+		{
+			name: "postgres with password",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabasePostgres,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     5432,
+				User:     "postgres",
+				Password: "foo",
+			},
+			driver: Postgres,
+			dsn:    "dbname=flipt host=localhost password=foo port=5432 user=postgres",
+		},
+		{
+			name: "mysql url",
+			cfg: config.DatabaseConfig{
+				URL: "mysql://mysql@localhost:3306/flipt",
+			},
+			driver: MySQL,
+			dsn:    "mysql@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true&sql_mode=ANSI",
+		},
+		{
+			name: "mysql no ANSI sql mode via opts",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseMySQL,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     3306,
+				User:     "mysql",
+			},
+			options: []Option{
+				WithMigrate,
+			},
+			driver: MySQL,
+			dsn:    "mysql@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true",
+		},
+		{
+			name: "mysql no port",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseMySQL,
+				Name:     "flipt",
+				Host:     "localhost",
+				User:     "mysql",
+				Password: "foo",
+			},
+			driver: MySQL,
+			dsn:    "mysql:foo@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true&sql_mode=ANSI",
+		},
+		{
+			name: "mysql no password",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseMySQL,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     3306,
+				User:     "mysql",
+			},
+			driver: MySQL,
+			dsn:    "mysql@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true&sql_mode=ANSI",
+		},
+		{
+			name: "mysql with password",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseMySQL,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     3306,
+				User:     "mysql",
+				Password: "foo",
+			},
+			driver: MySQL,
+			dsn:    "mysql:foo@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true&sql_mode=ANSI",
+		},
+		{
+			name: "cockroachdb url",
+			cfg: config.DatabaseConfig{
+				URL: "cockroachdb://cockroachdb@localhost:26257/flipt?sslmode=disable",
+			},
+			driver: CockroachDB,
+			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
+		},
+		{
+			name: "cockroachdb url alternative (cockroach://",
+			cfg: config.DatabaseConfig{
+				URL: "cockroach://cockroachdb@localhost:26257/flipt?sslmode=disable",
+			},
+			driver: CockroachDB,
+			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
+		},
+		{
+			name: "cockroachdb url alternative (crdb://",
+			cfg: config.DatabaseConfig{
+				URL: "crdb://cockroachdb@localhost:26257/flipt?sslmode=disable",
+			},
+			driver: CockroachDB,
+			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
+		},
+		{
+			name: "cockroachdb default disable sslmode",
+			// cockroachdb defaults to sslmode=disable
+			// https://www.cockroachlabs.com/docs/stable/connection-parameters.html#additional-connection-parameters
+			cfg: config.DatabaseConfig{
+				URL: "cockroachdb://cockroachdb@localhost:26257/flipt",
+			},
+			driver: CockroachDB,
+			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
+		},
+		{
+			name: "cockroachdb disable sslmode via opts",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseCockroachDB,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     26257,
+				User:     "cockroachdb",
+			},
+			options: []Option{
+				WithSSLDisabled,
+			},
+			driver: CockroachDB,
+			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
+		},
+		{
+			name: "cockroachdb no port",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseCockroachDB,
+				Name:     "flipt",
+				Host:     "localhost",
+				User:     "cockroachdb",
+			},
+			driver: CockroachDB,
+			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
+		},
+		{
+			name: "cockroachdb no password",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseCockroachDB,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     26257,
+				User:     "cockroachdb",
+			},
+			driver: CockroachDB,
+			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
+		},
+		{
+			name: "cockroachdb with password",
+			cfg: config.DatabaseConfig{
+				Protocol: config.DatabaseCockroachDB,
+				Name:     "flipt",
+				Host:     "localhost",
+				Port:     26257,
+				User:     "cockroachdb",
+				Password: "foo",
+			},
+			driver: CockroachDB,
+			dsn:    "postgres://cockroachdb:foo@localhost:26257/flipt?sslmode=disable",
+		},
+		{
+			name: "invalid url",
+			cfg: config.DatabaseConfig{
+				URL: "http://a b",
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown driver",
+			cfg: config.DatabaseConfig{
+				URL: "mongo://127.0.0.1",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		var (
+			cfg     = tt.cfg
+			driver  = tt.driver
+			url     = tt.dsn
+			wantErr = tt.wantErr
+			opts    Options
+		)
+
+		for _, opt := range tt.options {
+			opt(&opts)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			d, u, err := parse(config.Config{
+				Database: cfg,
+			}, opts)
+
+			if wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, driver, d)
+			assert.Equal(t, url, u.DSN)
+		})
+	}
+}

--- a/internal/storage/sql/db_test.go
+++ b/internal/storage/sql/db_test.go
@@ -1,45 +1,31 @@
-package sql
+package sql_test
 
 import (
 	"context"
-	"database/sql"
-	"errors"
-	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"go.flipt.io/flipt/internal/config"
 	"go.flipt.io/flipt/internal/storage"
+	fliptsql "go.flipt.io/flipt/internal/storage/sql"
 	"go.flipt.io/flipt/internal/storage/sql/mysql"
 	"go.flipt.io/flipt/internal/storage/sql/postgres"
 	"go.flipt.io/flipt/internal/storage/sql/sqlite"
+	fliptsqltesting "go.flipt.io/flipt/internal/storage/sql/testing"
 	"go.uber.org/zap/zaptest"
 
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/golang-migrate/migrate/v4/database"
-	"github.com/golang-migrate/migrate/v4/database/cockroachdb"
-	ms "github.com/golang-migrate/migrate/v4/database/mysql"
-	pg "github.com/golang-migrate/migrate/v4/database/postgres"
-
-	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
 func TestOpen(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-
 	tests := []struct {
 		name    string
 		cfg     config.DatabaseConfig
-		driver  Driver
+		driver  fliptsql.Driver
 		wantErr bool
 	}{
 		{
@@ -49,28 +35,28 @@ func TestOpen(t *testing.T) {
 				MaxOpenConn:     5,
 				ConnMaxLifetime: 30 * time.Minute,
 			},
-			driver: SQLite,
+			driver: fliptsql.SQLite,
 		},
 		{
 			name: "postgres url",
 			cfg: config.DatabaseConfig{
 				URL: "postgres://postgres@localhost:5432/flipt?sslmode=disable",
 			},
-			driver: Postgres,
+			driver: fliptsql.Postgres,
 		},
 		{
 			name: "mysql url",
 			cfg: config.DatabaseConfig{
 				URL: "mysql://mysql@localhost:3306/flipt",
 			},
-			driver: MySQL,
+			driver: fliptsql.MySQL,
 		},
 		{
 			name: "cockroachdb url",
 			cfg: config.DatabaseConfig{
 				URL: "cockroachdb://cockroachdb@localhost:26257/flipt?sslmode=disable",
 			},
-			driver: CockroachDB,
+			driver: fliptsql.CockroachDB,
 		},
 		{
 			name: "invalid url",
@@ -96,9 +82,9 @@ func TestOpen(t *testing.T) {
 		)
 
 		t.Run(tt.name, func(t *testing.T) {
-			db, d, err := Open(config.Config{
+			db, d, err := fliptsql.Open(config.Config{
 				Database: cfg,
-			}, logger)
+			})
 
 			if wantErr {
 				require.Error(t, err)
@@ -115,308 +101,14 @@ func TestOpen(t *testing.T) {
 	}
 }
 
-func TestParse(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-
-	tests := []struct {
-		name    string
-		cfg     config.DatabaseConfig
-		dsn     string
-		driver  Driver
-		options options
-		wantErr bool
-	}{
-		{
-			name: "sqlite url",
-			cfg: config.DatabaseConfig{
-				URL: "file:flipt.db",
-			},
-			driver: SQLite,
-			dsn:    "flipt.db?_fk=true&cache=shared",
-		},
-		{
-			name: "sqlite",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseSQLite,
-				Host:     "flipt.db",
-			},
-			driver: SQLite,
-			dsn:    "flipt.db?_fk=true&cache=shared",
-		},
-		{
-			name: "postgres url",
-			cfg: config.DatabaseConfig{
-				URL: "postgres://postgres@localhost:5432/flipt?sslmode=disable",
-			},
-			driver: Postgres,
-			dsn:    "dbname=flipt host=localhost port=5432 sslmode=disable user=postgres",
-		},
-		{
-			name: "postgres no disable sslmode",
-			cfg: config.DatabaseConfig{
-				URL: "postgres://postgres@localhost:5432/flipt",
-			},
-			driver: Postgres,
-			dsn:    "dbname=flipt host=localhost port=5432 user=postgres",
-		},
-		{
-			name: "postgres disable sslmode via opts",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabasePostgres,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     5432,
-				User:     "postgres",
-			},
-			options: options{
-				sslDisabled: true,
-			},
-			driver: Postgres,
-			dsn:    "dbname=flipt host=localhost port=5432 sslmode=disable user=postgres",
-		},
-		{
-			name: "postgres no port",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabasePostgres,
-				Name:     "flipt",
-				Host:     "localhost",
-				User:     "postgres",
-			},
-			driver: Postgres,
-			dsn:    "dbname=flipt host=localhost user=postgres",
-		},
-		{
-			name: "postgres no password",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabasePostgres,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     5432,
-				User:     "postgres",
-			},
-			driver: Postgres,
-			dsn:    "dbname=flipt host=localhost port=5432 user=postgres",
-		},
-		{
-			name: "postgres with password",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabasePostgres,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     5432,
-				User:     "postgres",
-				Password: "foo",
-			},
-			driver: Postgres,
-			dsn:    "dbname=flipt host=localhost password=foo port=5432 user=postgres",
-		},
-		{
-			name: "mysql url",
-			cfg: config.DatabaseConfig{
-				URL: "mysql://mysql@localhost:3306/flipt",
-			},
-			driver: MySQL,
-			dsn:    "mysql@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true&sql_mode=ANSI",
-		},
-		{
-			name: "mysql no ANSI sql mode via opts",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseMySQL,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     3306,
-				User:     "mysql",
-			},
-			options: options{
-				migrate: true,
-			},
-			driver: MySQL,
-			dsn:    "mysql@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true",
-		},
-		{
-			name: "mysql no port",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseMySQL,
-				Name:     "flipt",
-				Host:     "localhost",
-				User:     "mysql",
-				Password: "foo",
-			},
-			driver: MySQL,
-			dsn:    "mysql:foo@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true&sql_mode=ANSI",
-		},
-		{
-			name: "mysql no password",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseMySQL,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     3306,
-				User:     "mysql",
-			},
-			driver: MySQL,
-			dsn:    "mysql@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true&sql_mode=ANSI",
-		},
-		{
-			name: "mysql with password",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseMySQL,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     3306,
-				User:     "mysql",
-				Password: "foo",
-			},
-			driver: MySQL,
-			dsn:    "mysql:foo@tcp(localhost:3306)/flipt?multiStatements=true&parseTime=true&sql_mode=ANSI",
-		},
-		{
-			name: "cockroachdb url",
-			cfg: config.DatabaseConfig{
-				URL: "cockroachdb://cockroachdb@localhost:26257/flipt?sslmode=disable",
-			},
-			driver: CockroachDB,
-			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
-		},
-		{
-			name: "cockroachdb url alternative (cockroach://",
-			cfg: config.DatabaseConfig{
-				URL: "cockroach://cockroachdb@localhost:26257/flipt?sslmode=disable",
-			},
-			driver: CockroachDB,
-			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
-		},
-		{
-			name: "cockroachdb url alternative (crdb://",
-			cfg: config.DatabaseConfig{
-				URL: "crdb://cockroachdb@localhost:26257/flipt?sslmode=disable",
-			},
-			driver: CockroachDB,
-			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
-		},
-		{
-			name: "cockroachdb default disable sslmode",
-			// cockroachdb defaults to sslmode=disable
-			// https://www.cockroachlabs.com/docs/stable/connection-parameters.html#additional-connection-parameters
-			cfg: config.DatabaseConfig{
-				URL: "cockroachdb://cockroachdb@localhost:26257/flipt",
-			},
-			driver: CockroachDB,
-			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
-		},
-		{
-			name: "cockroachdb disable sslmode via opts",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseCockroachDB,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     26257,
-				User:     "cockroachdb",
-			},
-			options: options{
-				sslDisabled: true,
-			},
-			driver: CockroachDB,
-			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
-		},
-		{
-			name: "cockroachdb no port",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseCockroachDB,
-				Name:     "flipt",
-				Host:     "localhost",
-				User:     "cockroachdb",
-			},
-			driver: CockroachDB,
-			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
-		},
-		{
-			name: "cockroachdb no password",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseCockroachDB,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     26257,
-				User:     "cockroachdb",
-			},
-			driver: CockroachDB,
-			dsn:    "postgres://cockroachdb@localhost:26257/flipt?sslmode=disable",
-		},
-		{
-			name: "cockroachdb with password",
-			cfg: config.DatabaseConfig{
-				Protocol: config.DatabaseCockroachDB,
-				Name:     "flipt",
-				Host:     "localhost",
-				Port:     26257,
-				User:     "cockroachdb",
-				Password: "foo",
-			},
-			driver: CockroachDB,
-			dsn:    "postgres://cockroachdb:foo@localhost:26257/flipt?sslmode=disable",
-		},
-		{
-			name: "invalid url",
-			cfg: config.DatabaseConfig{
-				URL: "http://a b",
-			},
-			wantErr: true,
-		},
-		{
-			name: "unknown driver",
-			cfg: config.DatabaseConfig{
-				URL: "mongo://127.0.0.1",
-			},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-
-		var (
-			cfg     = tt.cfg
-			driver  = tt.driver
-			url     = tt.dsn
-			wantErr = tt.wantErr
-			opts    = tt.options
-		)
-
-		t.Run(tt.name, func(t *testing.T) {
-			d, u, err := parse(config.Config{
-				Database: cfg,
-			}, logger, opts)
-
-			if wantErr {
-				require.Error(t, err)
-				return
-			}
-
-			require.NoError(t, err)
-			assert.Equal(t, driver, d)
-			assert.Equal(t, url, u.DSN)
-		})
-	}
-}
-
 func TestDBTestSuite(t *testing.T) {
 	suite.Run(t, new(DBTestSuite))
 }
 
-const defaultTestDBURL = "file:../../flipt_test.db"
-
-type dbContainer struct {
-	testcontainers.Container
-	host string
-	port int
-}
-
 type DBTestSuite struct {
 	suite.Suite
-	db            *sql.DB
-	store         storage.Store
-	driver        Driver
-	testcontainer *dbContainer
+	db    *fliptsqltesting.Database
+	store storage.Store
 }
 
 var dd string
@@ -428,145 +120,24 @@ func TestMain(m *testing.M) {
 
 func (s *DBTestSuite) SetupSuite() {
 	setup := func() error {
-		var (
-			logger = zaptest.NewLogger(s.T())
-			proto  config.DatabaseProtocol
-		)
+		logger := zaptest.NewLogger(s.T())
 
-		switch dd {
-		case "cockroachdb":
-			proto = config.DatabaseCockroachDB
-		case "postgres":
-			proto = config.DatabasePostgres
-		case "mysql":
-			proto = config.DatabaseMySQL
-		default:
-			proto = config.DatabaseSQLite
-		}
-
-		cfg := config.Config{
-			Database: config.DatabaseConfig{
-				Protocol: proto,
-				URL:      defaultTestDBURL,
-			},
-		}
-
-		var (
-			username, password, dbName string
-			useTestContainer           bool
-		)
-
-		switch proto {
-		case config.DatabaseSQLite:
-			// no-op
-		case config.DatabaseCockroachDB:
-			useTestContainer = true
-			username = "root"
-			password = ""
-			dbName = "defaultdb"
-		default:
-			useTestContainer = true
-			username = "flipt"
-			password = "password"
-			dbName = "flipt_test"
-		}
-
-		if useTestContainer {
-			dbContainer, err := newDBContainer(s.T(), context.Background(), proto)
-			if err != nil {
-				return fmt.Errorf("creating db container: %w", err)
-			}
-
-			cfg.Database.URL = ""
-			cfg.Database.Host = dbContainer.host
-			cfg.Database.Port = dbContainer.port
-			cfg.Database.Name = dbName
-			cfg.Database.User = username
-			cfg.Database.Password = password
-
-			s.testcontainer = dbContainer
-		}
-
-		db, driver, err := open(cfg, logger, options{migrate: true, sslDisabled: true})
+		db, err := fliptsqltesting.Open()
 		if err != nil {
-			return fmt.Errorf("opening db: %w", err)
-		}
-
-		var (
-			dr   database.Driver
-			stmt string
-
-			tables = []string{"distributions", "rules", "constraints", "variants", "segments", "flags"}
-		)
-
-		switch driver {
-		case SQLite:
-			dr, err = sqlite3.WithInstance(db, &sqlite3.Config{})
-			stmt = "DELETE FROM %s"
-		case Postgres:
-			dr, err = pg.WithInstance(db, &pg.Config{})
-			stmt = "TRUNCATE TABLE %s CASCADE"
-		case CockroachDB:
-			dr, err = cockroachdb.WithInstance(db, &cockroachdb.Config{})
-			stmt = "TRUNCATE TABLE %s CASCADE"
-		case MySQL:
-			dr, err = ms.WithInstance(db, &ms.Config{})
-			stmt = "TRUNCATE TABLE %s"
-
-			// https://stackoverflow.com/questions/5452760/how-to-truncate-a-foreign-key-constrained-table
-			if _, err := db.Exec("SET FOREIGN_KEY_CHECKS = 0;"); err != nil {
-				return fmt.Errorf("disabling foreign key checks: %w", err)
-			}
-
-		default:
-			return fmt.Errorf("unknown driver: %s", proto)
-		}
-
-		if err != nil {
-			return fmt.Errorf("creating driver: %w", err)
-		}
-
-		for _, t := range tables {
-			_, _ = db.Exec(fmt.Sprintf(stmt, t))
-		}
-
-		f := filepath.Clean(fmt.Sprintf("../../../config/migrations/%s", driver))
-
-		mm, err := migrate.NewWithDatabaseInstance(fmt.Sprintf("file://%s", f), driver.String(), dr)
-		if err != nil {
-			return fmt.Errorf("creating migrate instance: %w", err)
-		}
-
-		if err := mm.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
-			return fmt.Errorf("running migrations: %w", err)
-		}
-
-		if err := db.Close(); err != nil {
-			return fmt.Errorf("closing db: %w", err)
-		}
-
-		// re-open db and enable ANSI mode for MySQL
-		db, driver, err = open(cfg, logger, options{migrate: false, sslDisabled: true})
-		if err != nil {
-			return fmt.Errorf("opening db: %w", err)
+			return err
 		}
 
 		s.db = db
-		s.driver = driver
 
 		var store storage.Store
 
-		switch driver {
-		case SQLite:
-			store = sqlite.NewStore(db, logger)
-		case Postgres, CockroachDB:
-			store = postgres.NewStore(db, logger)
-		case MySQL:
-			if _, err := db.Exec("SET FOREIGN_KEY_CHECKS = 1;"); err != nil {
-				return fmt.Errorf("enabling foreign key checks: %w", err)
-			}
-
-			store = mysql.NewStore(db, logger)
+		switch db.Driver {
+		case fliptsql.SQLite:
+			store = sqlite.NewStore(db.DB, logger)
+		case fliptsql.Postgres, fliptsql.CockroachDB:
+			store = postgres.NewStore(db.DB, logger)
+		case fliptsql.MySQL:
+			store = mysql.NewStore(db.DB, logger)
 		}
 
 		s.store = store
@@ -577,87 +148,10 @@ func (s *DBTestSuite) SetupSuite() {
 }
 
 func (s *DBTestSuite) TearDownSuite() {
-	if s.db != nil {
-		s.db.Close()
-	}
-
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if s.testcontainer != nil {
-		_ = s.testcontainer.Terminate(shutdownCtx)
+	if s.db != nil {
+		s.db.Shutdown(shutdownCtx)
 	}
-}
-
-func newDBContainer(t *testing.T, ctx context.Context, proto config.DatabaseProtocol) (*dbContainer, error) {
-	t.Helper()
-
-	if testing.Short() {
-		t.Skipf("skipping running %s tests in short mode", proto.String())
-	}
-
-	var (
-		req  testcontainers.ContainerRequest
-		port nat.Port
-	)
-
-	switch proto {
-	case config.DatabasePostgres:
-		port = nat.Port("5432/tcp")
-		req = testcontainers.ContainerRequest{
-			Image:        "postgres:11.2",
-			ExposedPorts: []string{"5432/tcp"},
-			WaitingFor:   wait.ForListeningPort(port),
-			Env: map[string]string{
-				"POSTGRES_USER":     "flipt",
-				"POSTGRES_PASSWORD": "password",
-				"POSTGRES_DB":       "flipt_test",
-			},
-		}
-	case config.DatabaseCockroachDB:
-		port = nat.Port("26257/tcp")
-		req = testcontainers.ContainerRequest{
-			Image:        "cockroachdb/cockroach:latest-v21.2",
-			ExposedPorts: []string{"26257/tcp", "8080/tcp"},
-			WaitingFor:   wait.ForHTTP("/health").WithPort("8080"),
-			Env: map[string]string{
-				"COCKROACH_USER":     "root",
-				"COCKROACH_DATABASE": "defaultdb",
-			},
-			Cmd: []string{"start-single-node", "--insecure"},
-		}
-	case config.DatabaseMySQL:
-		port = nat.Port("3306/tcp")
-		req = testcontainers.ContainerRequest{
-			Image:        "mysql:8",
-			ExposedPorts: []string{"3306/tcp"},
-			WaitingFor:   wait.ForListeningPort(port),
-			Env: map[string]string{
-				"MYSQL_USER":                 "flipt",
-				"MYSQL_PASSWORD":             "password",
-				"MYSQL_DATABASE":             "flipt_test",
-				"MYSQL_ALLOW_EMPTY_PASSWORD": "true",
-			},
-		}
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	mappedPort, err := container.MappedPort(ctx, port)
-	if err != nil {
-		return nil, err
-	}
-
-	hostIP, err := container.Host(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return &dbContainer{Container: container, host: hostIP, port: mappedPort.Int()}, nil
 }

--- a/internal/storage/sql/evaluation_test.go
+++ b/internal/storage/sql/evaluation_test.go
@@ -1,4 +1,4 @@
-package sql
+package sql_test
 
 import (
 	"context"

--- a/internal/storage/sql/flag_test.go
+++ b/internal/storage/sql/flag_test.go
@@ -1,4 +1,4 @@
-package sql
+package sql_test
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.flipt.io/flipt/internal/storage"
+	fliptsql "go.flipt.io/flipt/internal/storage/sql"
 	"go.flipt.io/flipt/internal/storage/sql/common"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 
@@ -100,7 +101,7 @@ func (s *DBTestSuite) TestListFlagsPagination_LimitOffset() {
 	}
 
 	for _, req := range reqs {
-		if s.driver == MySQL {
+		if s.db.Driver == fliptsql.MySQL {
 			// required for MySQL since it only s.stores timestamps to the second and not millisecond granularity
 			time.Sleep(time.Second)
 		}
@@ -173,7 +174,7 @@ func (s *DBTestSuite) TestListFlagsPagination_LimitWithNextPage() {
 	}
 
 	for _, req := range reqs {
-		if s.driver == MySQL {
+		if s.db.Driver == fliptsql.MySQL {
 			// required for MySQL since it only s.stores timestamps to the second and not millisecond granularity
 			time.Sleep(time.Second)
 		}

--- a/internal/storage/sql/metrics.go
+++ b/internal/storage/sql/metrics.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"database/sql"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -16,63 +17,67 @@ type statsGetter interface {
 	Stats() sql.DBStats
 }
 
+var once sync.Once
+
 // nolint
 func registerMetrics(d Driver, s statsGetter) {
-	labels := prometheus.Labels{"driver": d.String()}
+	once.Do(func() {
+		labels := prometheus.Labels{"driver": d.String()}
 
-	collector := &metricsCollector{
-		sg: s,
-		maxOpenDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "max_open_conn"),
-			"Maximum number of open connections to the database.",
-			nil,
-			labels,
-		),
-		openDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "open_conn"),
-			"The number of established connections both in use and idle.",
-			nil,
-			labels,
-		),
-		inUseDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "in_use_conn"),
-			"The number of connections currently in use.",
-			nil,
-			labels,
-		),
-		idleDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "idle_conn"),
-			"The number of idle connections.",
-			nil,
-			labels,
-		),
-		waitedForDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "waited_for_conn"),
-			"The total number of connections waited for.",
-			nil,
-			labels,
-		),
-		blockedSecondsDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "blocked_seconds_conn"),
-			"The total time blocked waiting for a new connection.",
-			nil,
-			labels,
-		),
-		closedMaxIdleDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "closed_max_idle_conn"),
-			"The total number of connections closed due to SetMaxIdleConns.",
-			nil,
-			labels,
-		),
-		closedMaxLifetimeDesc: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, subsystem, "closed_max_lifetime_conn"),
-			"The total number of connections closed due to SetConnMaxLifetime.",
-			nil,
-			labels,
-		),
-	}
+		collector := &metricsCollector{
+			sg: s,
+			maxOpenDesc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "max_open_conn"),
+				"Maximum number of open connections to the database.",
+				nil,
+				labels,
+			),
+			openDesc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "open_conn"),
+				"The number of established connections both in use and idle.",
+				nil,
+				labels,
+			),
+			inUseDesc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "in_use_conn"),
+				"The number of connections currently in use.",
+				nil,
+				labels,
+			),
+			idleDesc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "idle_conn"),
+				"The number of idle connections.",
+				nil,
+				labels,
+			),
+			waitedForDesc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "waited_for_conn"),
+				"The total number of connections waited for.",
+				nil,
+				labels,
+			),
+			blockedSecondsDesc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "blocked_seconds_conn"),
+				"The total time blocked waiting for a new connection.",
+				nil,
+				labels,
+			),
+			closedMaxIdleDesc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "closed_max_idle_conn"),
+				"The total number of connections closed due to SetMaxIdleConns.",
+				nil,
+				labels,
+			),
+			closedMaxLifetimeDesc: prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, subsystem, "closed_max_lifetime_conn"),
+				"The total number of connections closed due to SetConnMaxLifetime.",
+				nil,
+				labels,
+			),
+		}
 
-	prometheus.MustRegister(collector)
+		prometheus.MustRegister(collector)
+	})
 }
 
 type metricsCollector struct {

--- a/internal/storage/sql/rule_test.go
+++ b/internal/storage/sql/rule_test.go
@@ -1,4 +1,4 @@
-package sql
+package sql_test
 
 import (
 	"context"

--- a/internal/storage/sql/segment_test.go
+++ b/internal/storage/sql/segment_test.go
@@ -1,4 +1,4 @@
-package sql
+package sql_test
 
 import (
 	"context"
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.flipt.io/flipt/internal/storage"
+	fliptsql "go.flipt.io/flipt/internal/storage/sql"
 	"go.flipt.io/flipt/internal/storage/sql/common"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 
@@ -96,7 +97,7 @@ func (s *DBTestSuite) TestListSegmentsPagination_LimitOffset() {
 	}
 
 	for _, req := range reqs {
-		if s.driver == MySQL {
+		if s.db.Driver == fliptsql.MySQL {
 			// required for MySQL since it only s.stores timestamps to the second and not millisecond granularity
 			time.Sleep(time.Second)
 		}
@@ -169,7 +170,7 @@ func (s *DBTestSuite) TestListSegmentsPagination_LimitWithNextPage() {
 	oldest, middle, newest := reqs[0], reqs[1], reqs[2]
 
 	for _, req := range reqs {
-		if s.driver == MySQL {
+		if s.db.Driver == fliptsql.MySQL {
 			// required for MySQL since it only s.stores timestamps to the second and not millisecond granularity
 			time.Sleep(time.Second)
 		}

--- a/internal/storage/sql/testing/testing.go
+++ b/internal/storage/sql/testing/testing.go
@@ -1,0 +1,259 @@
+package testing
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/golang-migrate/migrate/v4/database"
+	"github.com/golang-migrate/migrate/v4/database/cockroachdb"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"go.flipt.io/flipt/config/migrations"
+	"go.flipt.io/flipt/internal/config"
+	fliptsql "go.flipt.io/flipt/internal/storage/sql"
+
+	ms "github.com/golang-migrate/migrate/v4/database/mysql"
+	pg "github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/database/sqlite3"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+)
+
+const defaultTestDBURL = "file:../../flipt_test.db"
+
+type Database struct {
+	DB        *sql.DB
+	Driver    fliptsql.Driver
+	Container *DBContainer
+}
+
+func (d *Database) Shutdown(ctx context.Context) {
+	if d.DB != nil {
+		d.DB.Close()
+	}
+
+	if d.Container != nil {
+		d.Container.Terminate(ctx)
+	}
+
+	return
+}
+
+func Open() (*Database, error) {
+	var proto config.DatabaseProtocol
+
+	switch os.Getenv("FLIPT_TEST_DATABASE_PROTOCOL") {
+	case "cockroachdb":
+		proto = config.DatabaseCockroachDB
+	case "postgres":
+		proto = config.DatabasePostgres
+	case "mysql":
+		proto = config.DatabaseMySQL
+	default:
+		proto = config.DatabaseSQLite
+	}
+
+	cfg := config.Config{
+		Database: config.DatabaseConfig{
+			Protocol: proto,
+			URL:      defaultTestDBURL,
+		},
+	}
+
+	var (
+		username, password, dbName string
+		useTestContainer           bool
+	)
+
+	switch proto {
+	case config.DatabaseSQLite:
+		// no-op
+	case config.DatabaseCockroachDB:
+		useTestContainer = true
+		username = "root"
+		password = ""
+		dbName = "defaultdb"
+	default:
+		useTestContainer = true
+		username = "flipt"
+		password = "password"
+		dbName = "flipt_test"
+	}
+
+	var (
+		container *DBContainer
+		err       error
+	)
+	if useTestContainer {
+		container, err = NewDBContainer(context.Background(), proto)
+		if err != nil {
+			return nil, fmt.Errorf("creating db container: %w", err)
+		}
+
+		cfg.Database.URL = ""
+		cfg.Database.Host = container.Host
+		cfg.Database.Port = container.Port
+		cfg.Database.Name = dbName
+		cfg.Database.User = username
+		cfg.Database.Password = password
+	}
+
+	db, driver, err := fliptsql.Open(cfg, fliptsql.WithMigrate, fliptsql.WithSSLDisabled)
+	if err != nil {
+		return nil, fmt.Errorf("opening db: %w", err)
+	}
+
+	var (
+		dr   database.Driver
+		stmt string
+
+		tables = []string{"distributions", "rules", "constraints", "variants", "segments", "flags", "authentications"}
+	)
+
+	switch driver {
+	case fliptsql.SQLite:
+		dr, err = sqlite3.WithInstance(db, &sqlite3.Config{})
+		stmt = "DELETE FROM %s"
+	case fliptsql.Postgres:
+		dr, err = pg.WithInstance(db, &pg.Config{})
+		stmt = "TRUNCATE TABLE %s CASCADE"
+	case fliptsql.CockroachDB:
+		dr, err = cockroachdb.WithInstance(db, &cockroachdb.Config{})
+		stmt = "TRUNCATE TABLE %s CASCADE"
+	case fliptsql.MySQL:
+		dr, err = ms.WithInstance(db, &ms.Config{})
+		stmt = "TRUNCATE TABLE %s"
+
+		// https://stackoverflow.com/questions/5452760/how-to-truncate-a-foreign-key-constrained-table
+		if _, err := db.Exec("SET FOREIGN_KEY_CHECKS = 0;"); err != nil {
+			return nil, fmt.Errorf("disabling foreign key checks: %w", err)
+		}
+
+	default:
+		return nil, fmt.Errorf("unknown driver: %s", proto)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("creating driver: %w", err)
+	}
+
+	for _, t := range tables {
+		_, _ = db.Exec(fmt.Sprintf(stmt, t))
+	}
+
+	// source migrations from embedded config/migrations package
+	// relative to the specific driver
+	sourceDriver, err := iofs.New(migrations.FS, driver.String())
+	if err != nil {
+		return nil, err
+	}
+
+	mm, err := migrate.NewWithInstance("iofs", sourceDriver, driver.String(), dr)
+	if err != nil {
+		return nil, fmt.Errorf("creating migrate instance: %w", err)
+	}
+
+	if err := mm.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return nil, fmt.Errorf("running migrations: %w", err)
+	}
+
+	if err := db.Close(); err != nil {
+		return nil, fmt.Errorf("closing db: %w", err)
+	}
+
+	// re-open db and enable ANSI mode for MySQL
+	db, driver, err = fliptsql.Open(cfg, fliptsql.WithSSLDisabled)
+	if err != nil {
+		return nil, fmt.Errorf("opening db: %w", err)
+	}
+
+	if driver == fliptsql.MySQL {
+		if _, err := db.Exec("SET FOREIGN_KEY_CHECKS = 1;"); err != nil {
+			return nil, fmt.Errorf("enabling foreign key checks: %w", err)
+		}
+	}
+
+	return &Database{
+		DB:        db,
+		Driver:    driver,
+		Container: container,
+	}, nil
+}
+
+type DBContainer struct {
+	testcontainers.Container
+	Host string
+	Port int
+}
+
+func NewDBContainer(ctx context.Context, proto config.DatabaseProtocol) (*DBContainer, error) {
+	var (
+		req  testcontainers.ContainerRequest
+		port nat.Port
+	)
+
+	switch proto {
+	case config.DatabasePostgres:
+		port = nat.Port("5432/tcp")
+		req = testcontainers.ContainerRequest{
+			Image:        "postgres:11.2",
+			ExposedPorts: []string{"5432/tcp"},
+			WaitingFor:   wait.ForListeningPort(port),
+			Env: map[string]string{
+				"POSTGRES_USER":     "flipt",
+				"POSTGRES_PASSWORD": "password",
+				"POSTGRES_DB":       "flipt_test",
+			},
+		}
+	case config.DatabaseCockroachDB:
+		port = nat.Port("26257/tcp")
+		req = testcontainers.ContainerRequest{
+			Image:        "cockroachdb/cockroach:latest-v21.2",
+			ExposedPorts: []string{"26257/tcp", "8080/tcp"},
+			WaitingFor:   wait.ForHTTP("/health").WithPort("8080"),
+			Env: map[string]string{
+				"COCKROACH_USER":     "root",
+				"COCKROACH_DATABASE": "defaultdb",
+			},
+			Cmd: []string{"start-single-node", "--insecure"},
+		}
+	case config.DatabaseMySQL:
+		port = nat.Port("3306/tcp")
+		req = testcontainers.ContainerRequest{
+			Image:        "mysql:8",
+			ExposedPorts: []string{"3306/tcp"},
+			WaitingFor:   wait.ForListeningPort(port),
+			Env: map[string]string{
+				"MYSQL_USER":                 "flipt",
+				"MYSQL_PASSWORD":             "password",
+				"MYSQL_DATABASE":             "flipt_test",
+				"MYSQL_ALLOW_EMPTY_PASSWORD": "true",
+			},
+		}
+	}
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	mappedPort, err := container.MappedPort(ctx, port)
+	if err != nil {
+		return nil, err
+	}
+
+	hostIP, err := container.Host(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DBContainer{Container: container, Host: hostIP, Port: mappedPort.Int()}, nil
+}

--- a/internal/storage/sql/testing/testing.go
+++ b/internal/storage/sql/testing/testing.go
@@ -87,6 +87,7 @@ func Open() (*Database, error) {
 		container *DBContainer
 		err       error
 	)
+
 	if useTestContainer {
 		container, err = NewDBContainer(context.Background(), proto)
 		if err != nil {
@@ -148,7 +149,7 @@ func Open() (*Database, error) {
 	// relative to the specific driver
 	sourceDriver, err := iofs.New(migrations.FS, driver.String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("constructing migration source driver (db driver %q): %w", driver.String(), err)
 	}
 
 	mm, err := migrate.NewWithInstance("iofs", sourceDriver, driver.String(), dr)

--- a/internal/storage/sql/testing/testing.go
+++ b/internal/storage/sql/testing/testing.go
@@ -38,10 +38,8 @@ func (d *Database) Shutdown(ctx context.Context) {
 	}
 
 	if d.Container != nil {
-		d.Container.Terminate(ctx)
+		_ = d.Container.Terminate(ctx)
 	}
-
-	return
 }
 
 func Open() (*Database, error) {

--- a/test/config/redis.yml
+++ b/test/config/redis.yml
@@ -3,8 +3,6 @@ log:
 
 db:
   url: file:./test/flipt.db
-  migrations:
-    path: ./config/migrations
 
 cache:
   enabled: true

--- a/test/config/test.yml
+++ b/test/config/test.yml
@@ -3,5 +3,3 @@ log:
 
 db:
   url: file:./test/flipt.db
-  migrations:
-    path: ./config/migrations


### PR DESCRIPTION
The core of this refactor is to move migrations into an `embed.FS` variable.
This will embed all migrations into the Flipt binary; making it more portable.

The PR:

1. Creates the new package `config/migrations` containing a single exported variable `FS` with `go:embed` directive.
2. Updates all the locations where we source migrations via `file`, to use the new source driver `iofs`.
3. Deprecates both `db.migrations.path` and `db.migrations_path` configuration options.
4. Removes all references internally to these deprecated paths.
5. Removes references to `config/migrations` from packaging, archiving and docker image building.
6. Does a little shuffling around of `storage/sql` to introduce a new re-usable `storage/sql/testing` package.