### PR TITLE
feat: allow setting config slice values via commas

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"unicode"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
@@ -363,6 +364,11 @@ func stringToSliceHookFunc() mapstructure.DecodeHookFunc {
 			return []string{}, nil
 		}
 
-		return strings.Fields(raw), nil
+		return strings.FieldsFunc(raw, func(r rune) bool {
+			if r == ',' {
+				return true
+			}
+			return unicode.IsSpace(r)
+		}), nil
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -608,6 +608,7 @@ func TestLoad(t *testing.T) {
 										ClientID:        "abcdefg",
 										ClientSecret:    "bcdefgh",
 										RedirectAddress: "http://auth.flipt.io",
+										Scopes:          []string{"openid", "email", "profile"},
 									},
 								},
 							},

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -62,6 +62,7 @@ authentication:
           client_id: "abcdefg"
           client_secret: "bcdefgh"
           redirect_address: "http://auth.flipt.io"
+          scopes: "openid,email,profile"
       cleanup:
         interval: 2h
         grace_period: 48h


### PR DESCRIPTION
Re: #1179

Got some user feedback that one of the expected ways of providing multiple values via an env var override using `,` doesn't work currently.

This PR should allow for both `,` or ` ` separated values for `[]string` config properties such as `cors.allowed_origins` or `oidc.provider.scopes`

ie: `FLIPT_AUTHENTICATION_METHODS_OIDC_PROVIDERS_GOOGLE_SCOPES=email,profile,openid` should now work.

we should document the ability to override list values in the docs as well

/cc @GeorgeMac 