### PR TITLE
feat(logging): support custom time, level and message keys

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -164,6 +164,9 @@ func main() {
 		cfg = res.Config
 		cfgWarnings = res.Warnings
 
+		loggerConfig.EncoderConfig.TimeKey = cfg.Log.Keys.Time
+		loggerConfig.EncoderConfig.LevelKey = cfg.Log.Keys.Level
+		loggerConfig.EncoderConfig.MessageKey = cfg.Log.Keys.Message
 		// log to file if enabled
 		if cfg.Log.File != "" {
 			loggerConfig.OutputPaths = []string{cfg.Log.File}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -168,6 +168,11 @@ func defaultConfig() *Config {
 			Level:     "INFO",
 			Encoding:  LogEncodingConsole,
 			GRPCLevel: "ERROR",
+			Keys: LogKeys{
+				Time:    "T",
+				Level:   "L",
+				Message: "M",
+			},
 		},
 
 		UI: UIConfig{
@@ -424,6 +429,11 @@ func TestLoad(t *testing.T) {
 					File:      "testLogFile.txt",
 					Encoding:  LogEncodingJSON,
 					GRPCLevel: "ERROR",
+					Keys: LogKeys{
+						Time:    "time",
+						Level:   "level",
+						Message: "msg",
+					},
 				}
 				cfg.Cors = CorsConfig{
 					Enabled:        true,

--- a/internal/config/log.go
+++ b/internal/config/log.go
@@ -16,6 +16,13 @@ type LogConfig struct {
 	File      string      `json:"file,omitempty" mapstructure:"file"`
 	Encoding  LogEncoding `json:"encoding,omitempty" mapstructure:"encoding"`
 	GRPCLevel string      `json:"grpcLevel,omitempty" mapstructure:"grpc_level"`
+	Keys      LogKeys     `json:"keys" mapstructure:"keys"`
+}
+
+type LogKeys struct {
+	Time    string `json:"time" mapstructure:"time"`
+	Level   string `json:"level" mapstructure:"level"`
+	Message string `json:"message" mapstructure:"message"`
 }
 
 func (c *LogConfig) setDefaults(v *viper.Viper) {
@@ -23,6 +30,11 @@ func (c *LogConfig) setDefaults(v *viper.Viper) {
 		"level":      "INFO",
 		"encoding":   "console",
 		"grpc_level": "ERROR",
+		"keys": map[string]any{
+			"time":    "T",
+			"level":   "L",
+			"message": "M",
+		},
 	})
 }
 

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -2,6 +2,10 @@ log:
   level: WARN
   file: "testLogFile.txt"
   encoding: "json"
+  keys:
+    time: "time"
+    level: "level"
+    message: "msg"
 
 cors:
   enabled: true


### PR DESCRIPTION
Fixes FLI-148
Fixes https://github.com/flipt-io/flipt/issues/1252

Adds support for custom keys in log output for:
- time
- level
- message

Each key can be configured under the `log.keys` object in the configuration.

Using the following Flipt configuration I get the subsequent logging output format:

config.yaml:
```yaml
log:
  level: DEBUG
  encoding: json
  keys:
    time: "time"
    level: "level"
    message: "msg"
```

Flipt output:
```json
{"level":"INFO","time":"2023-01-27T12:39:30Z","msg":"flipt starting","version":"dev","commit":"","date":"","go_version":"go1.19.5"}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"not a release version, disabling telemetry"}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"local state directory exists","path":"/Users/georgemac/Library/Application Support/flipt"}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"using driver","driver":"sqlite3"}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"migrations up to date"}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"store enabled","server":"grpc","driver":"sqlite3"}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"authentication method \"token\" server registered","server":"grpc"}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"authentication method \"oidc\" server registered","server":"grpc"}
{"level":"INFO","time":"2023-01-27T12:39:30Z","msg":"authentication middleware enabled","server":"grpc"}
{"level":"INFO","time":"2023-01-27T12:39:30Z","msg":"cleanup process not acquired","server":"grpc","next_attempt":"2023-01-27T12:49:10Z"}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"starting grpc server","server":"grpc"}
{"level":"INFO","time":"2023-01-27T12:39:30Z","msg":"CORS enabled","server":"http","allowed_origins":["http://localhost:5173","http://localhost:8080"]}
{"level":"DEBUG","time":"2023-01-27T12:39:30Z","msg":"starting http server","server":"http"}
{"level":"INFO","time":"2023-01-27T12:39:30Z","msg":"api available","server":"http","address":"http://0.0.0.0:8080/api/v1"}
{"level":"INFO","time":"2023-01-27T12:39:30Z","msg":"ui available","server":"http","address":"http://0.0.0.0:8080"}
```