### PR TITLE
chore: remove tag/push latest for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,22 +81,3 @@ jobs:
           ANALYTICS_KEY: ${{ secrets.ANALYTICS_KEY }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
-
-      - name: Tag and Push latest
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          if [[ $TAG == $(cat version.txt) ]]; then
-            docker pull flipt/flipt:$TAG
-            docker tag flipt/flipt:$TAG flipt/flipt:latest
-
-            docker pull markphelps/flipt:$TAG
-            docker tag markphelps/flipt:$TAG markphelps/flipt:latest
-
-            docker pull ghcr.io/flipt-io/flipt:$TAG
-            docker tag ghcr.io/flipt-io/flipt:$TAG ghcr.io/flipt-io/flipt:latest
-
-            docker push flipt/flipt:latest
-            docker push markphelps/flipt:latest
-            docker push ghcr.io/flipt-io/flipt:latest
-          fi


### PR DESCRIPTION
the change in #1182 broke the creation of the docker multi-arch manifest, since tagging/pushing via docker via the CLI only tags and pushes the image for the architecture on which its run

this requires us to then go back and manually fix the `latest` tag to be the correct multiarch manifest

Im proposing we remove this stage for now until we come up with a better solution of properly creating / pushing multiarch manifests only if this is the latest semantic verison