### PR TITLE
chore: rm duplicate grpc shutdown log

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -255,10 +255,7 @@ func NewGRPCServer(
 
 	// register grpcServer graceful stop on shutdown
 	server.onShutdown(func(context.Context) error {
-		logger.Info("shutting down grpc server...")
-
 		server.Server.GracefulStop()
-
 		return nil
 	})
 


### PR DESCRIPTION
Noticed this when shutting down the latest rc release:

```
^C2023-01-20T20:45:46Z	INFO	shutting down...
2023-01-20T20:45:46Z	INFO	shutting down HTTP server...	{"server": "http"}
2023-01-20T20:45:46Z	INFO	shutting down GRPC server...	{"server": "grpc"}
2023-01-20T20:45:46Z	INFO	shutting down grpc server...	{"server": "grpc"}
```

This PR removes the last line (duplicate message)