### PR TITLE
chore: only tag/push latest Docker for latest semantic tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           distribution: goreleaser-pro
           version: latest
-          args: release --rm-dist --nightly
+          args: release -f .goreleaser.nightly.yml --rm-dist --nightly
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,3 +66,16 @@ jobs:
           ANALYTICS_KEY: ${{ secrets.ANALYTICS_KEY }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+
+      - name: Tag and Push latest
+        env:
+          TAG: ${{ github.ref }}
+        run: |
+          if [[ $(git tag -l --sort=-version:refname | head -n 1) == $TAG ]]; then
+            docker tag flipt/flipt:$TAG flipt/flipt:latest
+            docker tag markphelps/flipt:$TAG markphelps/flipt:latest
+            docker tag ghcr.io/flipt-io/flipt:$TAG ghcr.io/flipt-io/flipt:latest
+            docker push flipt/flipt:latest
+            docker push markphelps/flipt:latest
+            docker push ghcr.io/flipt-io/flipt:latest
+          fi

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+includes:
+  - from_file:
+      path: .goreleaser.yml
+
+docker_manifests:
+  - name_template: "flipt/flipt:nightly"
+    image_templates:
+      - "flipt/flipt:{{ incpatch .Version }}-nightly-amd64"
+      - "flipt/flipt:{{ incpatch .Version }}-nightly-arm64"
+
+  - name_template: "markphelps/flipt:nightly"
+    image_templates:
+      - "flipt/flipt:{{ incpatch .Version }}-nightly-amd64"
+      - "flipt/flipt:{{ incpatch .Version }}-nightly-arm64"
+
+  - name_template: "ghcr.io/flipt-io/flipt:nightly"
+    image_templates:
+      - "ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-amd64"
+      - "ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-arm64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
 builds:
   - main: ./cmd/flipt/.
     ldflags:
@@ -83,26 +85,16 @@ dockers:
       - config/default.yml
 
 docker_manifests:
-  - name_template: "{{ if .IsNightly }}flipt/flipt:nightly{{ else }}flipt/flipt:latest{{ end }}"
-    image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:{{ .Tag }}-arm64{{ end }}"
   - name_template: "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly{{ else }}flipt/flipt:{{ .Tag }}{{ end }}"
     image_templates:
       - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:{{ .Tag }}-amd64{{ end }}"
       - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:{{ .Tag }}-arm64{{ end }}"
-  - name_template: "{{ if .IsNightly }}markphelps/flipt:nightly{{ else }}markphelps/flipt:latest{{ end }}" # TODO: deprecate
-    image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:{{ .Tag }}-arm64{{ end }}"
+
   - name_template: "{{ if .IsNightly }}markphelps/flipt:{{ incpatch .Version }}-nightly{{ else }}markphelps/flipt:{{ .Tag }}{{ end }}" # TODO: deprecate
     image_templates:
       - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:{{ .Tag }}-amd64{{ end }}"
       - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:{{ .Tag }}-arm64{{ end }}"
-  - name_template: "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:nightly{{ else }}ghcr.io/flipt-io/flipt:latest{{ end }}"
-    image_templates:
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}-arm64{{ end }}"
+
   - name_template: "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}{{ end }}"
     image_templates:
       - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}-amd64{{ end }}"


### PR DESCRIPTION
This _should_ fix the issue where creating a backport release was incorrectly also tagging the image as `latest` and pushing to our Docker registries

This removes the tagging of latest from `goreleaser` workflow and instead tags and pushes the image only if it is actually the most recent semantic release.

I tested this locally by writing a little script:

```bash
# test.sh

if [[ $(git tag -l --sort=-version:refname | head -n 1) == $TAG ]]; then
    echo "MATCH"
else
    echo "NO MATCH"
fi
```

```console
$ ./test.sh
NO MATCH

$ TAG=v1.15.1 ./test.sh
NO MATCH

$ TAG=v1.15.2 ./test.sh
MATCH
```
