### PR TITLE
fix: disable csp headers in non-release mode for ui dev

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -33,15 +33,13 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 )
 
-const devVersion = "dev"
-
 var (
 	cfg         *config.Config
 	cfgWarnings []string
 
 	cfgPath      string
 	forceMigrate bool
-	version      = devVersion
+	version      = "dev"
 	commit       string
 	date         string
 	goVersion    = runtime.Version()

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -81,7 +81,8 @@ func NewHTTPServer(
 		logger.Info("CORS enabled", zap.Strings("allowed_origins", cfg.Cors.AllowedOrigins))
 	}
 
-	if info.IsRelease {
+	// TODO: replace with more robust 'mode' detection
+	if !info.IsDevelopment() {
 		r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
 		r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src * data:;"))
 	}

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -81,8 +81,10 @@ func NewHTTPServer(
 		logger.Info("CORS enabled", zap.Strings("allowed_origins", cfg.Cors.AllowedOrigins))
 	}
 
-	r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
-	r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src * data:;"))
+	if info.IsRelease {
+		r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
+		r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src * data:;"))
+	}
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)

--- a/internal/info/flipt.go
+++ b/internal/info/flipt.go
@@ -15,6 +15,10 @@ type Flipt struct {
 	IsRelease       bool   `json:"isRelease"`
 }
 
+func (f Flipt) IsDevelopment() bool {
+	return f.Version == "dev" && !f.IsRelease
+}
+
 func (f Flipt) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var (
 		out []byte


### PR DESCRIPTION
Fixes: FLI-191

Don't set CSP header when running in development mode (version == "dev")

In the future I'd like to switch to some kind of 'mode' based logic, where we can more easily tell if Flipt is running locally for our development vs running in 'release' mode