### PR TITLE
chore: use minted GITHUB_TOKEN for task setup to avoid ratelimits

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,6 +23,14 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
       - uses: actions/checkout@v3
 
       - uses: actions/setup-go@v3
@@ -45,6 +53,8 @@ jobs:
           cache-dependency-path: ui/package-lock.json
 
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ steps.generate_token.outputs.token }}
 
       - name: Build the binary
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -23,6 +31,8 @@ jobs:
           cache: true
 
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ steps.generate_token.outputs.token }}
 
       - uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -19,6 +19,7 @@ jobs:
           app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
           private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
           installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
       - name: Trigger Workflow (Dispatch)
         if: ${{ github.event_name == "workflow_dispatch" }}
         env:
@@ -26,6 +27,7 @@ jobs:
         run: |
           gh workflow run proto-upgrade.yml -R flipt-io/flipt-grpc-go -f tag="${{ inputs.tag }}"
           gh workflow run proto-upgrade.yml -R flipt-io/flipt-grpc-ruby -f tag="${{ inputs.tag }}"
+
       - name: Trigger Workflow (Release)
         if: ${{ github.event_name == "release" }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -24,6 +32,8 @@ jobs:
           cache: true
 
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ steps.generate_token.outputs.token }}
 
       - uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,6 +9,14 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
@@ -20,6 +28,8 @@ jobs:
           cache: true
 
       - uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ steps.generate_token.outputs.token }}
 
       - uses: docker/setup-qemu-action@v2
 


### PR DESCRIPTION
use fresh minted GITHUB_TOKEN when calling `setup-task` in workflows to avoid GitHub rate limits causing jobs to fail

ex: https://github.com/flipt-io/flipt/actions/runs/3832718965/jobs/6523354201#step:6:5

https://github.com/arduino/setup-task#repo-token