### PR TITLE
fix/feat: use joins instead of n+1/opening multiple connections

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -106,6 +106,10 @@ func NewGRPCServer(
 		return nil, fmt.Errorf("opening db: %w", err)
 	}
 
+	if driver == sql.SQLite && cfg.Database.MaxOpenConn > 1 {
+		logger.Warn("ignoring config.db.max_open_conn due to driver limitation (sqlite)", zap.Int("attempted_max_conn", cfg.Database.MaxOpenConn))
+	}
+
 	server.onShutdown(func(context.Context) error {
 		return db.Close()
 	})

--- a/internal/info/flipt.go
+++ b/internal/info/flipt.go
@@ -16,7 +16,7 @@ type Flipt struct {
 }
 
 func (f Flipt) IsDevelopment() bool {
-	return f.Version == "dev" && !f.IsRelease
+	return f.Version == "dev"
 }
 
 func (f Flipt) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/sql/db.go
+++ b/internal/storage/sql/db.go
@@ -32,7 +32,7 @@ func Open(cfg config.Config, opts ...Option) (*sql.DB, Driver, error) {
 	sql.SetMaxIdleConns(cfg.Database.MaxIdleConn)
 
 	if driver == SQLite {
-		sql.SetMaxOpenConns(2)
+		sql.SetMaxOpenConns(1)
 	} else if cfg.Database.MaxOpenConn > 0 {
 		sql.SetMaxOpenConns(cfg.Database.MaxOpenConn)
 	}

--- a/internal/storage/sql/db.go
+++ b/internal/storage/sql/db.go
@@ -31,11 +31,11 @@ func Open(cfg config.Config, opts ...Option) (*sql.DB, Driver, error) {
 
 	sql.SetMaxIdleConns(cfg.Database.MaxIdleConn)
 
-	if driver == SQLite {
-		sql.SetMaxOpenConns(1)
-	} else if cfg.Database.MaxOpenConn > 0 {
-		sql.SetMaxOpenConns(cfg.Database.MaxOpenConn)
-	}
+	// if driver == SQLite {
+	// 	sql.SetMaxOpenConns(1)
+	// } else if cfg.Database.MaxOpenConn > 0 {
+	sql.SetMaxOpenConns(cfg.Database.MaxOpenConn)
+	// }
 
 	if cfg.Database.ConnMaxLifetime > 0 {
 		sql.SetConnMaxLifetime(cfg.Database.ConnMaxLifetime)

--- a/internal/storage/sql/db.go
+++ b/internal/storage/sql/db.go
@@ -31,15 +31,22 @@ func Open(cfg config.Config, opts ...Option) (*sql.DB, Driver, error) {
 
 	sql.SetMaxIdleConns(cfg.Database.MaxIdleConn)
 
+	var maxOpenConn int 
 	if cfg.Database.MaxOpenConn > 0 {
-		sql.SetMaxOpenConns(cfg.Database.MaxOpenConn)
+		maxOpenConn = cfg.Database.MaxOpenConn
 	}
 
 	// if we're using sqlite, we need to set always set the max open connections to 1
 	// see: https://github.com/mattn/go-sqlite3/issues/274
 	if driver == SQLite {
-		sql.SetMaxOpenConns(1)
+		if maxOpenConn > 1 {
+			log.Warning("Ignoring config.db.max_open_conn due to driver limitation (sqlite)", zap.String("attempted_max_conn", maxOpenConn))
+		}
+		
+		maxOpenConn = 1
 	}
+	
+	sql.SetMaxOpenConns(maxOpenConn)
 
 	if cfg.Database.ConnMaxLifetime > 0 {
 		sql.SetConnMaxLifetime(cfg.Database.ConnMaxLifetime)

--- a/internal/storage/sql/db.go
+++ b/internal/storage/sql/db.go
@@ -31,11 +31,15 @@ func Open(cfg config.Config, opts ...Option) (*sql.DB, Driver, error) {
 
 	sql.SetMaxIdleConns(cfg.Database.MaxIdleConn)
 
-	// if driver == SQLite {
-	// 	sql.SetMaxOpenConns(1)
-	// } else if cfg.Database.MaxOpenConn > 0 {
-	sql.SetMaxOpenConns(cfg.Database.MaxOpenConn)
-	// }
+	if cfg.Database.MaxOpenConn > 0 {
+		sql.SetMaxOpenConns(cfg.Database.MaxOpenConn)
+	}
+
+	// if we're using sqlite, we need to set always set the max open connections to 1
+	// see: https://github.com/mattn/go-sqlite3/issues/274
+	if driver == SQLite {
+		sql.SetMaxOpenConns(1)
+	}
 
 	if cfg.Database.ConnMaxLifetime > 0 {
 		sql.SetConnMaxLifetime(cfg.Database.ConnMaxLifetime)

--- a/internal/storage/sql/db.go
+++ b/internal/storage/sql/db.go
@@ -31,7 +31,7 @@ func Open(cfg config.Config, opts ...Option) (*sql.DB, Driver, error) {
 
 	sql.SetMaxIdleConns(cfg.Database.MaxIdleConn)
 
-	var maxOpenConn int 
+	var maxOpenConn int
 	if cfg.Database.MaxOpenConn > 0 {
 		maxOpenConn = cfg.Database.MaxOpenConn
 	}
@@ -39,13 +39,9 @@ func Open(cfg config.Config, opts ...Option) (*sql.DB, Driver, error) {
 	// if we're using sqlite, we need to set always set the max open connections to 1
 	// see: https://github.com/mattn/go-sqlite3/issues/274
 	if driver == SQLite {
-		if maxOpenConn > 1 {
-			log.Warning("Ignoring config.db.max_open_conn due to driver limitation (sqlite)", zap.String("attempted_max_conn", maxOpenConn))
-		}
-		
 		maxOpenConn = 1
 	}
-	
+
 	sql.SetMaxOpenConns(maxOpenConn)
 
 	if cfg.Database.ConnMaxLifetime > 0 {

--- a/internal/storage/sql/db.go
+++ b/internal/storage/sql/db.go
@@ -31,9 +31,12 @@ func Open(cfg config.Config, opts ...Option) (*sql.DB, Driver, error) {
 
 	sql.SetMaxIdleConns(cfg.Database.MaxIdleConn)
 
-	if cfg.Database.MaxOpenConn > 0 {
+	if driver == SQLite {
+		sql.SetMaxOpenConns(2)
+	} else if cfg.Database.MaxOpenConn > 0 {
 		sql.SetMaxOpenConns(cfg.Database.MaxOpenConn)
 	}
+
 	if cfg.Database.ConnMaxLifetime > 0 {
 		sql.SetConnMaxLifetime(cfg.Database.ConnMaxLifetime)
 	}
@@ -216,6 +219,7 @@ func parse(cfg config.Config, opts Options) (Driver, *dburl.URL, error) {
 	case SQLite:
 		v := url.Query()
 		v.Set("cache", "shared")
+		v.Set("mode", "rwc")
 		v.Set("_fk", "true")
 		url.RawQuery = v.Encode()
 

--- a/internal/storage/sql/db_internal_test.go
+++ b/internal/storage/sql/db_internal_test.go
@@ -23,7 +23,7 @@ func TestParse(t *testing.T) {
 				URL: "file:flipt.db",
 			},
 			driver: SQLite,
-			dsn:    "flipt.db?_fk=true&cache=shared",
+			dsn:    "flipt.db?_fk=true&cache=shared&mode=rwc",
 		},
 		{
 			name: "sqlite",
@@ -32,7 +32,7 @@ func TestParse(t *testing.T) {
 				Host:     "flipt.db",
 			},
 			driver: SQLite,
-			dsn:    "flipt.db?_fk=true&cache=shared",
+			dsn:    "flipt.db?_fk=true&cache=shared&mode=rwc",
 		},
 		{
 			name: "postgres url",


### PR DESCRIPTION
## Overview

This is kind of a doozy so bear with me. 🐻

This came about while I was looking at our StackHawk scans in reference to FLI-177.

Basically, StackHawk issues a bunch of concurrent queries to probe our app for security concerns, SQL injections, etc.

When I was running this locally (using the SQLite DB for Flipt), I kept running into these 500 errors:

```console
ERROR	finished unary call with code Internal	{"server": "grpc", "grpc.start_time": "2023-01-27T15:40:34-05:00", "system": "grpc", "span.kind": "server", "grpc.service": "flipt.Flipt", "grpc.method": "GetRule", "peer.address": "127.0.0.1:63802", "error": "rpc error: code = Internal desc = database is locked", "grpc.code": "Internal", "grpc.time_ms": 5191.929}
```

```
 database is locked
```

Being the relevant bit.

## A trip to the DB

In looking into this further and doing some googling, I realized that this is mainly a problem with SQLite and opening multiple connections simultaneously, as SQLite is really just a file, so it makes sense that only 1 connection should hold the lock on the file while doing its querying.

This also led me to https://github.com/mattn/go-sqlite3/issues/274, where they basically say the same thing, and recommend:

1. Always calling `row.Close()` to return the connection back to the pool
2. Setting `db.SetMaxOpenConnections(1)` to enforce this constraint of 1 connection

You can see the deadlock/timeout happening now in [the unit tests](https://github.com/flipt-io/flipt/actions/runs/4032805607/jobs/6932918486#step:4:128) since I followed this advice to set max open connections to `1`:

```
 ?   	go.flipt.io/flipt/internal/storage/oplock/testing	[no test files]
coverage: 67.0% of statements
panic: test timed out after 10m0s
```

## Going through our storage code

This led me to look at our storage (SQL) layer, to ensure we were doing (1), which we are, but then I realized there are several cases where we are trying to open issue multiple queries at once ourselves. Mainly when we try to populate a 1-many relationship such as `flag HAS MANY variants` like [here](https://github.com/flipt-io/flipt/blob/9286fff4b6745e83792be9ac2827292010d665fa/internal/storage/sql/common/flag.go#L44-L73) and [here](https://github.com/flipt-io/flipt/blob/9286fff4b6745e83792be9ac2827292010d665fa/internal/storage/sql/common/flag.go#L87-L146) (GetFlag and ListFlags respectively).

Here and in several other places, we are issuing 1 query to get the parent (flag), then calling this method ([variants](https://github.com/flipt-io/flipt/blob/9286fff4b6745e83792be9ac2827292010d665fa/internal/storage/sql/common/flag.go#L355)) to issue a query to get all the children (variants) for that flag.

The key part is that we don't actually close the flag `Row` before issuing the second query to get all the variants, so we are basically creating a deadlock in the case of SQLite.

While we could work around this for `GetFlag`, by first getting the flag row, then closing the row, then issuing the query to get all variants, this approach won't work as easily for `ListFlags` as we are required to loop through each row to hydrate the flags.

## Proposal(s)

### 1. Joins The Old Fashioned Way

The correct way to do this kind of thing in SQL is to just use JOINs and get all the flags and their variants at once. This has the benefit of not locking the db in our case and also results in fewer queries overall.

This is what I have prototyped in this PR, starting with the `ListFlags` because it is the most 'difficult'.

Unfortunately, Go does not make it easy to work with JOINS using the stdlib or even using `masterminds/squirrel` which is the SQLbuilder library we are using here. This is why I had to add the `map` in this PR to check to see if we have 'seen' this flag before adding it to the results.

Proposal 1 is basically to continue this pattern throughout the entire storage layer for all parent->child relationships, so that we can do things the 'right way' and stop creating unnecessary queries and potential performance degradations/errors in highly concurrent scenarios.

### 2. Introduce a Data Model layer + use SQLx or SQLC

This option is basically introducing data models that map to our database instead of passing the proto models all the way down + introducing a library to help with this parent <-> child relationship, removing the need to do this mapping ourselves.

#### SQLx

[SQLx ](https://github.com/jmoiron/sqlx)supports parent-child relationships in their [StructScan](https://jmoiron.github.io/sqlx/#advancedScanning) helper, it would just require us to define each of these data structs and add the appropriate `db:` struct tags to each field.

The benefits of this approach seem to me to be:

1. Get us closer to where we want to be in FLI-40 (using proper domain models)
2. Prevent the work required to manually handle these joins/relationships
4. Potentially reduce bugs by depending on `StructScan` instead of scanning the row results into the data types ourselves

#### SQLC

SQLC is similar to the approach that SQLx would result in, however, the main difference is that it generates the data models and the query/mutation methods themselves! Ex: https://docs.sqlc.dev/en/latest/howto/select.html

The benefits of this approach seem to me to be:

1. All of the benefits in the SQLx approach above
2. Less code to write/maintain ourselves

The downside of SQLC however is that it does not have the same database compatibility that the Go SQL package/SQLx has. 

Currently, it only supports:

- MySQL
- Postgres
- SQLite (beta)

While these are the only DBs we need now, it could potentially limit us if we wanted to support another SQL db down the road (although I'm not sure if we'll ever want to actually do this).

### Tl;dr

- We should probably use `JOIN`s instead of multiple queries to populate parent child data
- There are a few options, so we should figure out which one we actually want to move to