### PR TITLE
feat: (sqlite) add namespace support for rules storage

### DIFF
--- a/internal/ext/exporter.go
+++ b/internal/ext/exporter.go
@@ -16,7 +16,7 @@ const defaultBatchSize = 25
 type lister interface {
 	ListFlags(ctx context.Context, namespaceKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Flag], error)
 	ListSegments(ctx context.Context, namespaceKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Segment], error)
-	ListRules(ctx context.Context, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rule], error)
+	ListRules(ctx context.Context, namespaceKey, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rule], error)
 }
 
 type Exporter struct {
@@ -88,8 +88,10 @@ func (e *Exporter) Export(ctx context.Context, w io.Writer) error {
 				variantKeys[v.Id] = v.Key
 			}
 
+			// TODO: support all namespaces
+
 			// export rules for flag
-			resp, err := e.store.ListRules(ctx, flag.Key)
+			resp, err := e.store.ListRules(ctx, storage.DefaultNamespace, flag.Key)
 			if err != nil {
 				return fmt.Errorf("getting rules for flag %q: %w", flag.Key, err)
 			}

--- a/internal/ext/exporter_test.go
+++ b/internal/ext/exporter_test.go
@@ -34,7 +34,7 @@ func (m mockLister) ListSegments(ctx context.Context, namespaceKey string, opts 
 	}, m.segmentErr
 }
 
