### PR TITLE
chore: rm branch from post release workflows

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -2,7 +2,6 @@ on:
   workflow_run:
     workflows: [Release]
     types: [completed]
-    branches: [main]
   workflow_dispatch:
 
 name: Various Updates Post Release

--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -2,7 +2,6 @@ on:
   workflow_run:
     workflows: [Release]
     types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
Follow up to #1271 

I forgot that we don't always create releases from the `main` branch, so these workflows wouldn't always fire :(