### PR TITLE
chore: update to use goreleaser-pro for snapshot build

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -40,7 +40,7 @@ jobs:
       - name: GoReleaser (Snapshot)
         uses: goreleaser/goreleaser-action@v3
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro
           version: latest
           args: release --rm-dist --snapshot
         env:


### PR DESCRIPTION
to fix

```
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 35: field nightly not found in type config.Project
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.13.1/x64/goreleaser' failed with exit code 1
```