### PR TITLE
feat(auth/k8s): initial auth method service implementation

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -12,6 +12,7 @@ import (
 	"go.flipt.io/flipt/internal/containers"
 	"go.flipt.io/flipt/internal/gateway"
 	"go.flipt.io/flipt/internal/server/auth"
+	authkubernetes "go.flipt.io/flipt/internal/server/auth/method/kubernetes"
 	authoidc "go.flipt.io/flipt/internal/server/auth/method/oidc"
 	authtoken "go.flipt.io/flipt/internal/server/auth/method/token"
 	"go.flipt.io/flipt/internal/server/auth/public"
@@ -69,6 +70,19 @@ func authenticationGRPC(
 		authOpts = append(authOpts, auth.WithServerSkipsAuthentication(oidcServer))
 
 		logger.Debug("authentication method \"oidc\" server registered")
+	}
+
+	if cfg.Methods.Kubernetes.Enabled {
+		kubernetesServer, err := authkubernetes.New(logger, store, cfg)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("configuring kubernetes authentication: %w", err)
+		}
+		register.Add(kubernetesServer)
+
+		// OIDC server exposes unauthenticated endpoints
+		authOpts = append(authOpts, auth.WithServerSkipsAuthentication(kubernetesServer))
+
+		logger.Debug("authentication method \"kubernetes\" server registered")
 	}
 
 	// only enable enforcement middleware if authentication required
@@ -137,6 +151,10 @@ func authenticationHTTPMount(
 			registerFunc(ctx, conn, rpcauth.RegisterAuthenticationMethodOIDCServiceHandler))
 
 		middleware = append(middleware, oidcmiddleware.Handler)
