### PR TITLE
chore: switch to goreleaser-pro

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,11 @@ jobs:
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro
           version: latest
           args: release --rm-dist
         env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANALYTICS_KEY: ${{ secrets.ANALYTICS_KEY }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}


### PR DESCRIPTION
Bought a goreleaser-pro subscription so we can have nightly/rc builds that are published.

This setups the release action to use the pro version + use our license key