### PR TITLE
fix(migrations/sqlite3): syntax error in uniqueness constraint on temp table in down operation

### DIFF
--- a/config/migrations/sqlite3/1_variants_unique_per_flag.down.sql
+++ b/config/migrations/sqlite3/1_variants_unique_per_flag.down.sql
@@ -9,16 +9,15 @@ CREATE TABLE variants_temp
 (
   id VARCHAR(255) PRIMARY KEY UNIQUE NOT NULL,
   flag_key VARCHAR(255) NOT NULL REFERENCES flags ON DELETE CASCADE,
-  key VARCHAR(255) NOT NULL,
+  key VARCHAR(255) NOT NULL UNIQUE ON CONFLICT REPLACE,
   name VARCHAR(255) NOT NULL,
   description TEXT NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  UNIQUE key ON CONFLICT REPLACE
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-INSERT INTO variants_temp (id, flag_key, key, name, description, created_at, updated_at)
-  SELECT id, flag_key, key, name, description, created_at, updated_at
+INSERT INTO variants_temp (id, flag_key, `key`, name, description, created_at, updated_at)
+  SELECT id, flag_key, `key`, name, description, created_at, updated_at
   FROM variants;
 
 DROP TABLE variants;


### PR DESCRIPTION
I noticed the following error while attempting to run the down migrations for `sqlite` driver:

```
attempting to drop during import: reverting migrations: near "key": syntax error in line 0: /* SQLite doesn't allow you to drop unique constraints with ALTER TABLE
   so we have to create a new table with the schema we want and copy the data over.
   https://www.sqlite.org/lang_altertable.html
*/

PRAGMA foreign_keys=off;

CREATE TABLE variants_temp
(
  id VARCHAR(255) PRIMARY KEY UNIQUE NOT NULL,
  flag_key VARCHAR(255) NOT NULL REFERENCES flags ON DELETE CASCADE,
  key VARCHAR(255) NOT NULL,
  name VARCHAR(255) NOT NULL,
  description TEXT NOT NULL,
  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
  UNIQUE key ON CONFLICT REPLACE
);

INSERT INTO variants_temp (id, flag_key, key, name, description, created_at, updated_at)
  SELECT id, flag_key, key, name, description, created_at, updated_at
  FROM variants;

DROP TABLE variants;

ALTER TABLE variants_temp RENAME TO variants;

PRAGMA foreign_keys=on;
```

This adjusts the down migrations slightly to avoid it occurring. I successfully ran them after this change.
In my authentication storage PR, I update `import --drop` to run down migrations.
This causes them to get run in CI, so we should get that validation in CI soon too.
Though, we may want to consider running the down migrations against all DBs in CI for peace of mind.