### PR TITLE
chore: add frame-ancestors directive to CSP header

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -84,7 +84,7 @@ func NewHTTPServer(
 	// TODO: replace with more robust 'mode' detection
 	if !info.IsDevelopment() {
 		r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
-		r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src * data:;"))
+		r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src * data:; frame-ancestors 'none';"))
 	}
 
 	r.Use(middleware.RequestID)


### PR DESCRIPTION
Fixes: FLI-190

Adds missing `frame-ancestors` directive to `Content-Security-Policy` response header to prevent clickjacking

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors