### PR TITLE
chore(build): fix nightly/all builds to install gcc

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,8 @@ jobs:
 
       - name: Install GCC for arm64
         run: |
-          sudo apt-get install gcc-aarch64-linux-gnu
+          sudo apt-get update && \
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Install Syft
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,8 @@ jobs:
 
       - name: Install GCC for arm64
         run: |
-          sudo apt-get install gcc-aarch64-linux-gnu
+          sudo apt-get update &&
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Install Syft
         run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Install GCC for arm64
         run: |
-          sudo apt-get install gcc-aarch64-linux-gnu
+          sudo apt-get update && \
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Install Syft
         run: |


### PR DESCRIPTION
Fix issue with the nightly build: https://github.com/flipt-io/flipt/actions/runs/3643433494/jobs/6151648683#step:7:57

Pass: https://github.com/flipt-io/flipt/actions/runs/3644496837/jobs/6153804553