### PR TITLE
fix: get linter running correctly locally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,9 +14,11 @@ run:
     - "bin"
     - "_tools"
     - "dist"
-    - "rpc"
-    - "swagger"
+    - "rpc/flipt"
     - "ui"
+
+  skip-files:
+    - ".*pb.go"
 
   # which files to skip: they will be analyzed, but issues from them
   # won't be reported. Default value is empty list, but there is
@@ -30,7 +32,6 @@ linters:
     - errcheck
     - goconst
     - gocritic
-    - goimports
     - gosec
     - gosimple
     - govet
@@ -39,12 +40,12 @@ linters:
     - misspell
     - staticcheck
     - stylecheck
+    - sqlclosecheck
     - unconvert
     - unparam
   disable:
     - contextcheck
     - exhaustive
-    - rowserrcheck
   enable-all: false
   presets:
     - bugs
@@ -68,6 +69,10 @@ linters-settings:
     checks:
       - all
       - "-SA1019" # exclude staticcheck messages from github.com/golang/protobuf
+  stylecheck:
+    checks:
+      - all
+      - "-ST1003" # exclude underscores
   gosec:
     excludes: # exclude gosec messages about weak crypto
       - "G501"


### PR DESCRIPTION
## Before

```
mage lint
Linting...
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] Can't run linter goanalysis_metalinter: goimports: can't extract issues from gofmt diff output "--- /Users/markphelps/workspace/flipt/rpc/flipt/auth/auth.pb.go.orig\t2023-01-27 15:51:11\n+++ /Users/markphelps/workspace/flipt/rpc/flipt/auth/auth.pb.go\t2023-01-27 15:51:11\n@@ -7,14 +7,15 @@\n package auth\n \n import (\n+\treflect \"reflect\"\n+\tsync \"sync\"\n+\n \t_ \"github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options\"\n \tprotoreflect \"google.golang.org/protobuf/reflect/protoreflect\"\n \tprotoimpl \"google.golang.org/protobuf/runtime/protoimpl\"\n \temptypb \"google.golang.org/protobuf/types/known/emptypb\"\n \tstructpb \"google.golang.org/protobuf/types/known/structpb\"\n \ttimestamppb \"google.golang.org/protobuf/types/known/timestamppb\"\n-\treflect \"reflect\"\n-\tsync \"sync\"\n )\n \n const (\n": can't parse patch: parsing time "2023-01-27 15:51:11" as "2006-01-02 15:04:05 -0700": cannot parse "" as "-0700"
WARN [linters context] sqlclosecheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
ERRO Running error: 1 error occurred:
	* can't run linter goanalysis_metalinter: goimports: can't extract issues from gofmt diff output "--- /Users/markphelps/workspace/flipt/rpc/flipt/auth/auth.pb.go.orig\t2023-01-27 15:51:11\n+++ /Users/markphelps/workspace/flipt/rpc/flipt/auth/auth.pb.go\t2023-01-27 15:51:11\n@@ -7,14 +7,15 @@\n package auth\n \n import (\n+\treflect \"reflect\"\n+\tsync \"sync\"\n+\n \t_ \"github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options\"\n \tprotoreflect \"google.golang.org/protobuf/reflect/protoreflect\"\n \tprotoimpl \"google.golang.org/protobuf/runtime/protoimpl\"\n \temptypb \"google.golang.org/protobuf/types/known/emptypb\"\n \tstructpb \"google.golang.org/protobuf/types/known/structpb\"\n \ttimestamppb \"google.golang.org/protobuf/types/known/timestamppb\"\n-\treflect \"reflect\"\n-\tsync \"sync\"\n )\n \n const (\n": can't parse patch: parsing time "2023-01-27 15:51:11" as "2006-01-02 15:04:05 -0700": cannot parse "" as "-0700"

Error: failed to lint: running "golangci-lint run" failed with exit code 3
```

## After

```
mage lint
Linting...
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [linters context] rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] sqlclosecheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
```