### PR TITLE
fix(sql/testing): use wait.ForSQL when readying cockroach

### DIFF
--- a/internal/storage/sql/testing/testing.go
+++ b/internal/storage/sql/testing/testing.go
@@ -216,7 +216,9 @@ func NewDBContainer(ctx context.Context, proto config.DatabaseProtocol) (*DBCont
 		req = testcontainers.ContainerRequest{
 			Image:        "cockroachdb/cockroach:latest-v21.2",
 			ExposedPorts: []string{"26257/tcp", "8080/tcp"},
-			WaitingFor:   wait.ForHTTP("/health").WithPort("8080"),
+			WaitingFor: wait.ForSQL(port, "postgres", func(host string, port nat.Port) string {
+				return fmt.Sprintf("postgres://root@%s:%s/defaultdb?sslmode=disable", host, port.Port())
+			}),
 			Env: map[string]string{
 				"COCKROACH_USER":     "root",
 				"COCKROACH_DATABASE": "defaultdb",


### PR DESCRIPTION
I've noticed connections on cockroachdb attempting to apply migrations are getting stuck a lot during testing.

I'm unsure if this will help. However, I decided to attempt and migrate to the `wait.ForSQL` pattern for cockroach.
Just in case there is some kind of race when cockroach HTTP server is ready but SQL is in a bad state.

Example: https://github.com/flipt-io/flipt/actions/runs/3578054959/jobs/6017766294