+	}
+
+	if cfg.Methods.Kubernetes.Enabled {
+		muxOpts = append(muxOpts, registerFunc(ctx, conn, rpcauth.RegisterAuthenticationMethodKubernetesServiceHandler))
 	}
 
 	r.Group(func(r chi.Router) {

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -326,9 +326,10 @@ type AuthenticationCleanupSchedule struct {
 // method to be performed. This method supports Flipt being deployed in a Kubernetes environment
 // and allowing it to exchange client tokens for valid service account tokens presented via this method.
 type AuthenticationMethodKubernetesConfig struct {
-	// IssuerURL is the URL to the local Kubernetes cluster.
-	// The URL is used to fetch the OIDC configuration and subsequently the public key chain.
-	IssuerURL string `json:"issuerURL,omitempty" mapstructure:"issuer_url"`
+	// DiscoveryURL is the URL to the local Kubernetes cluster serving the "well-known" OIDC discovery endpoint.
+	// https://openid.net/specs/openid-connect-discovery-1_0.html
+	// The URL is used to fetch the OIDC configuration and subsequently the JWKS certificates.
+	DiscoveryURL string `json:"discoveryURL,omitempty" mapstructure:"discovery_url"`
 	// CAPath is the path on disk to the trusted certificate authority certificate for validating
 	// HTTPS requests to the issuer.
 	CAPath string `json:"caPath,omitempty" mapstructure:"ca_path"`
@@ -338,7 +339,7 @@ type AuthenticationMethodKubernetesConfig struct {
 }
 
 func (a AuthenticationMethodKubernetesConfig) setDefaults(defaults map[string]any) {
-	defaults["issuer_url"] = "https://kubernetes.default.svc.cluster.local"
+	defaults["discovery_url"] = "https://kubernetes.default.svc.cluster.local"
 	defaults["ca_path"] = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	defaults["service_account_token_path"] = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 }

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -338,8 +338,8 @@ type AuthenticationMethodKubernetesConfig struct {
 }
 
 func (a AuthenticationMethodKubernetesConfig) setDefaults(defaults map[string]any) {
-	defaults["issuer_url"] = "https://kubernetes.default.svc"
-	defaults["ca_path"] = "/var/run/secrets/kubernetes.io/serviceaccount/ca.cert"
+	defaults["issuer_url"] = "https://kubernetes.default.svc.cluster.local"
+	defaults["ca_path"] = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	defaults["service_account_token_path"] = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -497,7 +497,7 @@ func TestLoad(t *testing.T) {
 					Kubernetes: AuthenticationMethod[AuthenticationMethodKubernetesConfig]{
 						Enabled: true,
 						Method: AuthenticationMethodKubernetesConfig{
-							IssuerURL:               "https://kubernetes.default.svc.cluster.local",
+							DiscoveryURL:            "https://kubernetes.default.svc.cluster.local",
 							CAPath:                  "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 							ServiceAccountTokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						},
@@ -608,7 +608,7 @@ func TestLoad(t *testing.T) {
 						Kubernetes: AuthenticationMethod[AuthenticationMethodKubernetesConfig]{
 							Enabled: true,
 							Method: AuthenticationMethodKubernetesConfig{
-								IssuerURL:               "https://some-other-k8s.namespace.svc",
+								DiscoveryURL:            "https://some-other-k8s.namespace.svc",
 								CAPath:                  "/path/to/ca/certificate/ca.pem",
 								ServiceAccountTokenPath: "/path/to/sa/token",
 							},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -497,8 +497,8 @@ func TestLoad(t *testing.T) {
 					Kubernetes: AuthenticationMethod[AuthenticationMethodKubernetesConfig]{
 						Enabled: true,
 						Method: AuthenticationMethodKubernetesConfig{
-							IssuerURL:               "https://kubernetes.default.svc",
-							CAPath:                  "/var/run/secrets/kubernetes.io/serviceaccount/ca.cert",
+							IssuerURL:               "https://kubernetes.default.svc.cluster.local",
+							CAPath:                  "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 							ServiceAccountTokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token",
 						},
 						Cleanup: &AuthenticationCleanupSchedule{

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -67,7 +67,7 @@ authentication:
         grace_period: 48h
     kubernetes:
       enabled: true
-      issuer_url: "https://some-other-k8s.namespace.svc"
+      discovery_url: "https://some-other-k8s.namespace.svc"
       ca_path: "/path/to/ca/certificate/ca.pem"
       service_account_token_path: "/path/to/sa/token"
       cleanup:

--- a/internal/server/auth/method/kubernetes/server.go
+++ b/internal/server/auth/method/kubernetes/server.go
@@ -9,6 +9,7 @@ import (
 	storageauth "go.flipt.io/flipt/internal/storage/auth"
 	"go.flipt.io/flipt/rpc/flipt/auth"
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -55,8 +56,8 @@ type Server struct {
 	auth.UnimplementedAuthenticationMethodKubernetesServiceServer
 }
 
-// NewServer constructs a new Server instance based on the provided logger, store and configuration.
-func NewServer(logger *zap.Logger, store storageauth.Store, config config.AuthenticationConfig) (*Server, error) {
+// New constructs a new Server instance based on the provided logger, store and configuration.
+func New(logger *zap.Logger, store storageauth.Store, config config.AuthenticationConfig) (*Server, error) {
 	s := &Server{
 		logger: logger,
 		store:  store,
@@ -67,6 +68,11 @@ func NewServer(logger *zap.Logger, store storageauth.Store, config config.Authen
 	s.verifier, err = newKubernetesOIDCVerifier(logger, config.Methods.Kubernetes.Method)
 
 	return s, err
+}
+
+// RegisterGRPC registers the server instnace on the provided gRPC server.
+func (s *Server) RegisterGRPC(srv *grpc.Server) {
+	auth.RegisterAuthenticationMethodKubernetesServiceServer(srv, s)
 }
 
 // VerifyServiceAccount takes a service account token, configured by a kubernetes environment,

--- a/internal/server/auth/method/kubernetes/server.go
+++ b/internal/server/auth/method/kubernetes/server.go
@@ -42,6 +42,10 @@ type tokenVerifier interface {
 }
 
 // Server is the core server-side implementation of the "kubernetes" authentication method.
+//
+// The method allows services deployed into the same Kubernetes cluster as Flipt to leverage
+// their service account token in order to obtain access to Flipt itself.
+// When enabled, this authentication method grants any service in the same cluster access to Flipt.
 type Server struct {
 	logger *zap.Logger
 	store  storageauth.Store
@@ -66,6 +70,10 @@ func NewServer(logger *zap.Logger, store storageauth.Store, config config.Authen
 	return s, err
 }
 
+// VerifyServiceAccount takes a service account token, configured by a kubernetes environment,
+// validates it's authenticity and (if valid) creates a Flipt client token and returns it.
+// The returned client token is valid for the lifetime of the service account JWT.
+// The token tracks the source service account and pod identity of the provided token.
 func (s *Server) VerifyServiceAccount(ctx context.Context, req *auth.VerifyServiceAccountRequest) (*auth.VerifyServiceAccountResponse, error) {
 	claims, err := s.verifier.verify(ctx, req.ServiceAccountToken)
 	if err != nil {

--- a/internal/server/auth/method/kubernetes/server.go
+++ b/internal/server/auth/method/kubernetes/server.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -102,10 +101,4 @@ func (s *Server) VerifyServiceAccount(ctx context.Context, req *auth.VerifyServi
 		ClientToken:    clientToken,
 		Authentication: authentication,
 	}, nil
-}
-
-type noopTokenVerifier struct{}
-
-func (n noopTokenVerifier) verify(context.Context, string) (claims, error) {
-	return claims{}, errors.New("invalid token")
 }

--- a/internal/server/auth/method/kubernetes/server.go
+++ b/internal/server/auth/method/kubernetes/server.go
@@ -1,0 +1,42 @@
+package kubernetes
+
+import (
+	"context"
+
+	"go.flipt.io/flipt/internal/config"
+	storageauth "go.flipt.io/flipt/internal/storage/auth"
+	"go.flipt.io/flipt/rpc/flipt/auth"
+	"go.uber.org/zap"
+)
+
+type serviceAccount struct {
+	Name string `json:"name"`
+}
+
+type serviceAccountVerifier interface {
+	verify(jwt string) (serviceAccount, error)
+}
+
+// Server is the core server-side implementation of the "kubernetes" authentication method.
+type Server struct {
+	logger *zap.Logger
+	store  storageauth.Store
+	config config.AuthenticationConfig
+
+	verifier serviceAccountVerifier
+
+	auth.UnimplementedAuthenticationMethodKubernetesServiceServer
+}
+
+// NewServer constructs a new Server instance based on the provided logger, store and configuration.
+func NewServer(logger *zap.Logger, store storageauth.Store, config config.AuthenticationConfig) *Server {
+	return &Server{
+		logger: logger,
+		store:  store,
+		config: config,
+	}
+}
+
+func (s *Server) VerifyServiceAccount(ctx context.Context, req *auth.VerifyServiceAccountRequest) (*auth.VerifyServiceAccountResponse, error) {
+	return &auth.VerifyServiceAccountResponse{}, nil
+}

--- a/internal/server/auth/method/kubernetes/server.go
+++ b/internal/server/auth/method/kubernetes/server.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 
 	"go.flipt.io/flipt/internal/config"
 	storageauth "go.flipt.io/flipt/internal/storage/auth"
@@ -9,12 +10,19 @@ import (
 	"go.uber.org/zap"
 )
 
-type serviceAccount struct {
+type resource struct {
 	Name string `json:"name"`
+	UID  string `json:"uid"`
 }
 
-type serviceAccountVerifier interface {
-	verify(jwt string) (serviceAccount, error)
+type claims struct {
+	Namespace      string   `json:"namespace"`
+	Pod            resource `json:"pod"`
+	ServiceAccount resource `json:"serviceaccount"`
+}
+
+type tokenVerifier interface {
+	verify(jwt string) (claims, error)
 }
 
 // Server is the core server-side implementation of the "kubernetes" authentication method.
@@ -23,7 +31,7 @@ type Server struct {
 	store  storageauth.Store
 	config config.AuthenticationConfig
 
-	verifier serviceAccountVerifier
+	verifier tokenVerifier
 
 	auth.UnimplementedAuthenticationMethodKubernetesServiceServer
 }
@@ -31,12 +39,19 @@ type Server struct {
 // NewServer constructs a new Server instance based on the provided logger, store and configuration.
 func NewServer(logger *zap.Logger, store storageauth.Store, config config.AuthenticationConfig) *Server {
 	return &Server{
-		logger: logger,
-		store:  store,
-		config: config,
+		logger:   logger,
+		store:    store,
+		config:   config,
+		verifier: noopTokenVerifier{},
 	}
 }
 
 func (s *Server) VerifyServiceAccount(ctx context.Context, req *auth.VerifyServiceAccountRequest) (*auth.VerifyServiceAccountResponse, error) {
 	return &auth.VerifyServiceAccountResponse{}, nil
+}
+
+type noopTokenVerifier struct{}
+
+func (n noopTokenVerifier) verify(string) (claims, error) {
+	return claims{}, errors.New("invalid token")
 }

--- a/internal/server/auth/method/kubernetes/server_internal_test.go
+++ b/internal/server/auth/method/kubernetes/server_internal_test.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	staticID    = "staticID"
-	staticToken = "staticToken"
-	staticTime  = timestamppb.New(time.Date(2023, 2, 17, 10, 0, 0, 0, time.UTC))
+	staticID         = "staticID"
+	staticToken      = "staticToken"
+	staticTime       = timestamppb.New(time.Date(2023, 2, 17, 8, 0, 0, 0, time.UTC))
+	staticExpiration = timestamppb.New(time.Date(2023, 2, 17, 12, 0, 0, 0, time.UTC))
 )
 
 func Test_Server_VerifyServiceAccount(t *testing.T) {
@@ -38,14 +39,17 @@ func Test_Server_VerifyServiceAccount(t *testing.T) {
 			name: "valid client token",
 			verifier: mockTokenVerifier{
 				"somevalidtoken": claims{
-					Namespace: "applications",
-					Pod: resource{
-						Name: "booking-7d26f049-kdurb",
-						UID:  "bd8299f9-c50f-4b76-af33-9d8e3ef2b850",
-					},
-					ServiceAccount: resource{
-						Name: "booking",
-						UID:  "4f18914e-f276-44b2-aebd-27db1d8f8def",
+					Expiration: staticExpiration.AsTime().Unix(),
+					Identity: identity{
+						Namespace: "applications",
+						Pod: resource{
+							Name: "booking-7d26f049-kdurb",
+							UID:  "bd8299f9-c50f-4b76-af33-9d8e3ef2b850",
+						},
+						ServiceAccount: resource{
+							Name: "booking",
+							UID:  "4f18914e-f276-44b2-aebd-27db1d8f8def",
+						},
 					},
 				},
 			},
@@ -57,7 +61,7 @@ func Test_Server_VerifyServiceAccount(t *testing.T) {
 				Authentication: &auth.Authentication{
 					Id:        staticID,
 					Method:    auth.Method_METHOD_KUBERNETES,
-					ExpiresAt: staticTime,
+					ExpiresAt: staticExpiration,
 					CreatedAt: staticTime,
 					UpdatedAt: staticTime,
 					Metadata: map[string]string{

--- a/internal/server/auth/method/kubernetes/server_internal_test.go
+++ b/internal/server/auth/method/kubernetes/server_internal_test.go
@@ -1,0 +1,109 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/config"
+	"go.flipt.io/flipt/internal/storage/auth/memory"
+	"go.flipt.io/flipt/rpc/flipt/auth"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	staticID    = "staticID"
+	staticToken = "staticToken"
+	staticTime  = timestamppb.New(time.Date(2023, 2, 17, 10, 0, 0, 0, time.UTC))
+)
+
+func Test_Server_VerifyServiceAccount(t *testing.T) {
+	var (
+		ctx    = context.Background()
+		logger = zaptest.NewLogger(t)
+	)
+
+	for _, test := range []struct {
+		name         string
+		verifier     mockTokenVerifier
+		req          *auth.VerifyServiceAccountRequest
+		expectedResp *auth.VerifyServiceAccountResponse
+		expectedErr  error
+	}{
+		{
+			name: "valid client token",
+			verifier: mockTokenVerifier{
+				"somevalidtoken": claims{
+					Namespace: "applications",
+					Pod: resource{
+						Name: "booking-7d26f049-kdurb",
+						UID:  "bd8299f9-c50f-4b76-af33-9d8e3ef2b850",
+					},
+					ServiceAccount: resource{
+						Name: "booking",
+						UID:  "4f18914e-f276-44b2-aebd-27db1d8f8def",
+					},
+				},
+			},
+			req: &auth.VerifyServiceAccountRequest{
+				ServiceAccountToken: "somevalidtoken",
+			},
+			expectedResp: &auth.VerifyServiceAccountResponse{
+				ClientToken: staticToken,
+				Authentication: &auth.Authentication{
+					Id:        staticID,
+					Method:    auth.Method_METHOD_KUBERNETES,
+					ExpiresAt: staticTime,
+					CreatedAt: staticTime,
+					UpdatedAt: staticTime,
+					Metadata: map[string]string{
+						"io.flipt.auth.k8s.namespace":           "applications",
+						"io.flipt.auth.k8s.pod.name":            "booking-7d26f049-kdurb",
+						"io.flipt.auth.k8s.pod.uid":             "bd8299f9-c50f-4b76-af33-9d8e3ef2b850",
+						"io.flipt.auth.k8s.serviceaccount.name": "booking",
+						"io.flipt.auth.k8s.serviceaccount.uid":  "4f18914e-f276-44b2-aebd-27db1d8f8def",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				store = memory.NewStore(
+					memory.WithIDGeneratorFunc(func() string { return staticID }),
+					memory.WithTokenGeneratorFunc(func() string { return staticToken }),
+					memory.WithNowFunc(func() *timestamppb.Timestamp { return staticTime }),
+				)
+				conf   = config.AuthenticationConfig{}
+				server = NewServer(logger, store, conf)
+			)
+
+			// override token verifier for unit test
+			server.verifier = test.verifier
+
+			resp, err := server.VerifyServiceAccount(ctx, test.req)
+			if test.expectedErr != nil {
+				assert.Equal(t, test.expectedErr, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expectedResp, resp)
+		})
+	}
+}
+
+type mockTokenVerifier map[string]claims
+
+func (m mockTokenVerifier) verify(jwt string) (claims, error) {
+	claims, ok := m[jwt]
+	if !ok {
+		return claims, errors.New("token invalid")
+	}
+
+	return claims, nil
+}

--- a/internal/server/auth/method/kubernetes/server_test.go
+++ b/internal/server/auth/method/kubernetes/server_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_Server(t *testing.T) {
-	t.Skip("Skipping until serviceAccountVerifier has been implemented")
+	t.Skip("Skipping until tokenVerifier has been implemented (FLI-210)")
 
 	var (
 		router = chi.NewRouter()

--- a/internal/server/auth/method/kubernetes/server_test.go
+++ b/internal/server/auth/method/kubernetes/server_test.go
@@ -1,0 +1,153 @@
+package kubernetes_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/hashicorp/cap/oidc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/config"
+	k8stesting "go.flipt.io/flipt/internal/server/auth/method/kubernetes/testing"
+	"go.flipt.io/flipt/rpc/flipt/auth"
+	"go.uber.org/zap/zaptest"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func Test_Server(t *testing.T) {
+	t.Skip("Skipping until serviceAccountVerifier has been implemented")
+
+	var (
+		router = chi.NewRouter()
+		// httpServer is the test server used for hosting
+		// Flipts oidc authorize and callback handles
+		httpServer = httptest.NewServer(router)
+		// rewriting http server to use localhost as it is a domain and
+		// the <=go1.18 implementation will propagate cookies on it.
+		// From go1.19+ cookiejar support IP addresses as cookie domains.
+		clientAddress = strings.Replace(httpServer.URL, "127.0.0.1", "localhost", 1)
+
+		logger = zaptest.NewLogger(t)
+		ctx    = context.Background()
+	)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+
+	tp := oidc.StartTestProvider(
+		t,
+		oidc.WithTestDefaults(&oidc.TestProviderDefaults{
+			SigningKey: &oidc.TestSigningKey{
+				PrivKey: priv,
+				PubKey:  priv.Public(),
+				Alg:     oidc.RS256,
+			},
+		}),
+	)
+	defer tp.Stop()
+
+	// write CA certification to temporary file
+	caPath := writeStringToTemp(t, "ca-*.cert", tp.CACert())
+
+	fliptServiceAccountToken := oidc.TestSignJWT(t, priv, string(oidc.RS256), nil, nil)
+	fliptServiceAccountTokenPath := writeStringToTemp(t, "token-*", fliptServiceAccountToken)
+
+	var (
+		authConfig = config.AuthenticationConfig{
+			Methods: config.AuthenticationMethods{
+				Kubernetes: config.AuthenticationMethod[config.AuthenticationMethodKubernetesConfig]{
+					Enabled: true,
+					Method: config.AuthenticationMethodKubernetesConfig{
+						IssuerURL:               tp.Addr(),
+						CAPath:                  caPath,
+						ServiceAccountTokenPath: fliptServiceAccountTokenPath,
+					},
+				},
+			},
+		}
+		server = k8stesting.StartHTTPServer(t, ctx, logger, authConfig, router)
+	)
+
+	t.Cleanup(func() { _ = server.Stop() })
+
+	client := &http.Client{}
+
+	t.Run("Valid service account token", func(t *testing.T) {
+		var (
+			verifyURL = clientAddress + "/auth/v1/method/kubernetes/serviceaccount"
+			// generate service account JWT using the configured private key
+			payload = auth.VerifyServiceAccountRequest{
+				ServiceAccountToken: oidc.TestSignJWT(
+					t,
+					priv,
+					string(oidc.RS256),
+					map[string]any{
+						"kubernetes.io": map[string]any{
+							"namespace": "applications",
+							"pod": map[string]any{
+								"name": "booking-7d26f049-kdurb",
+								"uid":  "bd8299f9-c50f-4b76-af33-9d8e3ef2b850",
+							},
+							"serviceaccount": map[string]any{
+								"name": "booking",
+								"uid":  "4f18914e-f276-44b2-aebd-27db1d8f8def",
+							},
+						},
+					},
+					nil,
+				),
+			}
+		)
+
+		data, err := protojson.Marshal(&payload)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, verifyURL, bytes.NewReader(data))
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		var response auth.CallbackResponse
+		if !assert.NoError(t, protojson.Unmarshal(data, &response)) {
+			t.Log("Unexpected response", string(data))
+			t.FailNow()
+		}
+
+		assert.Empty(t, response.ClientToken) // middleware moves it to cookie
+		assert.Equal(t, auth.Method_METHOD_OIDC, response.Authentication.Method)
+		assert.Equal(t, map[string]string{
+			"io.flipt.auth.k8s.namespace":           "applications",
+			"io.flipt.auth.k8s.pod.name":            "booking-7d26f049-kdurb",
+			"io.flipt.auth.k8s.pod.uid":             "bd8299f9-c50f-4b76-af33-9d8e3ef2b850",
+			"io.flipt.auth.k8s.serviceaccount.name": "booking",
+			"io.flipt.auth.k8s.serviceaccount.uid":  "4f18914e-f276-44b2-aebd-27db1d8f8def",
+		}, response.Authentication.Metadata)
+
+		// ensure expiry is set
+		assert.NotNil(t, response.Authentication.ExpiresAt)
+	})
+}
+
+func writeStringToTemp(t *testing.T, pattern, contents string) string {
+	fi, err := os.CreateTemp("", pattern)
+	require.NoError(t, err)
+
+	_, err = io.Copy(fi, strings.NewReader(contents))
+	require.NoError(t, err)
+
+	err = fi.Close()
+	require.NoError(t, err)
+
+	return fi.Name()
+}

--- a/internal/server/auth/method/kubernetes/server_test.go
+++ b/internal/server/auth/method/kubernetes/server_test.go
@@ -85,7 +85,7 @@ func Test_Server(t *testing.T) {
 				Kubernetes: config.AuthenticationMethod[config.AuthenticationMethodKubernetesConfig]{
 					Enabled: true,
 					Method: config.AuthenticationMethodKubernetesConfig{
-						IssuerURL:               tp.Addr(),
+						DiscoveryURL:            tp.Addr(),
 						CAPath:                  caPath,
 						ServiceAccountTokenPath: fliptServiceAccountTokenPath,
 					},

--- a/internal/server/auth/method/kubernetes/server_test.go
+++ b/internal/server/auth/method/kubernetes/server_test.go
@@ -124,7 +124,7 @@ func Test_Server(t *testing.T) {
 			t.FailNow()
 		}
 
-		assert.Empty(t, response.ClientToken) // middleware moves it to cookie
+		assert.NotEmpty(t, response.ClientToken)
 		assert.Equal(t, auth.Method_METHOD_OIDC, response.Authentication.Method)
 		assert.Equal(t, map[string]string{
 			"io.flipt.auth.k8s.namespace":           "applications",

--- a/internal/server/auth/method/kubernetes/testing/grpc.go
+++ b/internal/server/auth/method/kubernetes/testing/grpc.go
@@ -48,7 +48,7 @@ func StartGRPCServer(t *testing.T, ctx context.Context, logger *zap.Logger, conf
 		}
 	)
 
-	srv, err := kubernetes.NewServer(logger, store, conf)
+	srv, err := kubernetes.New(logger, store, conf)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/server/auth/method/kubernetes/testing/grpc.go
+++ b/internal/server/auth/method/kubernetes/testing/grpc.go
@@ -1,0 +1,79 @@
+package testing
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/config"
+	"go.flipt.io/flipt/internal/server/auth/method/kubernetes"
+	middleware "go.flipt.io/flipt/internal/server/middleware/grpc"
+	"go.flipt.io/flipt/internal/storage/auth/memory"
+	"go.flipt.io/flipt/rpc/flipt/auth"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+type GRPCServer struct {
+	*grpc.Server
+
+	ClientConn *grpc.ClientConn
+	Store      *memory.Store
+
+	errc chan error
+}
+
+func (s *GRPCServer) Client() auth.AuthenticationMethodKubernetesServiceClient {
+	return auth.NewAuthenticationMethodKubernetesServiceClient(s.ClientConn)
+}
+
+func StartGRPCServer(t *testing.T, ctx context.Context, logger *zap.Logger, conf config.AuthenticationConfig) *GRPCServer {
+	t.Helper()
+
+	var (
+		store    = memory.NewStore()
+		listener = bufconn.Listen(1024 * 1024)
+		server   = grpc.NewServer(
+			grpc_middleware.WithUnaryServerChain(
+				middleware.ErrorUnaryInterceptor,
+			),
+		)
+		grpcServer = &GRPCServer{
+			Server: server,
+			Store:  store,
+			errc:   make(chan error, 1),
+		}
+	)
+
+	auth.RegisterAuthenticationMethodKubernetesServiceServer(server, kubernetes.NewServer(logger, store, conf))
+
+	go func() {
+		defer close(grpcServer.errc)
+		grpcServer.errc <- server.Serve(listener)
+	}()
+
+	var (
+		err    error
+		dialer = func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}
+	)
+
+	grpcServer.ClientConn, err = grpc.DialContext(ctx, "", grpc.WithInsecure(), grpc.WithContextDialer(dialer))
+	require.NoError(t, err)
+
+	return grpcServer
+}
+
+func (s *GRPCServer) Stop() error {
+	if err := s.ClientConn.Close(); err != nil {
+		return err
+	}
+
+	s.Server.Stop()
+
+	return <-s.errc
+}

--- a/internal/server/auth/method/kubernetes/testing/http.go
+++ b/internal/server/auth/method/kubernetes/testing/http.go
@@ -1,0 +1,49 @@
+package testing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/config"
+	"go.flipt.io/flipt/internal/gateway"
+	"go.flipt.io/flipt/rpc/flipt/auth"
+	"go.uber.org/zap"
+)
+
+type HTTPServer struct {
+	*GRPCServer
+}
+
+func StartHTTPServer(
+	t *testing.T,
+	ctx context.Context,
+	logger *zap.Logger,
+	conf config.AuthenticationConfig,
+	router chi.Router,
+) *HTTPServer {
+	t.Helper()
+
+	var (
+		mux        = gateway.NewGatewayServeMux()
+		httpServer = &HTTPServer{
+			GRPCServer: StartGRPCServer(t, ctx, logger, conf),
+		}
+	)
+
+	err := auth.RegisterAuthenticationMethodKubernetesServiceHandler(
+		ctx,
+		mux,
+		httpServer.GRPCServer.ClientConn,
+	)
+	require.NoError(t, err)
+
+	router.Mount("/auth/v1", mux)
+
+	return httpServer
+}
+
+func (s *HTTPServer) Stop() error {
+	return s.GRPCServer.Stop()
+}

--- a/internal/server/auth/method/kubernetes/verify.go
+++ b/internal/server/auth/method/kubernetes/verify.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -21,9 +24,9 @@ import (
 // The material returned from the OIDC configuration endpoints is trusted as the signing party
 // in order to validate presented service account tokens.
 type kubernetesOIDCVerifier struct {
-	logger *zap.Logger
-	config config.AuthenticationMethodKubernetesConfig
-	client *http.Client
+	logger   *zap.Logger
+	config   config.AuthenticationMethodKubernetesConfig
+	provider *oidc.Provider
 }
 
 func newKubernetesOIDCVerifier(logger *zap.Logger, config config.AuthenticationMethodKubernetesConfig) (*kubernetesOIDCVerifier, error) {
@@ -55,44 +58,63 @@ func newKubernetesOIDCVerifier(logger *zap.Logger, config config.AuthenticationM
 		},
 	}
 
+	client := &http.Client{
+		Transport: transportFunc(func(r *http.Request) (*http.Response, error) {
+			// Re-evaluate token from disk per request.
+			// This client will be used by the OIDC code to periodically fetch
+			// OIDC configuration and JWKS key chain from the k8s api-server.
+			// The OIDC wrapper handles caching that result.
+			// Each time it needs to request again we should re-read the SA token
+			// as it may have been refreshed by kubernetes.
+			token, err := os.ReadFile(config.ServiceAccountTokenPath)
+			if err != nil {
+				logger.Error("reading service account token", zap.Error(err))
+
+				return nil, fmt.Errorf("authentication OIDC client: %w", err)
+			}
+
+			if _, ok := r.Header["Authorization"]; !ok {
+				r.Header["Authorization"] = []string{fmt.Sprintf("Bearer %s", token)}
+			}
+
+			return transport.RoundTrip(r)
+		}),
+	}
+
+	// Kubernetes is not an OIDC / OAuth provider in the traditional sense
+	// and they go off-specification. The Issuer returned by the "well-known" endpoint
+	// does not match the supplied discovery URL.
+	// To ensure this isn't a problem we skip the OIDC libraries requirement
+	// that both URLs should match.
+	// We also instruct the library to use the issuer retrieved from the discovery
+	// endpoint when we verify service account ID tokens.
+	issuer, err := resolveTokenIssuer(client, config.DiscoveryURL)
+	if err != nil {
+		return nil, err
+	}
+
+	provider, err := oidc.NewProvider(
+		// skip issuer verification when NewProvider requests the discovery document.
+		oidc.InsecureIssuerURLContext(
+			oidc.ClientContext(context.Background(), client),
+			// override the issuer to match the discovery endpoint response.
+			issuer,
+		),
+		config.DiscoveryURL,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &kubernetesOIDCVerifier{
-		logger: logger,
-		config: config,
-		client: &http.Client{
-			Transport: transportFunc(func(r *http.Request) (*http.Response, error) {
-				// Re-evaluate token from disk per request.
-				// This client will be used by the OIDC code to periodically fetch
-				// OIDC configuration and JWKS key chain from the k8s api-server.
-				// The OIDC wrapper handles caching that result.
-				// Each time it needs to request again we should re-read the SA token
-				// as it may have been refreshed by kubernetes.
-				token, err := os.ReadFile(config.ServiceAccountTokenPath)
-				if err != nil {
-					logger.Error("reading service account token", zap.Error(err))
-
-					return nil, fmt.Errorf("authentication OIDC client: %w", err)
-				}
-
-				if _, ok := r.Header["Authorization"]; !ok {
-					r.Header["Authorization"] = []string{fmt.Sprintf("Bearer %s", token)}
-				}
-
-				return transport.RoundTrip(r)
-			}),
-		},
+		logger:   logger,
+		config:   config,
+		provider: provider,
 	}, nil
 }
 
 func (k *kubernetesOIDCVerifier) verify(ctx context.Context, jwt string) (c claims, err error) {
-	provider, err := oidc.NewProvider(
-		oidc.ClientContext(ctx, k.client),
-		k.config.IssuerURL,
-	)
-	if err != nil {
-		return c, err
-	}
-
-	token, err := provider.Verifier(&oidc.Config{
+	token, err := k.provider.Verifier(&oidc.Config{
 		// we're not interested in the OIDC client ID
 		// as we're not doing a real OAuth 2 flow.
 		SkipClientIDCheck: true,
@@ -112,4 +134,39 @@ type transportFunc func(*http.Request) (*http.Response, error)
 
 func (fn transportFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return fn(r)
+}
+
+func resolveTokenIssuer(client *http.Client, discoveryURL string) (string, error) {
+	req, err := http.NewRequest(
+		"GET",
+		strings.TrimSuffix(discoveryURL, "/")+"/.well-known/openid-configuration",
+		nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching OIDC configuration: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("reading OIDC configuration: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OIDC configuration response status %q: %w", resp.Status, err)
+	}
+
+	var config struct {
+		Issuer string `json:"issuer"`
+	}
+
+	if err = json.Unmarshal(body, &config); err != nil {
+		return "", fmt.Errorf("OIDC configuration unmarshal: %w", err)
+	}
+
+	return config.Issuer, nil
 }

--- a/internal/server/auth/method/kubernetes/verify.go
+++ b/internal/server/auth/method/kubernetes/verify.go
@@ -49,7 +49,10 @@ func newKubernetesOIDCVerifier(logger *zap.Logger, config config.AuthenticationM
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       &tls.Config{RootCAs: rootCAs},
+		TLSClientConfig: &tls.Config{
+			RootCAs:    rootCAs,
+			MinVersion: tls.VersionTLS12,
+		},
 	}
 
 	return &kubernetesOIDCVerifier{

--- a/internal/server/auth/method/kubernetes/verify.go
+++ b/internal/server/auth/method/kubernetes/verify.go
@@ -1,0 +1,103 @@
+package kubernetes
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"go.flipt.io/flipt/internal/config"
+	"go.uber.org/zap"
+)
+
+type kubernetesOIDCVerifier struct {
+	logger *zap.Logger
+	config config.AuthenticationMethodKubernetesConfig
+	client *http.Client
+}
+
+func newKubernetesOIDCVerifier(logger *zap.Logger, config config.AuthenticationMethodKubernetesConfig) (*kubernetesOIDCVerifier, error) {
+	caCert, err := os.ReadFile(config.CAPath)
+	if err != nil {
+		logger.Error("reading CA certificate", zap.Error(err))
+
+		return nil, fmt.Errorf("building OIDC client: %w", err)
+	}
+
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("failed to append cert from path: %q", config.CAPath)
+	}
+
+	transport := &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       &tls.Config{RootCAs: rootCAs},
+	}
+
+	return &kubernetesOIDCVerifier{
+		logger: logger,
+		config: config,
+		client: &http.Client{
+			Transport: transportFunc(func(r *http.Request) (*http.Response, error) {
+				// Re-evaluate token from disk per request.
+				// this client will be used by the OIDC code to periodically fetch
+				// OIDC configuration and PKI key chain from k8s.
+				// It handles caching that result.
+				// Each time it needs to request again we should re-read the SA token
+				// as it may have been refreshed by kubernetes.
+				token, err := os.ReadFile(config.ServiceAccountTokenPath)
+				if err != nil {
+					logger.Error("reading service account token", zap.Error(err))
+
+					return nil, fmt.Errorf("authentication OIDC client: %w", err)
+				}
+
+				if _, ok := r.Header["Authorization"]; !ok {
+					r.Header["Authorization"] = []string{fmt.Sprintf("Bearer %s", token)}
+				}
+
+				return transport.RoundTrip(r)
+			}),
+		},
+	}, nil
+}
+
+func (k *kubernetesOIDCVerifier) verify(ctx context.Context, jwt string) (c claims, err error) {
+	provider, err := oidc.NewProvider(
+		oidc.ClientContext(ctx, k.client),
+		k.config.IssuerURL,
+	)
+	if err != nil {
+		return c, err
+	}
+
+	token, err := provider.Verifier(&oidc.Config{
+		// we're not interested in the OIDC client ID
+		// as we're not doing a real OAuth 2 flow.
+		SkipClientIDCheck: true,
+	}).Verify(ctx, jwt)
+	if err != nil {
+		return c, err
+	}
+
+	c.Expiration = token.Expiry.Unix()
+
+	err = token.Claims(&c)
+
+	return
+}
+
+type transportFunc func(*http.Request) (*http.Response, error)
+
+func (fn transportFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return fn(r)
+}


### PR DESCRIPTION
Depends on https://github.com/flipt-io/flipt/pull/1341 ✅ 

Fixes FLI-210
Fixes FLI-211

This PR is the core of the implementation of the VerifyServiceAccount authentication method RPC call.

The purpose of this call is to verify a supplied service account against the OIDC configuration of a trusted kubernetes cluster. Given the token is valid then it is used to create an authentication and associated client token in the backing authentication storage implementation.

This PR includes both the implementation and the installation of the method into the gRPC and HTTP servers.
It also includes a fix to the defaults for both CA path and Issuer URL.
The CA path was incorrectly prefixed with `.cert` and it needed to be `.crt`.
The Issuer URL default includes the prefix `.cluster.local` in the standard k8s service account token.

Those have been amended making the defaults match appropriately.

![kubernetes authentication method flow](https://user-images.githubusercontent.com/1253326/220099841-7b0acb10-c8fe-41ea-be39-42949d222abe.svg)

UPDATE: I renamed `IssuerURL` in configuration to `DiscoveryURL`.

It is simply used as the OIDC discovery URL. The issuer doesn't match in the Kubernetes world.
However, the discovery response does contain the correct issuer URL to be used when validating service account tokens.

I also update the implementation to use one provider for the lifetime of the service.
Also, to avoid wasted requests to discovery and JWKS endpoints.