### PR TITLE
chore: add markdownlint

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,15 +40,15 @@ Examples:
 - Screenshots
 - Exported data from the database
 
-**Screenshots**
-
 <!--
+#### Screenshots
+
 If applicable, add screenshots to help explain your problem.
 -->
 
-**Attach an Export**
-
 <!--
+#### Attach an Export**
+
 If the bug could be best shown with a specific set of data, please export your data by running:
 
 ```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -31,15 +31,15 @@ Examples:
 - Screenshots
 - Exported data from the database
 
-**Screenshots**
-
 <!--
+#### Screenshots
+
 If applicable, add screenshots to help explain your request.
 -->
 
-**Attach an Export**
-
 <!--
+#### Attach an Export
+
 If your feature request is based on a limitation that could be best shown with a specific set of data, please export your data by running:
 
 ```

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  go-lint:
+    name: "Lint Go"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.18"
+          check-latest: true
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.3.0
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.49
+          skip-pkg-cache: true
+          skip-build-cache: true
+          args: --timeout=10m
+
+  markdown-lint:
+    name: "Lint Markdown"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DavidAnson/markdownlint-cli2-action@v7
+        with:
+          command: config
+          globs: |
+            .markdownlint.yaml
+            **/*.md
+            !**/test/**/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,27 +17,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-go@v3
-        with:
-          go-version: "1.18"
-          check-latest: true
-          cache: true
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.3.0
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.49
-          skip-pkg-cache: true
-          skip-build-cache: true
-          args: --timeout=10m
-
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,12 @@
+---
+line-length: false
+no-hard-tabs: false
+no-trailing-spaces: false
+no-inline-html: false
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024:
+  # Only check sibling headings
+  allow_different_nesting: true
+  # Only check sibling headings
+  siblings_only: true

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -2,7 +2,9 @@
 line-length: false
 no-hard-tabs: false
 no-trailing-spaces: false
+no-trailing-punctuation: false
 no-inline-html: false
+first-line-heading: false
 
 # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD024:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -433,7 +433,7 @@ Happy Halloween! Flipt goes 1.0.0 today! :jack_o_lantern:
 
 - Moved evaluation logic to be independent of datastore
 - Updated several dependencies
-- Moved documentation to https://github.com/markphelps/flipt.io
+- Moved documentation to [https://github.com/markphelps/flipt.io](https://github.com/markphelps/flipt.io)
 - Updated documentation link in UI
 
 ### Fixed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,9 +68,9 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html)
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development
 
-The following are instructions for setting up your local machine for Flipt development. For info on using VSCode Remote Containers / GitHub Codespaces, see [#remote containers](#remote-containers) below.
+The following are instructions for setting up your local machine for Flipt development. For info on using VSCode Remote Containers / GitHub Codespaces, see [#cdes](#cdes) below.
 
 ## Requirements
 
@@ -28,7 +28,7 @@ Flipt is built with Go 1.18+.
 
 ## Bootstrap
 
-The `bootstrap` task will install all of the necessary tools used for development and testing. It does this using a seperate tools modules as described here: https://marcofranssen.nl/manage-go-tools-via-go-modules
+The `bootstrap` task will install all of the necessary tools used for development and testing. It does this using a seperate tools modules as described here: [https://marcofranssen.nl/manage-go-tools-via-go-modules](https://marcofranssen.nl/manage-go-tools-via-go-modules)
 
 ## Configuration
 
@@ -76,9 +76,9 @@ In development, the three ports that Flipt users are:
 
 These three ports will be forwarded to your local machine automatically if you are developing Flipt in a VSCode Remote Container or GitHub Codespace.
 
-## Remote Containers/GitHub Codespaces
+## CDEs
 
-Flipt now supports [VSCode Remote Containers](https://github.com/Microsoft/vscode-dev-containers)/[GitHub Codespaces](https://github.com/features/codespaces).
+Flipt now supports Containerized Development Environments (CDE) [VSCode Remote Containers](https://github.com/Microsoft/vscode-dev-containers)/[GitHub Codespaces](https://github.com/features/codespaces).
 
 These technologies allow you to quickly get setup with a Flipt development environment either locally or 'in the cloud'.
 

--- a/README.md
+++ b/README.md
@@ -196,9 +196,7 @@ For help and discussion around Flipt, feature flag best practices, and more, joi
 
 ## Feedback
 
-If you are a user of Flipt I'd really :heart: it if you could leave a testimonal on how Flipt is working for you.
-
-https://testimonial.to/flipt
+If you are a user of Flipt I'd really :heart: it if you could leave a [testimonal](https://testimonial.to/flipt) on how Flipt is working for you.
 
 ## Author
 

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -23,6 +23,7 @@ To run this example application you'll need:
 1. Open the Flipt UI (default: [http://localhost:8080](http://localhost:8080))
 1. Note you will be prompted for a username and password, the default is `admin:password`. This can be configured by setting the `HTTP_USERNAME` and `HTTP_PASSWORD` environment variables in the [docker-compose.yml](docker-compose.yml) file.
 1. Try to get a list of flags without authenticating using the REST API:
+
     ```shell
     ❯ curl -v http://localhost:8080/api/v1/flags
     *   Trying 127.0.0.1...
@@ -37,8 +38,10 @@ To run this example application you'll need:
     < HTTP/1.1 401 Unauthorized
     < Content-Type: text/plain; charset=utf-8
     ```
+
 1. You should get a **401 Unauthorized** response as no username or password was present on the request
 1. Try again, providing the username and password:
+
     ```shell
     ❯ curl -v -u admin:password http://localhost:8080/api/v1/flags
     *   Trying 127.0.0.1...
@@ -55,4 +58,5 @@ To run this example application you'll need:
     < HTTP/1.1 200 OK
     < Content-Type: application/json
     ```
+
 1. This time the request succeeds and a **200 OK** response is returned


### PR DESCRIPTION
- moves lint steps into their own workflow file
- adds `markdownlint` job to lint markdown because we arent barbarians
- fixes markdown lint errors