### PR TITLE
chore: try to fix post release workflows to trigger

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,12 +1,15 @@
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 name: Various Updates Post Release
 jobs:
   release_client:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Generate token
         id: generate_token

--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -1,6 +1,8 @@
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       tag:
@@ -11,6 +13,7 @@ name: Release Updates to GRPC Clients
 jobs:
   release_client:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Generate token
         id: generate_token


### PR DESCRIPTION
Try to fix the following workflows to run after the `release` workflow succeeds:
- `release-clients` (updates grpc clients if necessary)
- `post-release` (performs other post release tasks, currently updating `try.flipt.io`)

This updates these workflows to be triggered on [workflow_run](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run)

For whatever reason they were not being triggered using the `release` trigger