-func (m mockLister) ListRules(ctx context.Context, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rule], error) {
+func (m mockLister) ListRules(ctx context.Context, namespaceKey string, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rule], error) {
 	return storage.ResultSet[*flipt.Rule]{
 		Results: m.rules,
 	}, m.ruleErr

--- a/internal/server/middleware/grpc/support_test.go
+++ b/internal/server/middleware/grpc/support_test.go
@@ -109,18 +109,18 @@ func (m *storeMock) DeleteConstraint(ctx context.Context, r *flipt.DeleteConstra
 	return args.Error(0)
 }
 
-func (m *storeMock) GetRule(ctx context.Context, id string) (*flipt.Rule, error) {
-	args := m.Called(ctx, id)
+func (m *storeMock) GetRule(ctx context.Context, namespaceKey string, id string) (*flipt.Rule, error) {
+	args := m.Called(ctx, namespaceKey, id)
 	return args.Get(0).(*flipt.Rule), args.Error(1)
 }
 
-func (m *storeMock) ListRules(ctx context.Context, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rule], error) {
-	args := m.Called(ctx, flagKey, opts)
+func (m *storeMock) ListRules(ctx context.Context, namespaceKey string, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rule], error) {
+	args := m.Called(ctx, namespaceKey, flagKey, opts)
 	return args.Get(0).(storage.ResultSet[*flipt.Rule]), args.Error(1)
 }
 
-func (m *storeMock) CountRules(ctx context.Context) (uint64, error) {
-	args := m.Called(ctx)
+func (m *storeMock) CountRules(ctx context.Context, namespaceKey string) (uint64, error) {
+	args := m.Called(ctx, namespaceKey)
 	return args.Get(0).(uint64), args.Error(1)
 }
 

--- a/internal/server/rule.go
+++ b/internal/server/rule.go
@@ -14,7 +14,7 @@ import (
 // GetRule gets a rule
 func (s *Server) GetRule(ctx context.Context, r *flipt.GetRuleRequest) (*flipt.Rule, error) {
 	s.logger.Debug("get rule", zap.Stringer("request", r))
-	rule, err := s.store.GetRule(ctx, r.Id)
+	rule, err := s.store.GetRule(ctx, r.NamespaceKey, r.Id)
 	s.logger.Debug("get rule", zap.Stringer("response", rule))
 	return rule, err
 }
@@ -41,7 +41,7 @@ func (s *Server) ListRules(ctx context.Context, r *flipt.ListRuleRequest) (*flip
 		opts = append(opts, storage.WithOffset(uint64(r.Offset)))
 	}
 
-	results, err := s.store.ListRules(ctx, r.FlagKey, opts...)
+	results, err := s.store.ListRules(ctx, r.NamespaceKey, r.FlagKey, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (s *Server) ListRules(ctx context.Context, r *flipt.ListRuleRequest) (*flip
 
 	resp.Rules = append(resp.Rules, results.Results...)
 
-	total, err := s.store.CountRules(ctx)
+	total, err := s.store.CountRules(ctx, r.NamespaceKey)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/rule_test.go
+++ b/internal/server/rule_test.go
@@ -24,7 +24,7 @@ func TestGetRule(t *testing.T) {
 		req = &flipt.GetRuleRequest{Id: "id", FlagKey: "flagKey"}
 	)
 
-	store.On("GetRule", mock.Anything, "id").Return(&flipt.Rule{
+	store.On("GetRule", mock.Anything, mock.Anything, "id").Return(&flipt.Rule{
 		Id: "1",
 	}, nil)
 
@@ -47,7 +47,7 @@ func TestListRules_PaginationOffset(t *testing.T) {
 	defer store.AssertExpectations(t)
 
 	params := storage.QueryParams{}
-	store.On("ListRules", mock.Anything, "flagKey", mock.MatchedBy(func(opts []storage.QueryOption) bool {
+	store.On("ListRules", mock.Anything, mock.Anything, "flagKey", mock.MatchedBy(func(opts []storage.QueryOption) bool {
 		for _, opt := range opts {
 			opt(&params)
 		}
@@ -64,7 +64,7 @@ func TestListRules_PaginationOffset(t *testing.T) {
 			NextPageToken: "bar",
 		}, nil)
 
-	store.On("CountRules", mock.Anything).Return(uint64(1), nil)
+	store.On("CountRules", mock.Anything, mock.Anything).Return(uint64(1), nil)
 
 	got, err := s.ListRules(context.TODO(), &flipt.ListRuleRequest{FlagKey: "flagKey",
 		Offset: 10,
@@ -90,7 +90,7 @@ func TestListRules_PaginationPageToken(t *testing.T) {
 	defer store.AssertExpectations(t)
 
 	params := storage.QueryParams{}
-	store.On("ListRules", mock.Anything, "flagKey", mock.MatchedBy(func(opts []storage.QueryOption) bool {
+	store.On("ListRules", mock.Anything, mock.Anything, "flagKey", mock.MatchedBy(func(opts []storage.QueryOption) bool {
 		for _, opt := range opts {
 			opt(&params)
 		}
@@ -107,7 +107,7 @@ func TestListRules_PaginationPageToken(t *testing.T) {
 			NextPageToken: "bar",
 		}, nil)
 
-	store.On("CountRules", mock.Anything).Return(uint64(1), nil)
+	store.On("CountRules", mock.Anything, mock.Anything).Return(uint64(1), nil)
 
 	got, err := s.ListRules(context.TODO(), &flipt.ListRuleRequest{FlagKey: "flagKey",
 		PageToken: "Zm9v",

--- a/internal/server/support_test.go
+++ b/internal/server/support_test.go
@@ -108,18 +108,18 @@ func (m *storeMock) DeleteConstraint(ctx context.Context, r *flipt.DeleteConstra
 	return args.Error(0)
 }
 
-func (m *storeMock) GetRule(ctx context.Context, id string) (*flipt.Rule, error) {
-	args := m.Called(ctx, id)
+func (m *storeMock) GetRule(ctx context.Context, namespaceKey string, id string) (*flipt.Rule, error) {
+	args := m.Called(ctx, namespaceKey, id)
 	return args.Get(0).(*flipt.Rule), args.Error(1)
 }
 
-func (m *storeMock) ListRules(ctx context.Context, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rule], error) {
-	args := m.Called(ctx, flagKey, opts)
+func (m *storeMock) ListRules(ctx context.Context, namespaceKey string, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rule], error) {
+	args := m.Called(ctx, namespaceKey, flagKey, opts)
 	return args.Get(0).(storage.ResultSet[*flipt.Rule]), args.Error(1)
 }
 
-func (m *storeMock) CountRules(ctx context.Context) (uint64, error) {
-	args := m.Called(ctx)
+func (m *storeMock) CountRules(ctx context.Context, namespaceKey string) (uint64, error) {
+	args := m.Called(ctx, namespaceKey)
 	return args.Get(0).(uint64), args.Error(1)
 }
 

--- a/internal/storage/sql/common/flag.go
+++ b/internal/storage/sql/common/flag.go
@@ -379,7 +379,7 @@ func (s *Store) UpdateFlag(ctx context.Context, r *flipt.UpdateFlagRequest) (*fl
 	}
 
 	if count != 1 {
-		return nil, errs.ErrNotFoundf("flag %q", r.Key)
+		return nil, errs.ErrNotFoundf(`flag "%s/%s"`, r.NamespaceKey, r.Key)
 	}
 
 	return s.GetFlag(ctx, r.NamespaceKey, r.Key)

--- a/internal/storage/sql/flag_test.go
+++ b/internal/storage/sql/flag_test.go
@@ -75,6 +75,7 @@ func (s *DBTestSuite) TestListFlags() {
 
 	res, err := s.store.ListFlags(context.TODO(), storage.DefaultNamespace)
 	require.NoError(t, err)
+
 	got := res.Results
 	assert.NotZero(t, len(got))
 
@@ -359,7 +360,7 @@ func (s *DBTestSuite) TestUpdateFlag_NotFound() {
 		Enabled:     true,
 	})
 
-	assert.EqualError(t, err, "flag \"foo\" not found")
+	assert.EqualError(t, err, "flag \"default/foo\" not found")
 }
 
 func (s *DBTestSuite) TestDeleteFlag() {

--- a/internal/storage/sql/segment_test.go
+++ b/internal/storage/sql/segment_test.go
@@ -48,7 +48,7 @@ func (s *DBTestSuite) TestGetSegmentNotFound() {
 	t := s.T()
 
 	_, err := s.store.GetSegment(context.TODO(), storage.DefaultNamespace, "foo")
-	assert.EqualError(t, err, "segment \"foo\" not found")
+	assert.EqualError(t, err, "segment \"default/foo\" not found")
 }
 
 func (s *DBTestSuite) TestListSegments() {
@@ -350,7 +350,7 @@ func (s *DBTestSuite) TestUpdateSegment_NotFound() {
 		Description: "bar",
 	})
 
-	assert.EqualError(t, err, "segment \"foo\" not found")
+	assert.EqualError(t, err, "segment \"default/foo\" not found")
 }
 
 func (s *DBTestSuite) TestDeleteSegment() {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -159,9 +159,9 @@ type SegmentStore interface {
 
 // RuleStore stores and retrieves rules and distributions
 type RuleStore interface {
-	GetRule(ctx context.Context, id string) (*flipt.Rule, error)
-	ListRules(ctx context.Context, flagKey string, opts ...QueryOption) (ResultSet[*flipt.Rule], error)
-	CountRules(ctx context.Context) (uint64, error)
+	GetRule(ctx context.Context, namespaceKey, id string) (*flipt.Rule, error)
+	ListRules(ctx context.Context, namespaceKey, flagKey string, opts ...QueryOption) (ResultSet[*flipt.Rule], error)
+	CountRules(ctx context.Context, namespaceKey string) (uint64, error)
 	CreateRule(ctx context.Context, r *flipt.CreateRuleRequest) (*flipt.Rule, error)
 	UpdateRule(ctx context.Context, r *flipt.UpdateRuleRequest) (*flipt.Rule, error)
 	DeleteRule(ctx context.Context, r *flipt.DeleteRuleRequest) error


### PR DESCRIPTION
Fixes: FLI-245

Like #1369 but for `rules`