### PR TITLE
fix(auth): mount core auth service via grpc gateway

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -614,6 +614,10 @@ func run(ctx context.Context, logger *zap.Logger) error {
 			return fmt.Errorf("registering grpc gateway: %w", err)
 		}
 
+		if err := authrpc.RegisterAuthenticationServiceHandler(ctx, api, conn); err != nil {
+			return fmt.Errorf("registering auth grpc gateway: %w", err)
+		}
+
 		if cfg.Authentication.Methods.Token.Enabled {
 			if err := authrpc.RegisterAuthenticationMethodTokenServiceHandler(ctx, api, conn); err != nil {
 				return fmt.Errorf("registering auth grpc gateway: %w", err)

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -530,6 +530,9 @@ func run(ctx context.Context, logger *zap.Logger) error {
 		pb.RegisterFliptServer(grpcServer, srv)
 
 		// register auth service
+		authServer := auth.NewServer(logger, authenticationStore)
+		authrpc.RegisterAuthenticationServiceServer(grpcServer, authServer)
+		// register auth method token service
 		if cfg.Authentication.Methods.Token.Enabled {
 			// attempt to bootstrap authentication store
 			clientToken, err := authstorage.Bootstrap(ctx, authenticationStore)

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -41,6 +41,11 @@ func ErrorUnaryInterceptor(ctx context.Context, req interface{}, _ *grpc.UnarySe
 
 	metrics.ErrorsTotal.Add(ctx, 1)
 
+	// given already a *status.Error then forward unchanged
+	if _, ok := status.FromError(err); ok {
+		return
+	}
+
 	var errnf errs.ErrNotFound
 	if errors.As(err, &errnf) {
 		err = status.Error(codes.NotFound, err.Error())

--- a/test/api.sh
+++ b/test/api.sh
@@ -23,10 +23,6 @@ finish() {
 
 trap finish EXIT
 
-authRequired() {
-  [ -n "${TEST_FLIPT_API_AUTH_REQUIRED:-}" ]
-}
-
 uuid_str()
 {
     uuidgen
@@ -327,12 +323,12 @@ step_10_test_auths()
 
     # getting self using token returns expected ID
     authedShakedown GET '/auth/v1/self' -H 'Content-Type: application/json'
-    if [ $(authRequired) ]; then
+    if [ -n "${TEST_FLIPT_API_AUTH_REQUIRED:-}" ]; then
         status 200
         matches "\"id\":\"${tokenID}\""
     else
         # there is no self when authentication is disabled
-        status 403
+        status 401
     fi
 }
 

--- a/test/api.sh
+++ b/test/api.sh
@@ -305,10 +305,10 @@ step_10_test_auths()
 {
     # create a new token for the purpose of this test
     tokenPayload=$(_curl -X POST -H 'Content-Type: application/json' -H "Authorization: Bearer ${FLIPT_TOKEN:-''}" -sS "$SHAKEDOWN_URL/auth/v1/method/token" -d '{"name":"token","description":"an access token"}')
-    tokenID=$(cat "${tokenPayload}" | jq '.authentication.id')
+    tokenID=$(echo "${tokenPayload}" | jq '.authentication.id')
 
     # replace FLIPT_TOKEN with created token
-    FLIPT_TOKEN=$(cat "${tokenPayload}" | jq '.clientToken')
+    FLIPT_TOKEN=$(echo "${tokenPayload}" | jq '.clientToken')
     export $FLIPT_TOKEN
 
     # token should succeed when used via authorization header to list flags

--- a/test/api.sh
+++ b/test/api.sh
@@ -313,16 +313,16 @@ step_10_test_auths()
 
     # token should succeed when used via authorization header to list flags
     # (both when auth is required and not)
-    authedShakedown -H 'Content-Type: application/json' GET '/api/v1/flags'
+    authedShakedown GET '/api/v1/flags' -H 'Content-Type: application/json'
         status 200
 
     # listing tokens includes the created token
-    authedShakedown -H 'Content-Type: application/json' GET "/auth/v1/tokens"
+    authedShakedown GET "/auth/v1/tokens" -H 'Content-Type: application/json'
         status 200
         matches "\"id\":\"${tokenID}\""
 
     # getting self using token returns expected ID
-    authedShakedown -H 'Content-Type: application/json' GET '/auth/v1/self'
+    authedShakedown GET '/auth/v1/self' -H 'Content-Type: application/json'
         status 200
         matches "\"id\":\"${tokenID}\""
 }

--- a/test/api.sh
+++ b/test/api.sh
@@ -304,7 +304,7 @@ step_9_test_metrics()
 step_10_test_auths()
 {
     # create a new token for the purpose of this test
-    tokenPayload=$(_curl -X POST -H 'Content-Type: application/json' -H "Authorization: Bearer ${FLIPT_TOKEN}" -sS "$SHAKEDOWN_URL/auth/v1/method/token" -d '{"name":"token","description":"an access token"}')
+    tokenPayload=$(_curl -X POST -H 'Content-Type: application/json' -H "Authorization: Bearer ${FLIPT_TOKEN:-''}" -sS "$SHAKEDOWN_URL/auth/v1/method/token" -d '{"name":"token","description":"an access token"}')
     tokenID=$(cat "${tokenPayload}" | jq '.authentication.id')
 
     # replace FLIPT_TOKEN with created token

--- a/test/api.sh
+++ b/test/api.sh
@@ -23,6 +23,10 @@ finish() {
 
 trap finish EXIT
 
+authRequired() {
+  [ -n "${TEST_FLIPT_API_AUTH_REQUIRED:-}" ]
+}
+
 uuid_str()
 {
     uuidgen
@@ -323,8 +327,13 @@ step_10_test_auths()
 
     # getting self using token returns expected ID
     authedShakedown GET '/auth/v1/self' -H 'Content-Type: application/json'
+    if [ $(authRequired) ]; then
         status 200
         matches "\"id\":\"${tokenID}\""
+    else
+        # there is no self when authentication is disabled
+        status 403
+    fi
 }
 
 run()

--- a/test/api.sh
+++ b/test/api.sh
@@ -305,10 +305,10 @@ step_10_test_auths()
 {
     # create a new token for the purpose of this test
     tokenPayload=$(_curl -X POST -H 'Content-Type: application/json' -H "Authorization: Bearer ${FLIPT_TOKEN:-''}" -sS "$SHAKEDOWN_URL/auth/v1/method/token" -d '{"name":"token","description":"an access token"}')
-    tokenID=$(echo "${tokenPayload}" | jq '.authentication.id')
+    tokenID=$(echo "${tokenPayload}" | jq -r '.authentication.id')
 
     # replace FLIPT_TOKEN with created token
-    FLIPT_TOKEN=$(echo "${tokenPayload}" | jq '.clientToken')
+    FLIPT_TOKEN=$(echo "${tokenPayload}" | jq -r '.clientToken')
     export FLIPT_TOKEN
 
     # token should succeed when used via authorization header to list flags

--- a/test/api.sh
+++ b/test/api.sh
@@ -309,7 +309,7 @@ step_10_test_auths()
 
     # replace FLIPT_TOKEN with created token
     FLIPT_TOKEN=$(echo "${tokenPayload}" | jq '.clientToken')
-    export $FLIPT_TOKEN
+    export FLIPT_TOKEN
 
     # token should succeed when used via authorization header to list flags
     # (both when auth is required and not)

--- a/test/api_with_auth.sh
+++ b/test/api_with_auth.sh
@@ -10,6 +10,8 @@ fi
 _api_test_hook() {
   FLIPT_TOKEN=$(cat out.log | jq -r '. | select(.M=="access token created") | .client_token')
   export FLIPT_TOKEN
+
+  export TEST_FLIPT_API_AUTH_REQUIRED='true'
 }
 
 run() {

--- a/test/config/test.yml
+++ b/test/config/test.yml
@@ -3,3 +3,8 @@ log:
 
 db:
   url: file:./test/flipt.db
+
+authentication:
+  methods:
+    token:
+      enabled: true


### PR DESCRIPTION
@markphelps noticed that the core auth service (list, self, getByID) was not actually mounted yet (my bad 🤦).

I added some test cases to the shakedown tests around these endpoints.
Along with mounting the service itself.

The tests should at-least avoid the regression of this in the future.

The tests:

1. create a new token.
2. list flags using that token.
3. list tokens using that token and assert token is present in list.
4. get self using token.