### PR TITLE
chore: Push latest manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
           sudo apt-get update &&
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      - name: Install Skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install skopeo
+
       - name: Install Syft
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
@@ -88,15 +93,11 @@ jobs:
         run: |
           if [[ $TAG == $(cat version.txt) ]]; then
             docker pull flipt/flipt:$TAG
-            docker tag flipt/flipt:$TAG flipt/flipt:latest
+            skopeo copy --all docker://flipt/flipt:$TAG docker://flipt/flipt:latest
 
             docker pull markphelps/flipt:$TAG
-            docker tag markphelps/flipt:$TAG markphelps/flipt:latest
+            skopeo copy --all docker://markphelps/flipt:$TAG docker://markphelps/flipt:latest
 
             docker pull ghcr.io/flipt-io/flipt:$TAG
-            docker tag ghcr.io/flipt-io/flipt:$TAG ghcr.io/flipt-io/flipt:latest
-
-            docker push flipt/flipt:latest
-            docker push markphelps/flipt:latest
-            docker push ghcr.io/flipt-io/flipt:latest
+            skopeo copy --all docker://ghcr.io/flipt-io/flipt:$TAG docker://ghcr.io/flipt-io/flipt:latest
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,3 +81,22 @@ jobs:
           ANALYTICS_KEY: ${{ secrets.ANALYTICS_KEY }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+
+      - name: Tag and Push latest
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [[ $TAG == $(cat version.txt) ]]; then
+            docker pull flipt/flipt:$TAG
+            docker tag flipt/flipt:$TAG flipt/flipt:latest
+
+            docker pull markphelps/flipt:$TAG
+            docker tag markphelps/flipt:$TAG markphelps/flipt:latest
+
+            docker pull ghcr.io/flipt-io/flipt:$TAG
+            docker tag ghcr.io/flipt-io/flipt:$TAG ghcr.io/flipt-io/flipt:latest
+
+            docker push flipt/flipt:latest
+            docker push markphelps/flipt:latest
+            docker push ghcr.io/flipt-io/flipt:latest
+          fi


### PR DESCRIPTION
This shoulld allow us to continue pushing the `latest` manifest if we are the most recent release  (semver) of Flipt

It uses [skopeo](https://github.com/containers/skopeo) to do the `copy`/`push` step

Per [skopeo's copy docs](https://github.com/containers/skopeo/blob/main/docs/skopeo-copy.1.md), it should use the auth from Docker if no other auth is found, which we should already have setup correctly because of our previous `docker login` step

> If the authorization state is not found there, $HOME/.docker/config.json is checked, which is set using docker login.