### PR TITLE
chore: setup codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @flipt-io/maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    reviewers:
-      - markphelps
-    assignees:
-      - markphelps
     ignore:
       - dependency-name: "*"
         update-types:
@@ -19,7 +15,7 @@ updates:
     labels:
       - "dependencies"
       - "go"
-      # Add default Kodiak `merge.automerge_label`
+      # kodiak `merge.automerge_label`
       - "automerge"
 
   - package-ecosystem: gomod
@@ -27,10 +23,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    reviewers:
-      - markphelps
-    assignees:
-      - markphelps
     ignore:
       - dependency-name: "*"
         update-types:
@@ -41,7 +33,7 @@ updates:
     labels:
       - "dependencies"
       - "go"
-      # Add default Kodiak `merge.automerge_label`
+      # kodiak `merge.automerge_label`
       - "automerge"
 
   - package-ecosystem: npm
@@ -49,10 +41,6 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    reviewers:
-      - markphelps
-    assignees:
-      - markphelps
     ignore:
       - dependency-name: "*"
         update-types:
@@ -65,17 +53,19 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    reviewers:
-      - markphelps
-    assignees:
-      - markphelps
+    labels:
+      - "dependencies"
+      - "github_actions"
+      # kodiak `merge.automerge_label`
+      - "automerge"
 
   - package-ecosystem: "docker"
     directory: "/build"
     schedule:
       interval: daily
     open-pull-requests-limit: 5
-    reviewers:
-      - markphelps
-    assignees:
-      - markphelps
+    labels:
+      - "dependencies"
+      - "docker"
+      # kodiak `merge.automerge_label`
+      - "automerge"

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -34,20 +34,20 @@ Description.
 
 ### API ListFlagRequest, ListSegmentRequest, ListRuleRequest offset
 
-> since [v1.13.0](https://github.com/markphelps/flipt/releases/tag/v1.13.0)
+> since [v1.13.0](https://github.com/flipt-io/flipt/releases/tag/v1.13.0)
 
 `offset` has been deprecated in favor of `page_token`/`next_page_token` for `ListFlagRequest`, `ListSegmentRequest` and `ListRuleRequest`. See: [#936](https://github.com/flipt-io/flipt/issues/936).
 
 ### db.migrations.path and db.migrations_path
 
-> since [v1.14.0](https://github.com/markphelps/flipt/releases/tag/v1.10.0)
+> since [v1.14.0](https://github.com/flipt-io/flipt/releases/tag/v1.10.0)
 
 These options are no longer considered during Flipt execution.
 Database migrations are embedded directly within the Flipt binary.
 
 ### cache.memory.enabled
 
-> since [v1.10.0](https://github.com/markphelps/flipt/releases/tag/v1.10.0)
+> since [v1.10.0](https://github.com/flipt-io/flipt/releases/tag/v1.10.0)
 
 Enabling in-memory cache via `cache.memory` is deprecated in favor of setting the `cache.backend` to `memory` and `cache.enabled` to `true`.
 
@@ -69,7 +69,7 @@ Enabling in-memory cache via `cache.memory` is deprecated in favor of setting th
 
 ### cache.memory.expiration
 
-> since [v1.10.0](https://github.com/markphelps/flipt/releases/tag/v1.10.0)
+> since [v1.10.0](https://github.com/flipt-io/flipt/releases/tag/v1.10.0)
 
 Setting cache expiration via `cache.memory` is deprecated in favor of setting the `cache.backend` to `memory` and `cache.ttl` to the desired duration.
 


### PR DESCRIPTION
- setup [codeowners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
- add automerge label for Docker and GH Actions dependabot updates
- Update Deprecations.md to rm `markphelps` references