### PR TITLE
fix: 500/ dont expose invalid base64 decode error for page token

### DIFF
--- a/internal/server/flag.go
+++ b/internal/server/flag.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 
+	"go.flipt.io/flipt/errors"
 	fliptotel "go.flipt.io/flipt/internal/server/otel"
 	"go.flipt.io/flipt/internal/storage"
 	flipt "go.flipt.io/flipt/rpc/flipt"
@@ -47,7 +48,7 @@ func (s *Server) ListFlags(ctx context.Context, r *flipt.ListFlagRequest) (*flip
 	if r.PageToken != "" {
 		tok, err := base64.StdEncoding.DecodeString(r.PageToken)
 		if err != nil {
-			return nil, err
+			return nil, errors.ErrInvalidf("page_token is not valid: %s", r.PageToken)
 		}
 
 		opts = append(opts, storage.WithPageToken(string(tok)))

--- a/internal/server/flag.go
+++ b/internal/server/flag.go
@@ -48,7 +48,7 @@ func (s *Server) ListFlags(ctx context.Context, r *flipt.ListFlagRequest) (*flip
 	if r.PageToken != "" {
 		tok, err := base64.StdEncoding.DecodeString(r.PageToken)
 		if err != nil {
-			return nil, errors.ErrInvalidf("page_token is not valid: %s", r.PageToken)
+			return nil, errors.ErrInvalidf("pageToken is not valid: %q", r.PageToken)
 		}
 
 		opts = append(opts, storage.WithPageToken(string(tok)))

--- a/internal/server/flag_test.go
+++ b/internal/server/flag_test.go
@@ -143,7 +143,7 @@ func TestListFlags_PaginationInvalidPageToken(t *testing.T) {
 		Offset:    10,
 	})
 
-	assert.EqualError(t, err, "page_token is not valid: Invalid string")
+	assert.EqualError(t, err, `pageToken is not valid: "Invalid string"`)
 }
 
 func TestCreateFlag(t *testing.T) {

--- a/internal/server/flag_test.go
+++ b/internal/server/flag_test.go
@@ -80,7 +80,7 @@ func TestListFlags_PaginationOffset(t *testing.T) {
 	assert.Equal(t, int32(1), got.TotalCount)
 }
 
-func TestListFlags_PaginationNextPageToken(t *testing.T) {
+func TestListFlags_PaginationPageToken(t *testing.T) {
 	var (
 		store  = &storeMock{}
 		logger = zaptest.NewLogger(t)
@@ -122,6 +122,28 @@ func TestListFlags_PaginationNextPageToken(t *testing.T) {
 	assert.NotEmpty(t, got.Flags)
 	assert.Equal(t, "YmFy", got.NextPageToken)
 	assert.Equal(t, int32(1), got.TotalCount)
+}
+
+func TestListFlags_PaginationInvalidPageToken(t *testing.T) {
+	var (
+		store  = &storeMock{}
+		logger = zaptest.NewLogger(t)
+		s      = &Server{
+			logger: logger,
+			store:  store,
+		}
+	)
+
+	defer store.AssertExpectations(t)
+
+	store.AssertNotCalled(t, "ListFlags")
+
+	_, err := s.ListFlags(context.TODO(), &flipt.ListFlagRequest{
+		PageToken: "Invalid string",
+		Offset:    10,
+	})
+
+	assert.EqualError(t, err, "page_token is not valid: Invalid string")
 }
 
 func TestCreateFlag(t *testing.T) {

--- a/internal/server/rule.go
+++ b/internal/server/rule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 
+	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/storage"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 	"go.uber.org/zap"
@@ -31,7 +32,7 @@ func (s *Server) ListRules(ctx context.Context, r *flipt.ListRuleRequest) (*flip
 	if r.PageToken != "" {
 		tok, err := base64.StdEncoding.DecodeString(r.PageToken)
 		if err != nil {
-			return nil, err
+			return nil, errors.ErrInvalidf("page_token is not valid: %s", r.PageToken)
 		}
 
 		opts = append(opts, storage.WithPageToken(string(tok)))

--- a/internal/server/rule.go
+++ b/internal/server/rule.go
@@ -32,7 +32,7 @@ func (s *Server) ListRules(ctx context.Context, r *flipt.ListRuleRequest) (*flip
 	if r.PageToken != "" {
 		tok, err := base64.StdEncoding.DecodeString(r.PageToken)
 		if err != nil {
-			return nil, errors.ErrInvalidf("page_token is not valid: %s", r.PageToken)
+			return nil, errors.ErrInvalidf("pageToken is not valid: %q", r.PageToken)
 		}
 
 		opts = append(opts, storage.WithPageToken(string(tok)))

--- a/internal/server/rule_test.go
+++ b/internal/server/rule_test.go
@@ -77,7 +77,7 @@ func TestListRules_PaginationOffset(t *testing.T) {
 	assert.Equal(t, int32(1), got.TotalCount)
 }
 
-func TestListRules_PaginationNextPageToken(t *testing.T) {
+func TestListRules_PaginationPageToken(t *testing.T) {
 	var (
 		store  = &storeMock{}
 		logger = zaptest.NewLogger(t)
@@ -119,6 +119,28 @@ func TestListRules_PaginationNextPageToken(t *testing.T) {
 	assert.NotEmpty(t, got.Rules)
 	assert.Equal(t, "YmFy", got.NextPageToken)
 	assert.Equal(t, int32(1), got.TotalCount)
+}
+
+func TestListRules_PaginationInvalidPageToken(t *testing.T) {
+	var (
+		store  = &storeMock{}
+		logger = zaptest.NewLogger(t)
+		s      = &Server{
+			logger: logger,
+			store:  store,
+		}
+	)
+
+	defer store.AssertExpectations(t)
+
+	store.AssertNotCalled(t, "ListRules")
+
+	_, err := s.ListRules(context.TODO(), &flipt.ListRuleRequest{FlagKey: "flagKey",
+		PageToken: "Invalid string",
+		Offset:    10,
+	})
+
+	assert.EqualError(t, err, "page_token is not valid: Invalid string")
 }
 
 func TestCreateRule(t *testing.T) {

--- a/internal/server/rule_test.go
+++ b/internal/server/rule_test.go
@@ -140,7 +140,7 @@ func TestListRules_PaginationInvalidPageToken(t *testing.T) {
 		Offset:    10,
 	})
 
-	assert.EqualError(t, err, "page_token is not valid: Invalid string")
+	assert.EqualError(t, err, `pageToken is not valid: "Invalid string"`)
 }
 
 func TestCreateRule(t *testing.T) {

--- a/internal/server/segment.go
+++ b/internal/server/segment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 
+	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/storage"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 	"go.uber.org/zap"
@@ -31,7 +32,7 @@ func (s *Server) ListSegments(ctx context.Context, r *flipt.ListSegmentRequest) 
 	if r.PageToken != "" {
 		tok, err := base64.StdEncoding.DecodeString(r.PageToken)
 		if err != nil {
-			return nil, err
+			return nil, errors.ErrInvalidf("page_token is not valid: %s", r.PageToken)
 		}
 
 		opts = append(opts, storage.WithPageToken(string(tok)))

--- a/internal/server/segment.go
+++ b/internal/server/segment.go
@@ -32,7 +32,7 @@ func (s *Server) ListSegments(ctx context.Context, r *flipt.ListSegmentRequest) 
 	if r.PageToken != "" {
 		tok, err := base64.StdEncoding.DecodeString(r.PageToken)
 		if err != nil {
-			return nil, errors.ErrInvalidf("page_token is not valid: %s", r.PageToken)
+			return nil, errors.ErrInvalidf("pageToken is not valid: %q", r.PageToken)
 		}
 
 		opts = append(opts, storage.WithPageToken(string(tok)))

--- a/internal/server/segment_test.go
+++ b/internal/server/segment_test.go
@@ -77,7 +77,7 @@ func TestListSegments_PaginationOffset(t *testing.T) {
 	assert.Equal(t, int32(1), got.TotalCount)
 }
 
-func TestListSegments_PaginationNextPageToken(t *testing.T) {
+func TestListSegments_PaginationPageToken(t *testing.T) {
 	var (
 		store  = &storeMock{}
 		logger = zaptest.NewLogger(t)
@@ -119,6 +119,28 @@ func TestListSegments_PaginationNextPageToken(t *testing.T) {
 	assert.NotEmpty(t, got.Segments)
 	assert.Equal(t, "YmFy", got.NextPageToken)
 	assert.Equal(t, int32(1), got.TotalCount)
+}
+
+func TestListSegments_PaginationInvalidPageToken(t *testing.T) {
+	var (
+		store  = &storeMock{}
+		logger = zaptest.NewLogger(t)
+		s      = &Server{
+			logger: logger,
+			store:  store,
+		}
+	)
+
+	defer store.AssertExpectations(t)
+
+	store.AssertNotCalled(t, "ListSegments")
+
+	_, err := s.ListSegments(context.TODO(), &flipt.ListSegmentRequest{
+		PageToken: "Invalid string",
+		Offset:    10,
+	})
+
+	assert.EqualError(t, err, "page_token is not valid: Invalid string")
 }
 
 func TestCreateSegment(t *testing.T) {

--- a/internal/server/segment_test.go
+++ b/internal/server/segment_test.go
@@ -140,7 +140,7 @@ func TestListSegments_PaginationInvalidPageToken(t *testing.T) {
 		Offset:    10,
 	})
 
-	assert.EqualError(t, err, "page_token is not valid: Invalid string")
+	assert.EqualError(t, err, `pageToken is not valid: "Invalid string"`)
 }
 
 func TestCreateSegment(t *testing.T) {


### PR DESCRIPTION
Fixes: FLI-189

- Prevent 500
- Don't expose invalid base64 decode error to user if bad `pageToken`

## Before

```
curl -v "http://localhost:8080/api/v1/flags/flagKey/rules?limit=10&offset=10&pageToken=pageToken"

< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json
< Vary: Origin
< X-Content-Type-Options: nosniff
< Date: Fri, 27 Jan 2023 20:26:02 GMT
< Content-Length: 72

{"code":13,"message":"illegal base64 data at input byte 8","details":[]}%     
```

## After

```
curl -v "http://localhost:8080/api/v1/flags/flagKey/rules?limit=10&offset=10&pageToken=pageToken"

< HTTP/1.1 400 Bad Request
< Content-Type: application/json
< Vary: Origin
< Date: Thu, 02 Feb 2023 21:16:11 GMT
< Content-Length: 70

{"code":3,"message":"pageToken is not valid: \"pageToken\"","details":[]}%     
```