### PR TITLE
Change test case to show the correct format of multi domains for CORS

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,7 +368,7 @@ func TestLoad(t *testing.T) {
 				}
 				cfg.Cors = CorsConfig{
 					Enabled:        true,
-					AllowedOrigins: []string{"foo.com"},
+					AllowedOrigins: []string{"foo.com", "bar.com"},
 				}
 				cfg.Cache.Enabled = true
 				cfg.Cache.Backend = CacheMemory

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -8,7 +8,7 @@ ui:
 
 cors:
   enabled: true
-  allowed_origins: "foo.com"
+  allowed_origins: "foo.com bar.com"
 
 cache:
   enabled: true

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -8,7 +8,7 @@ ui:
 
 cors:
   enabled: true
-  allowed_origins: "foo.com bar.com"
+  allowed_origins: "foo.com,bar.com"
 
 cache:
   enabled: true


### PR DESCRIPTION
## Overview
The format of `cors.allowed_origins` config was changed by https://github.com/flipt-io/flipt/pull/1079 refactoring.
So I change the test case to explain the format explicitly.

## Explanation
Before the above change at v1.13.0, [the format with white space](https://github.com/flipt-io/flipt/commit/f06335ad5af6dd853b73b2126e550ae2b377424a#diff-6146da5455717d6d0dc2fcb1b31d8f88f3fb164a536d1bff64394511b2c0344a) worked fine since the parameter was parsed by `viper.GetStringSlice` [here](https://github.com/flipt-io/flipt/pull/1079/files#diff-9610c88fc96f562246494f72b1eaeff59e104154ccc636f919a8020506923d0fL22). But after the above change, it is parsed by `mapstructure.StringToSliceHookFunc(",")` [here](https://github.com/flipt-io/flipt/pull/1079/files#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR17) so the expected format was changed.
I'm not sure we should fix to parse for the previous format, but changing test case to show the correct format won't be harmful.