### PR TITLE
fix(config/cors): use strings.Fields for string to string slice fields

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ import (
 
 var decodeHooks = mapstructure.ComposeDecodeHookFunc(
 	mapstructure.StringToTimeDurationHookFunc(),
-	mapstructure.StringToSliceHookFunc(","),
+	stringToSliceHookFunc(),
 	stringToEnumHookFunc(stringToLogEncoding),
 	stringToEnumHookFunc(stringToCacheBackend),
 	stringToEnumHookFunc(stringToScheme),
@@ -186,5 +186,25 @@ func stringToEnumHookFunc[T constraints.Integer](mappings map[string]T) mapstruc
 		enum := mappings[data.(string)]
 
 		return enum, nil
+	}
+}
+
+// stringToSliceHookFunc returns a DecodeHookFunc that converts
+// string to []string by splitting using strings.Fields().
+func stringToSliceHookFunc() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data interface{}) (interface{}, error) {
+		if f != reflect.String || t != reflect.Slice {
+			return data, nil
+		}
+
+		raw := data.(string)
+		if raw == "" {
+			return []string{}, nil
+		}
+
+		return strings.Fields(raw), nil
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,7 +368,7 @@ func TestLoad(t *testing.T) {
 				}
 				cfg.Cors = CorsConfig{
 					Enabled:        true,
-					AllowedOrigins: []string{"foo.com", "bar.com"},
+					AllowedOrigins: []string{"foo.com", "bar.com", "baz.com"},
 				}
 				cfg.Cache.Enabled = true
 				cfg.Cache.Backend = CacheMemory

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -8,7 +8,7 @@ ui:
 
 cors:
   enabled: true
-  allowed_origins: "foo.com,bar.com"
+  allowed_origins: "foo.com bar.com  baz.com"
 
 cache:
   enabled: true


### PR DESCRIPTION
@showwin pointed out that we regressed in terms of splitting behaviour on `allowed_origins` here:
https://github.com/flipt-io/flipt/pull/1173

Before the config refactor, we were splitting using `strings.Fields()` (this was the internal behaviour of `viper.GetStringSlice()`). Afterwards, `mapstructure.StringToSliceHook(",")` was leading to a simple `strings.Split(..., ",")`.

This adjusts the string to slice hook to use `strings.Fields(...)`.
This function treats one or more consecutive whitespace characters as a delimiter.
I added an example case to demonstrate this.

Once merged, we will cut a few patch releases on previous versions.