### PR TITLE
feat: set csp and content-type-options headers

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -81,6 +81,9 @@ func NewHTTPServer(
 		logger.Info("CORS enabled", zap.Strings("allowed_origins", cfg.Cors.AllowedOrigins))
 	}
 
+	r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
+	r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src *;"))
+
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
 	r.Use(middleware.Heartbeat("/health"))

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -82,7 +82,7 @@ func NewHTTPServer(
 	}
 
 	r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
-	r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src *;"))
+	r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src * data:;"))
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)


### PR DESCRIPTION
Fixes: FLI-178

Sets [`Content-Security-Policy`](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) header to `"default-src 'self'; img-src *;"` which defaults to only allow resources, scripts, etc from this host, but allows images from anywhere per: https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#examples_common_use_cases

See also: https://infosec.mozilla.org/guidelines/web_security#content-security-policy

Also sets [`X-Content-Type-Options`](https://infosec.mozilla.org/guidelines/web_security#x-content-type-options) as well

I am a bit concerned about breaking some functionality since there are some warnings in the browser, however it doesn't seem to actually affect anything during the light testing I've done:

![CleanShot 2023-01-26 at 16 23 50](https://user-images.githubusercontent.com/209477/214954099-52002741-0cc5-4a31-8e78-410e76c5a28c.png)

One option is it make these opt-in, or maybe opt out? Although there's a multitude of ways to configure CSP, so I'm not sure if we can come up with a default that works for everyone. A final option is to simply not do this work ourselves
