### PR TITLE
fix(config/cors): [release/1.15] use strings.Fields for string to string slice fields (#1179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v1.15.2](https://github.com/markphelps/flipt/releases/tag/v1.15.2) - 2022-11-29
+
+### Fixed
+
+- Fix configuration unmarshalling from `string` to `[]string` to delimit on `" "` vs `","` [#1179](https://github.com/flipt-io/flipt/pull/1179)
+
 ## [v1.15.1](https://github.com/markphelps/flipt/releases/tag/v1.15.1) - 2022-11-28
 
 ### Fixed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ import (
 
 var decodeHooks = mapstructure.ComposeDecodeHookFunc(
 	mapstructure.StringToTimeDurationHookFunc(),
-	mapstructure.StringToSliceHookFunc(","),
+	stringToSliceHookFunc(),
 	stringToEnumHookFunc(stringToLogEncoding),
 	stringToEnumHookFunc(stringToCacheBackend),
 	stringToEnumHookFunc(stringToScheme),
@@ -186,5 +186,25 @@ func stringToEnumHookFunc[T constraints.Integer](mappings map[string]T) mapstruc
 		enum := mappings[data.(string)]
 
 		return enum, nil
+	}
+}
+
+// stringToSliceHookFunc returns a DecodeHookFunc that converts
+// string to []string by splitting using strings.Fields().
+func stringToSliceHookFunc() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data interface{}) (interface{}, error) {
+		if f != reflect.String || t != reflect.Slice {
+			return data, nil
+		}
+
+		raw := data.(string)
+		if raw == "" {
+			return []string{}, nil
+		}
+
+		return strings.Fields(raw), nil
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -368,7 +368,7 @@ func TestLoad(t *testing.T) {
 				}
 				cfg.Cors = CorsConfig{
 					Enabled:        true,
-					AllowedOrigins: []string{"foo.com"},
+					AllowedOrigins: []string{"foo.com", "bar.com", "baz.com"},
 				}
 				cfg.Cache.Enabled = true
 				cfg.Cache.Backend = CacheMemory

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -8,7 +8,7 @@ ui:
 
 cors:
   enabled: true
-  allowed_origins: "foo.com"
+  allowed_origins: "foo.com bar.com  baz.com"
 
 cache:
   enabled: true


### PR DESCRIPTION
Backporting fix in #1179 onto release v1.15.

Once merged, we can cut `v1.15.2`.