### PR TITLE
feat: deprecate ui enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Deprecated
+
+- Deprecates `ui.enabled` in favor of always enabling the UI
+
 ## [v1.16.0](https://github.com/flipt-io/flipt/releases/tag/v1.16.0) - 2022-11-30
 
 ### Added

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -32,18 +32,25 @@ Description.
 
 -->
 
+### ui.enabled
+
+> since [unreleased](TODO)
+
+An upcoming release will enable the UI always and this option will be removed.
+There will be a new version of Flipt (headless) that will run Flipt without the UI and only include the API.
+
+### db.migrations.path and db.migrations_path
+
+> since [v1.14.0](https://github.com/flipt-io/flipt/releases/tag/v1.14.0)
+
+These options are no longer considered during Flipt execution.
+Database migrations are embedded directly within the Flipt binary.
+
 ### API ListFlagRequest, ListSegmentRequest, ListRuleRequest offset
 
 > since [v1.13.0](https://github.com/flipt-io/flipt/releases/tag/v1.13.0)
 
 `offset` has been deprecated in favor of `page_token`/`next_page_token` for `ListFlagRequest`, `ListSegmentRequest` and `ListRuleRequest`. See: [#936](https://github.com/flipt-io/flipt/issues/936).
-
-### db.migrations.path and db.migrations_path
-
-> since [v1.14.0](https://github.com/flipt-io/flipt/releases/tag/v1.10.0)
-
-These options are no longer considered during Flipt execution.
-Database migrations are embedded directly within the Flipt binary.
 
 ### cache.memory.enabled
 

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -38,7 +38,8 @@ import (
 const devVersion = "dev"
 
 var (
-	cfg *config.Config
+	cfg         *config.Config
+	cfgWarnings []string
 
 	cfgPath      string
 	forceMigrate bool
@@ -156,13 +157,14 @@ func main() {
 	banner = buf.String()
 
 	cobra.OnInitialize(func() {
-		var err error
-
 		// read in config
-		cfg, err = config.Load(cfgPath)
+		res, err := config.Load(cfgPath)
 		if err != nil {
 			logger().Fatal("loading configuration", zap.Error(err))
 		}
+
+		cfg = res.Config
+		cfgWarnings = res.Warnings
 
 		// log to file if enabled
 		if cfg.Log.File != "" {
@@ -232,7 +234,7 @@ func run(ctx context.Context, logger *zap.Logger) error {
 	}
 
 	// print out any warnings from config parsing
-	for _, warning := range cfg.Warnings {
+	for _, warning := range cfgWarnings {
 		logger.Warn("configuration warning", zap.String("message", warning))
 	}
 

--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -52,7 +52,7 @@ func (c *CacheConfig) setDefaults(v *viper.Viper) {
 func (c *CacheConfig) deprecations(v *viper.Viper) []deprecation {
 	var deprecations []deprecation
 
-	if v.GetBool("cache.memory.enabled") {
+	if v.InConfig("cache.memory.enabled") {
 		deprecations = append(deprecations, deprecation{
 
 			option:            "cache.memory.enabled",
@@ -60,7 +60,7 @@ func (c *CacheConfig) deprecations(v *viper.Viper) []deprecation {
 		})
 	}
 
-	if v.IsSet("cache.memory.expiration") {
+	if v.InConfig("cache.memory.expiration") {
 		deprecations = append(deprecations, deprecation{
 			option:            "cache.memory.expiration",
 			additionalMessage: deprecatedMsgMemoryExpiration,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -227,6 +227,7 @@ func TestLoad(t *testing.T) {
 		path     string
 		wantErr  error
 		expected func() *Config
+		warnings []string
 	}{
 		{
 			name:     "defaults",
@@ -237,6 +238,9 @@ func TestLoad(t *testing.T) {
 			name:     "deprecated - cache memory items defaults",
 			path:     "./testdata/deprecated/cache_memory_items.yml",
 			expected: defaultConfig,
+			warnings: []string{
+				"\"cache.memory.enabled\" is deprecated and will be removed in a future version. Please use 'cache.backend' and 'cache.enabled' instead.",
+			},
 		},
 		{
 			name: "deprecated - cache memory enabled",
@@ -246,30 +250,34 @@ func TestLoad(t *testing.T) {
 				cfg.Cache.Enabled = true
 				cfg.Cache.Backend = CacheMemory
 				cfg.Cache.TTL = -time.Second
-				cfg.Warnings = []string{
-					"\"cache.memory.enabled\" is deprecated and will be removed in a future version. Please use 'cache.backend' and 'cache.enabled' instead.",
-					"\"cache.memory.expiration\" is deprecated and will be removed in a future version. Please use 'cache.ttl' instead.",
-				}
 				return cfg
+			},
+			warnings: []string{
+				"\"cache.memory.enabled\" is deprecated and will be removed in a future version. Please use 'cache.backend' and 'cache.enabled' instead.",
+				"\"cache.memory.expiration\" is deprecated and will be removed in a future version. Please use 'cache.ttl' instead.",
 			},
 		},
 		{
-			name: "deprecated - database migrations path",
-			path: "./testdata/deprecated/database_migrations_path.yml",
-			expected: func() *Config {
-				cfg := defaultConfig()
-				cfg.Warnings = []string{"\"db.migrations.path\" is deprecated and will be removed in a future version. Migrations are now embedded within Flipt and are no longer required on disk."}
-				return cfg
-			},
+			name:     "deprecated - database migrations path",
+			path:     "./testdata/deprecated/database_migrations_path.yml",
+			expected: defaultConfig,
+			warnings: []string{"\"db.migrations.path\" is deprecated and will be removed in a future version. Migrations are now embedded within Flipt and are no longer required on disk."},
 		},
 		{
-			name: "deprecated - database migrations path legacy",
-			path: "./testdata/deprecated/database_migrations_path_legacy.yml",
+			name:     "deprecated - database migrations path legacy",
+			path:     "./testdata/deprecated/database_migrations_path_legacy.yml",
+			expected: defaultConfig,
+			warnings: []string{"\"db.migrations.path\" is deprecated and will be removed in a future version. Migrations are now embedded within Flipt and are no longer required on disk."},
+		},
+		{
+			name: "deprecated - ui disabled",
+			path: "./testdata/deprecated/ui_disabled.yml",
 			expected: func() *Config {
 				cfg := defaultConfig()
-				cfg.Warnings = []string{"\"db.migrations.path\" is deprecated and will be removed in a future version. Migrations are now embedded within Flipt and are no longer required on disk."}
+				cfg.UI.Enabled = false
 				return cfg
 			},
+			warnings: []string{"\"ui.enabled\" is deprecated and will be removed in a future version."},
 		},
 		{
 			name: "cache - no backend set",
@@ -382,9 +390,6 @@ func TestLoad(t *testing.T) {
 					Encoding:  LogEncodingJSON,
 					GRPCLevel: "ERROR",
 				}
-				cfg.UI = UIConfig{
-					Enabled: false,
-				}
 				cfg.Cors = CorsConfig{
 					Enabled:        true,
 					AllowedOrigins: []string{"foo.com", "bar.com", "baz.com"},
@@ -443,6 +448,7 @@ func TestLoad(t *testing.T) {
 			path     = tt.path
 			wantErr  = tt.wantErr
 			expected *Config
+			warnings = tt.warnings
 		)
 
 		if tt.expected != nil {
@@ -450,7 +456,7 @@ func TestLoad(t *testing.T) {
 		}
 
 		t.Run(tt.name+" (YAML)", func(t *testing.T) {
-			cfg, err := Load(path)
+			res, err := Load(path)
 
 			if wantErr != nil {
 				t.Log(err)
@@ -460,8 +466,9 @@ func TestLoad(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.NotNil(t, cfg)
-			assert.Equal(t, expected, cfg)
+			assert.NotNil(t, res)
+			assert.Equal(t, expected, res.Config)
+			assert.Equal(t, warnings, res.Warnings)
 		})
 
 		t.Run(tt.name+" (ENV)", func(t *testing.T) {
@@ -483,7 +490,7 @@ func TestLoad(t *testing.T) {
 			}
 
 			// load default (empty) config
-			cfg, err := Load("./testdata/default.yml")
+			res, err := Load("./testdata/default.yml")
 
 			if wantErr != nil {
 				t.Log(err)
@@ -493,8 +500,8 @@ func TestLoad(t *testing.T) {
 
 			require.NoError(t, err)
 
-			assert.NotNil(t, cfg)
-			assert.Equal(t, expected, cfg)
+			assert.NotNil(t, res)
+			assert.Equal(t, expected, res.Config)
 		})
 	}
 }

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -3,9 +3,6 @@ log:
   file: "testLogFile.txt"
   encoding: "json"
 
-ui:
-  enabled: false
-
 cors:
   enabled: true
   allowed_origins: "foo.com bar.com  baz.com"
@@ -46,5 +43,5 @@ authentication:
     token:
       enabled: true
       cleanup:
-         interval: 2h
-         grace_period: 48h
+        interval: 2h
+        grace_period: 48h

--- a/internal/config/testdata/deprecated/ui_disabled.yml
+++ b/internal/config/testdata/deprecated/ui_disabled.yml
@@ -1,0 +1,2 @@
+ui:
+  enabled: false

--- a/internal/config/ui.go
+++ b/internal/config/ui.go
@@ -16,3 +16,15 @@ func (c *UIConfig) setDefaults(v *viper.Viper) {
 		"enabled": true,
 	})
 }
+
+func (c *UIConfig) deprecations(v *viper.Viper) []deprecation {
+	var deprecations []deprecation
+
+	if v.GetBool("ui.enabled") {
+		deprecations = append(deprecations, deprecation{
+			option: "ui.enabled",
+		})
+	}
+
+	return deprecations
+}

--- a/internal/config/ui.go
+++ b/internal/config/ui.go
@@ -20,7 +20,7 @@ func (c *UIConfig) setDefaults(v *viper.Viper) {
 func (c *UIConfig) deprecations(v *viper.Viper) []deprecation {
 	var deprecations []deprecation
 
-	if v.GetBool("ui.enabled") {
+	if v.InConfig("ui.enabled") {
 		deprecations = append(deprecations, deprecation{
 			option: "ui.enabled",
 		})


### PR DESCRIPTION
Re: FLI-125

- Refactors config parsing to separate out `Warnings` from the `Config` itself, making it easier to write tests against config parsing

- Deprecates `ui.enabled` as in the future we will have 2 versions of Flipt:

1. Current version where UI is always enable
2. Headless version which is API only