### PR TITLE
chore: fix bootstrap in devcontainer/first build

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,11 +70,6 @@ tasks:
     desc: Install necessary development tools
     cmds:
       - ./script/bootstrap
-    sources:
-      - ./_tools/go.mod
-    generates:
-      - ./_tools/go.sum
-    method: checksum
 
   build:
     desc: Run Go build


### PR DESCRIPTION
Remove the 'caching' that Task allows for `task bootstrap`. this will guarantee that users that build Flipt for the first-time or in a devcontainer always have the necessary tools installed (ie: buf)

cc @josebalius

Also it doesn't slow down the build since Go will not re-download if those tools already exist at those versions