### PR TITLE
chore: downcase log for cleanup skipped

### DIFF
--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -44,7 +44,7 @@ func (s *AuthenticationService) Run(ctx context.Context) {
 	for _, info := range s.config.Methods.AllMethods() {
 		logger := s.logger.With(zap.Stringer("method", info.Method))
 		if info.Cleanup == nil {
-			logger.Debug("Cleanup for auth method not defined (skipping)")
+			logger.Debug("cleanup for auth method not defined (skipping)")
 			continue
 		}
 


### PR DESCRIPTION
`Cleanup for auth method not defined (skipping)` -> `cleanup for auth method not defined (skipping)`