### PR TITLE
chore: try to fix latest tag/push on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           TAG: ${{ github.ref }}
         run: |
-          if [[ $(git tag -l --sort=-version:refname | head -n 1) == $TAG ]]; then
+          if [[ $TAG =~ $(git tag -l --sort=-version:refname | head -n 1) ]]; then
             docker tag flipt/flipt:$TAG flipt/flipt:latest
             docker tag markphelps/flipt:$TAG markphelps/flipt:latest
             docker tag ghcr.io/flipt-io/flipt:$TAG ghcr.io/flipt-io/flipt:latest


### PR DESCRIPTION
Testing using similar script strategy in #1182 

```console
workspace/flipt - [main●] » TAG=refs/tags/v1.15.0 ./test.sh
NO MATCH
workspace/flipt - [main●] » TAG=refs/tags/v1.16 ./test.sh
NO MATCH
workspace/flipt - [main●] » TAG=refs/tags/v1.16.1 ./test.sh
NO MATCH
workspace/flipt - [main●] » TAG=refs/tags/v1.16.0 ./test.sh
MATCH
workspace/flipt - [main●] » git tag -l --sort=-version:refname | head -n 1
v1.16.0
```
