### PR TITLE
fix(meta): remove `runtime.HttpBodyMarshaler` from gateway stack

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -137,12 +137,6 @@ func NewHTTPServer(
 
 			// mount the metadata service to the chi router under /meta.
 			r.Mount("/meta", runtime.NewServeMux(
-				runtime.WithMarshalerOption("application/json", &runtime.HTTPBodyMarshaler{
-					Marshaler: gateway.JSONMarshaler,
-				}),
-				runtime.WithMarshalerOption("application/json+pretty", &runtime.HTTPBodyMarshaler{
-					Marshaler: gateway.JSONPrettyMarshaler,
-				}),
 				registerFunc(
 					ctx,
 					conn,

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -137,8 +137,12 @@ func NewHTTPServer(
 
 			// mount the metadata service to the chi router under /meta.
 			r.Mount("/meta", runtime.NewServeMux(
-				runtime.WithMarshalerOption("application/json", &runtime.HTTPBodyMarshaler{}),
-				runtime.WithMarshalerOption("application/json+pretty", &runtime.HTTPBodyMarshaler{}),
+				runtime.WithMarshalerOption("application/json", &runtime.HTTPBodyMarshaler{
+					Marshaler: gateway.JSONMarshaler,
+				}),
+				runtime.WithMarshalerOption("application/json+pretty", &runtime.HTTPBodyMarshaler{
+					Marshaler: gateway.JSONPrettyMarshaler,
+				}),
 				registerFunc(
 					ctx,
 					conn,

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -6,6 +6,22 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+var (
+	// JSONMarshaler is the base JSON marshaller for Flipts gRPC gateway handler stack.
+	JSONMarshaler = flipt.NewV1toV2MarshallerAdapter()
+	// JSONPrettyMarshaler is Flipt's JSON marshaler when the `pretty` directive is added
+	// to the requested JSON mime-type.
+	JSONPrettyMarshaler = &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			Indent:    "  ",
+			Multiline: true, // Optional, implied by presence of "Indent".
+		},
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+		},
+	}
+)
+
 // commonMuxOptions are options for gateway mux which are used for multiple instances.
 // This is required to fix a backwards compatibility issue with the v2 marshaller where `null` map values
 // cause an error because they are not allowed by the proto spec, but they were handled by the v1 marshaller.
@@ -14,16 +30,8 @@ import (
 //
 // See: https://github.com/flipt-io/flipt/issues/664
 var commonMuxOptions = []runtime.ServeMuxOption{
-	runtime.WithMarshalerOption(runtime.MIMEWildcard, flipt.NewV1toV2MarshallerAdapter()),
-	runtime.WithMarshalerOption("application/json+pretty", &runtime.JSONPb{
-		MarshalOptions: protojson.MarshalOptions{
-			Indent:    "  ",
-			Multiline: true, // Optional, implied by presence of "Indent".
-		},
-		UnmarshalOptions: protojson.UnmarshalOptions{
-			DiscardUnknown: true,
-		},
-	}),
+	runtime.WithMarshalerOption(runtime.MIMEWildcard, JSONMarshaler),
+	runtime.WithMarshalerOption("application/json+pretty", JSONPrettyMarshaler),
 }
 
 // NewGatewayServeMux builds a new gateway serve mux with common options.

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -6,22 +6,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-var (
-	// JSONMarshaler is the base JSON marshaller for Flipts gRPC gateway handler stack.
-	JSONMarshaler = flipt.NewV1toV2MarshallerAdapter()
-	// JSONPrettyMarshaler is Flipt's JSON marshaler when the `pretty` directive is added
-	// to the requested JSON mime-type.
-	JSONPrettyMarshaler = &runtime.JSONPb{
-		MarshalOptions: protojson.MarshalOptions{
-			Indent:    "  ",
-			Multiline: true, // Optional, implied by presence of "Indent".
-		},
-		UnmarshalOptions: protojson.UnmarshalOptions{
-			DiscardUnknown: true,
-		},
-	}
-)
-
 // commonMuxOptions are options for gateway mux which are used for multiple instances.
 // This is required to fix a backwards compatibility issue with the v2 marshaller where `null` map values
 // cause an error because they are not allowed by the proto spec, but they were handled by the v1 marshaller.
@@ -30,8 +14,16 @@ var (
 //
 // See: https://github.com/flipt-io/flipt/issues/664
 var commonMuxOptions = []runtime.ServeMuxOption{
-	runtime.WithMarshalerOption(runtime.MIMEWildcard, JSONMarshaler),
-	runtime.WithMarshalerOption("application/json+pretty", JSONPrettyMarshaler),
+	runtime.WithMarshalerOption(runtime.MIMEWildcard, flipt.NewV1toV2MarshallerAdapter()),
+	runtime.WithMarshalerOption("application/json+pretty", &runtime.JSONPb{
+		MarshalOptions: protojson.MarshalOptions{
+			Indent:    "  ",
+			Multiline: true, // Optional, implied by presence of "Indent".
+		},
+		UnmarshalOptions: protojson.UnmarshalOptions{
+			DiscardUnknown: true,
+		},
+	}),
 }
 
 // NewGatewayServeMux builds a new gateway serve mux with common options.

--- a/test/api.sh
+++ b/test/api.sh
@@ -321,10 +321,10 @@ step_8_test_meta()
       header_matches "Set-Cookie" "_gorilla_csrf"
 
       # ensure unauthenticated request returns 401
-      shakedown GET "/meta/info"
+      shakedown GET "/meta/info" -H 'Accept: application/json'
         status 401
 
-      shakedown GET "/meta/config"
+      shakedown GET "/meta/config" -H 'Accept: application/json'
         status 401
     fi
 }

--- a/test/api.sh
+++ b/test/api.sh
@@ -319,6 +319,13 @@ step_8_test_meta()
 
       # ensure CSRF cookie is present
       header_matches "Set-Cookie" "_gorilla_csrf"
+
+      # ensure unauthenticated request returns 401
+      shakedown GET "/meta/info"
+        status 401
+
+      shakedown GET "/meta/config"
+        status 401
     fi
 }
 

--- a/test/api.sh
+++ b/test/api.sh
@@ -28,8 +28,12 @@ uuid_str()
     uuidgen
 }
 
+shakedownJSON() {
+  shakedown "$@" -H "Accept: application/json"
+}
+
 authedShakedown() {
-  shakedown "$@" -H "Authorization: Bearer ${FLIPT_TOKEN:-""}"
+  shakedownJSON "$@" -H "Authorization: Bearer ${FLIPT_TOKEN:-""}"
 }
 
 _curl() {
@@ -321,10 +325,10 @@ step_8_test_meta()
       header_matches "Set-Cookie" "_gorilla_csrf"
 
       # ensure unauthenticated request returns 401
-      shakedown GET "/meta/info" -H 'Accept: application/json'
+      shakedownJSON GET "/meta/info"
         status 401
 
-      shakedown GET "/meta/config" -H 'Accept: application/json'
+      shakedownJSON GET "/meta/config"
         status 401
     fi
 }
@@ -346,32 +350,32 @@ step_10_test_auths()
     export FLIPT_TOKEN
 
     # /auth/v1/method is always public
-    shakedown GET '/auth/v1/method' -H 'Content-Type: application/json'
+    shakedownJSON GET '/auth/v1/method'
         status 200
 
     # token should succeed when used via authorization header to list flags
     # (both when auth is required and not)
-    authedShakedown GET '/api/v1/flags' -H 'Content-Type: application/json'
+    authedShakedown GET '/api/v1/flags'
         status 200
 
     # listing tokens includes the created token
-    authedShakedown GET "/auth/v1/tokens" -H 'Content-Type: application/json'
+    authedShakedown GET "/auth/v1/tokens"
         status 200
         matches "\"id\":\"${tokenID}\""
 
     if [ -n "${TEST_FLIPT_API_AUTH_REQUIRED:-}" ]; then
         # getting self using token returns expected ID
-        authedShakedown GET '/auth/v1/self' -H 'Content-Type: application/json'
+        authedShakedown GET '/auth/v1/self'
         status 200
         matches "\"id\":\"${tokenID}\""
 
         # cookie based auth is configured and should also work
-        shakedown GET '/auth/v1/self' -H 'Content-Type: application/json' -H "Cookie: flipt_client_token=${FLIPT_TOKEN}"
+        shakedownJSON GET '/auth/v1/self' -H "Cookie: flipt_client_token=${FLIPT_TOKEN}"
         status 200
         matches "\"id\":\"${tokenID}\""
     else
         # there is no self when authentication is disabled
-        authedShakedown GET '/auth/v1/self' -H 'Content-Type: application/json'
+        authedShakedown GET '/auth/v1/self'
         status 401
     fi
 }


### PR DESCRIPTION
Fixes FLI-176

This fixes the case where the `/meta` prefixed endpoints would return `500` (and panic server-side) when authentication was required and no authentication was provided.
Additionally, this only occurred when the `Accept` header was explicitly set to `application/json`.

The accept header caused the `HttpBodyMarshaler` to be invoked. When authentication was not provided, the resulting body was an error and not the expected `HttpBody` instance. This marshaller was fallback to an embedded marshaller in this instance. This wasn't being set and was therefore `nil`, causing a panic at runtime.

Update: After reflecting on the behaviour that this only failed when the `Accept` header was presented, I looked into whether you need to explicitly set the `HttpBodyMarshaler` and it turns out you don't.
The Marshal stack handles the presence of `HttpBody` without it.

In 8d2f4330 I drop them altogether and it behaves as it should. 