### PR TITLE
fix(cleanup): ensure all methods register their cleanup schedules

### DIFF
--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -44,7 +44,7 @@ func (s *AuthenticationService) Run(ctx context.Context) {
 	for _, info := range s.config.Methods.AllMethods() {
 		logger := s.logger.With(zap.Stringer("method", info.Method))
 		if info.Cleanup == nil {
-			logger.Info("Cleanup for auth method not defined (skipping)")
+			logger.Debug("Cleanup for auth method not defined (skipping)")
 			continue
 		}
 
@@ -85,7 +85,7 @@ func (s *AuthenticationService) Run(ctx context.Context) {
 				acquiredUntil = entry.AcquiredUntil
 
 				if !acquired {
-					logger.Info("cleanup process not acquired", zap.Time("next_attempt", entry.AcquiredUntil))
+					logger.Debug("cleanup process not acquired", zap.Time("next_attempt", entry.AcquiredUntil))
 					continue
 				}
 

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -65,6 +65,7 @@ func TestCleanup(t *testing.T) {
 	})
 
 	for _, info := range authConfig.Methods.AllMethods() {
+		info := info
 		t.Run(fmt.Sprintf("Authentication Method %q", info.Method), func(t *testing.T) {
 			t.Run("create an expiring token and ensure it exists", func(t *testing.T) {
 				clientToken, storedAuth, err = authstore.CreateAuthentication(

--- a/internal/cleanup/cleanup_test.go
+++ b/internal/cleanup/cleanup_test.go
@@ -2,6 +2,7 @@ package cleanup
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,17 +28,18 @@ func TestCleanup(t *testing.T) {
 		authstore  = inmemauth.NewStore()
 		lock       = inmemoplock.New()
 		authConfig = config.AuthenticationConfig{
-			Methods: config.AuthenticationMethods{
-				Token: config.AuthenticationMethod[config.AuthenticationMethodTokenConfig]{
-					Enabled: true,
-					Cleanup: &config.AuthenticationCleanupSchedule{
-						Interval:    time.Second,
-						GracePeriod: 5 * time.Second,
-					},
-				},
-			},
+			Methods: config.AuthenticationMethods{},
 		}
 	)
+
+	// enable all methods and set their cleanup configuration
+	for _, info := range authConfig.Methods.AllMethods() {
+		info.Enable(t)
+		info.SetCleanup(t, config.AuthenticationCleanupSchedule{
+			Interval:    time.Second,
+			GracePeriod: 5 * time.Second,
+		})
+	}
 
 	// create an initial non-expiring token
 	clientToken, storedAuth, err := authstore.CreateAuthentication(
@@ -62,38 +64,42 @@ func TestCleanup(t *testing.T) {
 		assert.Equal(t, storedAuth, retrievedAuth)
 	})
 
-	t.Run("create an expiring token and ensure it exists", func(t *testing.T) {
-		clientToken, storedAuth, err = authstore.CreateAuthentication(
-			ctx,
-			&authstorage.CreateAuthenticationRequest{
-				Method:    auth.Method_METHOD_TOKEN,
-				ExpiresAt: timestamppb.New(time.Now().UTC().Add(5 * time.Second)),
-			},
-		)
-		require.NoError(t, err)
+	for _, info := range authConfig.Methods.AllMethods() {
+		t.Run(fmt.Sprintf("Authentication Method %q", info.Method), func(t *testing.T) {
+			t.Run("create an expiring token and ensure it exists", func(t *testing.T) {
+				clientToken, storedAuth, err = authstore.CreateAuthentication(
+					ctx,
+					&authstorage.CreateAuthenticationRequest{
+						Method:    info.Method,
+						ExpiresAt: timestamppb.New(time.Now().UTC().Add(5 * time.Second)),
+					},
+				)
+				require.NoError(t, err)
 
-		retrievedAuth, err := authstore.GetAuthenticationByClientToken(ctx, clientToken)
-		require.NoError(t, err)
-		assert.Equal(t, storedAuth, retrievedAuth)
-	})
+				retrievedAuth, err := authstore.GetAuthenticationByClientToken(ctx, clientToken)
+				require.NoError(t, err)
+				assert.Equal(t, storedAuth, retrievedAuth)
+			})
 
-	t.Run("ensure grace period protects token from being deleted", func(t *testing.T) {
-		// token should still exist as it wont be deleted until
-		// expiry + grace period (5s + 5s == 10s)
-		time.Sleep(5 * time.Second)
+			t.Run("ensure grace period protects token from being deleted", func(t *testing.T) {
+				// token should still exist as it wont be deleted until
+				// expiry + grace period (5s + 5s == 10s)
+				time.Sleep(5 * time.Second)
 
-		retrievedAuth, err := authstore.GetAuthenticationByClientToken(ctx, clientToken)
-		require.NoError(t, err)
-		assert.Equal(t, storedAuth, retrievedAuth)
+				retrievedAuth, err := authstore.GetAuthenticationByClientToken(ctx, clientToken)
+				require.NoError(t, err)
+				assert.Equal(t, storedAuth, retrievedAuth)
 
-		// ensure authentication is expired but still persisted
-		assert.True(t, retrievedAuth.ExpiresAt.AsTime().Before(time.Now().UTC()))
-	})
+				// ensure authentication is expired but still persisted
+				assert.True(t, retrievedAuth.ExpiresAt.AsTime().Before(time.Now().UTC()))
+			})
 
-	t.Run("once expiry and grace period ellapses ensure token is deleted", func(t *testing.T) {
-		time.Sleep(10 * time.Second)
+			t.Run("once expiry and grace period ellapses ensure token is deleted", func(t *testing.T) {
+				time.Sleep(10 * time.Second)
 
-		_, err := authstore.GetAuthenticationByClientToken(ctx, clientToken)
-		require.Error(t, err, "resource not found")
-	})
+				_, err := authstore.GetAuthenticationByClientToken(ctx, clientToken)
+				require.Error(t, err, "resource not found")
+			})
+		})
+	}
 }

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/spf13/viper"
@@ -164,7 +165,7 @@ type AuthenticationMethods struct {
 }
 
 // AllMethods returns all the AuthenticationMethod instances available.
-func (a AuthenticationMethods) AllMethods() []StaticAuthenticationMethodInfo {
+func (a *AuthenticationMethods) AllMethods() []StaticAuthenticationMethodInfo {
 	return []StaticAuthenticationMethodInfo{
 		a.Token.Info(),
 		a.OIDC.Info(),
@@ -177,6 +178,23 @@ type StaticAuthenticationMethodInfo struct {
 	AuthenticationMethodInfo
 	Enabled bool
 	Cleanup *AuthenticationCleanupSchedule
+
+	// used for testing purposes to ensure all methods
+	// are appropriately cleaned up via the background process.
+	setEnabled func()
+	setCleanup func(AuthenticationCleanupSchedule)
+}
+
+// Enable can only be called in a testing scenario.
+// It us used to enable a target method without having the concrete reference.
+func (s StaticAuthenticationMethodInfo) Enable(t *testing.T) {
+	s.setEnabled()
+}
+
+// SetCleanup can only be called in a testing scenario.
+// It us used to configure cleanup for a target method without having the concrete reference.
+func (s StaticAuthenticationMethodInfo) SetCleanup(t *testing.T, c AuthenticationCleanupSchedule) {
+	s.setCleanup(c)
 }
 
 // AuthenticationMethodInfo is a structure which describes properties
@@ -211,11 +229,18 @@ type AuthenticationMethod[C AuthenticationMethodInfoProvider] struct {
 	Cleanup *AuthenticationCleanupSchedule `json:"cleanup,omitempty" mapstructure:"cleanup"`
 }
 
-func (a AuthenticationMethod[C]) Info() StaticAuthenticationMethodInfo {
+func (a *AuthenticationMethod[C]) Info() StaticAuthenticationMethodInfo {
 	return StaticAuthenticationMethodInfo{
 		AuthenticationMethodInfo: a.Method.Info(),
 		Enabled:                  a.Enabled,
 		Cleanup:                  a.Cleanup,
+
+		setEnabled: func() {
+			a.Enabled = true
+		},
+		setCleanup: func(c AuthenticationCleanupSchedule) {
+			a.Cleanup = &c
+		},
 	}
 }
 

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -186,13 +186,13 @@ type StaticAuthenticationMethodInfo struct {
 }
 
 // Enable can only be called in a testing scenario.
-// It us used to enable a target method without having the concrete reference.
+// It is used to enable a target method without having a concrete reference.
 func (s StaticAuthenticationMethodInfo) Enable(t *testing.T) {
 	s.setEnabled()
 }
 
 // SetCleanup can only be called in a testing scenario.
-// It us used to configure cleanup for a target method without having the concrete reference.
+// It is used to configure cleanup for a target method without having a concrete reference.
 func (s StaticAuthenticationMethodInfo) SetCleanup(t *testing.T, c AuthenticationCleanupSchedule) {
 	s.setCleanup(c)
 }


### PR DESCRIPTION
It was observed that OIDC method-created authentications were not getting cleared away.
The `cleanup` process when created was hardcoded to only perform cleanup for `METHOD_TOKEN` (mistakenly).

This was an easy mistake (not registering the method in all the places). It was why I added the generic method container and the `AllMethods()` support to ensure that adding new methods was as simple as ensuring the methods returns it info here:
https://github.com/flipt-io/flipt/blob/6144f3244c61b9987c8a2ac5e837840fbc051d3b/internal/config/authentication.go#L168-L171

The types should depend on performing background operations of this `AllMethods()` list. Instead of having to manually add new methods everywhere they're created.

However, I never updated `cleanup` to take advantage of this.
This change does that. It updates the cleanup process to walk this list and create a cleanup goroutine per method.

Additionally, the cleanup test ensures that each method defined on all methods is configure and tested.