### PR TITLE
fix(csrf): dont attempt to create CSRF token when key is not defined

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -129,7 +129,9 @@ func NewHTTPServer(
 		r.Group(func(r chi.Router) {
 			r.Use(func(handler http.Handler) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.Header().Set("X-CSRF-Token", csrf.Token(r))
+					if cfg.Authentication.Session.CSRF.Key != "" {
+						w.Header().Set("X-CSRF-Token", csrf.Token(r))
+					}
 
 					handler.ServeHTTP(w, r)
 				})


### PR DESCRIPTION
We're currently generating and setting the CSRF token to empty string when a key is not configured.

This ensures we only generate and set a token if configured to do so.