### PR TITLE
chore: make UI dev easier

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,6 @@
   "extensions": [
     "golang.Go",
     "dbaeumer.vscode-eslint",
-    "octref.vetur",
     "zxh404.vscode-proto3",
     "esbenp.prettier-vscode"
   ],
@@ -28,10 +27,6 @@
   "portsAttributes": {
     "8080": {
       "label": "HTTP Port",
-      "onAutoForward": "notify"
-    },
-    "8081": {
-      "label": "UI Dev Port",
       "onAutoForward": "notify"
     },
     "9000": {

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,19 +47,24 @@ After changing `flipt.proto`, you'll need to run `mage proto`. This will regener
 
 The UI is built using [NPM](https://nodejs.org/en/) and [Vite](https://vitejs.dev/) and is also statically compiled into the Flipt binary using [go:embed](https://golang.org/pkg/embed/).
 
-The UI code has been migrated to it's own repository: [flipt-ui](https://github.com/flipt-io/flipt-ui).
+The UI code has been migrated to it's own repository: [flipt-ui](https://github.com/flipt-io/flipt-ui), clone it somewhere on your machine and follow the instructions in the README to get started.
 
-TODO (WIP): More info on how to develop the UI within this repository.
+To develop the project with the UI also in development mode (with hot reloading):
+
+1. Run `npm run dev` where you have the `flipt-ui` repository checked out. This will start a development server on port `5173` and proxy API requests to the Flipt API on port `8080`.
+2. Run `mage dev` from the this repository. This will create a dev build that will serve the UI from the development server, while still making it accessible on port `8080`.
+3. Run the binary with the local config: `./bin/flipt --config ./config/local.yml`. This will enable CORS with the correct configuration and start the server on port `8080`.
+4. Visit `http://localhost:8080` to see the UI.
+5. Any changes made in the `flipt-ui` repository will be picked up by the development server and the UI will be reloaded.
 
 ### Ports
 
-In development, the three ports that Flipt users are:
+In development, the two ports that Flipt users are:
 
 - `8080`: The port for the Flipt REST API
-- `8081`: The port for the Flipt UI (via `npm run dev`)
 - `9000`: The port for the Flipt GRPC Server
 
-These three ports will be forwarded to your local machine automatically if you are developing Flipt in a VSCode Remote Container or GitHub Codespace.
+These ports will be forwarded to your local machine automatically if you are developing Flipt in a VSCode Remote Container or GitHub Codespace.
 
 ## CDEs
 

--- a/config/local.yml
+++ b/config/local.yml
@@ -7,9 +7,9 @@ log:
 # ui:
 #   enabled: true
 
-# cors:
-#   enabled: false
-#   allowed_origins: "*"
+cors:
+  enabled: true
+  allowed_origins: ["*"]
 
 # cache:
 #   enabled: false

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -150,7 +150,7 @@ func NewHTTPServer(
 
 	// TODO: remove (deprecated as of 1.17)
 	if cfg.UI.Enabled {
-		u, err := fs.Sub(ui.UI, "dist")
+		u, err := fs.Sub(ui.UI, ui.Mount)
 		if err != nil {
 			return nil, fmt.Errorf("mounting UI: %w", err)
 		}

--- a/magefile.go
+++ b/magefile.go
@@ -52,9 +52,18 @@ func Bootstrap() error {
 	return goInstall(tools...)
 }
 
-// Build builds the project
+// Build builds the project similar to a release build
 func Build() error {
 	mg.Deps(Prep)
+	return build("")
+}
+
+func Dev() error {
+	mg.Deps(Clean)
+	return build("dev")
+}
+
+func build(mode string) error {
 	fmt.Println("Building...")
 
 	buildDate := time.Now().UTC().Format(time.RFC3339)
@@ -64,7 +73,13 @@ func Build() error {
 		return fmt.Errorf("failed to get git commit: %w", err)
 	}
 
-	return sh.RunV("go", "build", "-trimpath", "-tags", "assets", "-ldflags", fmt.Sprintf("-X main.commit=%s -X main.date=%s", gitCommit, buildDate), "-o", "./bin/flipt", "./cmd/flipt/")
+	args := []string{"build", "-trimpath", "-ldflags", fmt.Sprintf("-X main.commit=%s -X main.date=%s", gitCommit, buildDate), "-o", "./bin/flipt", "./cmd/flipt/"}
+
+	if mode != "dev" {
+		args = append(args, "-tags", "assets")
+	}
+
+	return sh.RunV("go", args...)
 }
 
 // Clean cleans up built files

--- a/ui/doc.go
+++ b/ui/doc.go
@@ -5,6 +5,8 @@ package ui
 
 import "embed"
 
-//go:embed index.html
-var UI embed.FS
-var Mount = "."
+var (
+	//go:embed index.html
+	UI    embed.FS
+	Mount = "."
+)

--- a/ui/doc.go
+++ b/ui/doc.go
@@ -5,4 +5,6 @@ package ui
 
 import "embed"
 
+//go:embed index.html
 var UI embed.FS
+var Mount = "."

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -7,3 +7,4 @@ import "embed"
 
 //go:embed dist/*
 var UI embed.FS
+var Mount = "/dist"

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -5,6 +5,8 @@ package ui
 
 import "embed"
 
-//go:embed dist/*
-var UI embed.FS
-var Mount = "/dist"
+var (
+	//go:embed dist/*
+	UI    embed.FS
+	Mount = "dist"
+)

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" className="h-full w-auto">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Flipt</title>
+    <script type="module">
+      import RefreshRuntime from "http://localhost:5173/@react-refresh";
+      RefreshRuntime.injectIntoGlobalHook(window);
+      window.$RefreshReg$ = () => {};
+      window.$RefreshSig$ = () => (type) => type;
+      window.__vite_plugin_react_preamble_installed__ = true;
+    </script>
+    <script type="module" src="http://localhost:5173/@vite/client"></script>
+  </head>
+  <body className="h-full bg-white antialiased">
+    <div id="root"></div>
+  </body>
+  <script type="module" src="http://localhost:5173/src/main.tsx"></script>
+</html>


### PR DESCRIPTION
This takes advantage of https://vitejs.dev/guide/backend-integration.html and allows us to still load the UI on port `:8080` when developing while taking advantage of hot reloading provided by Vite.

The instructors are updated in `DEVELOPMENT.md`, but basically the steps are:

1. Run `npm run dev` where you have the `flipt-ui` repository checked out. This will start a development server on port `5173` and proxy API requests to the Flipt API on port `8080`.
2. Run `mage dev` from the this repository. This will create a dev build that will serve the UI from the development server, while still making it accessible on port `8080`.
3. Run the binary with the local config: `./bin/flipt --config ./config/local.yml`. This will enable CORS with the correct configuration and start the server on port `8080`.
4. Visit `http://localhost:8080` to see the UI.
5. Any changes made in the `flipt-ui` repository will be picked up by the development server and the UI will be reloaded.
