### PR TITLE
fix: return better error messages for grpc-gateway errors

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -137,6 +137,7 @@ func registerFunc(ctx context.Context, conn *grpc.ClientConn, fn func(context.Co
 
 func authenticationHTTPMount(
 	ctx context.Context,
+	logger *zap.Logger,
 	cfg config.AuthenticationConfig,
 	r chi.Router,
 	conn *grpc.ClientConn,
@@ -172,6 +173,6 @@ func authenticationHTTPMount(
 	r.Group(func(r chi.Router) {
 		r.Use(middleware...)
 
-		r.Mount("/auth/v1", gateway.NewGatewayServeMux(muxOpts...))
+		r.Mount("/auth/v1", gateway.NewGatewayServeMux(logger, muxOpts...))
 	})
 }

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -55,7 +55,7 @@ func NewHTTPServer(
 		isConsole = cfg.Log.Encoding == config.LogEncodingConsole
 
 		r        = chi.NewRouter()
-		api      = gateway.NewGatewayServeMux()
+		api      = gateway.NewGatewayServeMux(logger)
 		httpPort = cfg.Server.HTTPPort
 	)
 
@@ -130,7 +130,7 @@ func NewHTTPServer(
 
 		// mount all authentication related HTTP components
 		// to the chi router.
-		authenticationHTTPMount(ctx, cfg.Authentication, r, conn)
+		authenticationHTTPMount(ctx, logger, cfg.Authentication, r, conn)
 
 		r.Group(func(r chi.Router) {
 			r.Use(func(handler http.Handler) http.Handler {

--- a/internal/server/auth/method/kubernetes/testing/http.go
+++ b/internal/server/auth/method/kubernetes/testing/http.go
@@ -26,7 +26,7 @@ func StartHTTPServer(
 	t.Helper()
 
 	var (
-		mux        = gateway.NewGatewayServeMux()
+		mux        = gateway.NewGatewayServeMux(logger)
 		httpServer = &HTTPServer{
 			GRPCServer: StartGRPCServer(t, ctx, logger, conf),
 		}

--- a/internal/server/auth/method/oidc/testing/http.go
+++ b/internal/server/auth/method/oidc/testing/http.go
@@ -34,6 +34,7 @@ func StartHTTPServer(
 
 		oidcmiddleware = oidc.NewHTTPMiddleware(conf.Session)
 		mux            = gateway.NewGatewayServeMux(
+			logger,
 			runtime.WithMetadata(oidc.ForwardCookies),
 			runtime.WithForwardResponseOption(oidcmiddleware.ForwardResponseOption),
 		)

--- a/rpc/flipt/marshaller.go
+++ b/rpc/flipt/marshaller.go
@@ -2,11 +2,12 @@ package flipt
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 
 	grpc_gateway_v1 "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	grpc_gateway_v2 "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"go.uber.org/zap"
 )
 
 var _ grpc_gateway_v2.Marshaler = &V1toV2MarshallerAdapter{}
@@ -22,10 +23,11 @@ var _ grpc_gateway_v2.Marshaler = &V1toV2MarshallerAdapter{}
 // TODO: remove this custom marshaller for Flipt API v2 as we want to use the default v2 marshaller directly.
 type V1toV2MarshallerAdapter struct {
 	*grpc_gateway_v1.JSONPb
+	logger *zap.Logger
 }
 
-func NewV1toV2MarshallerAdapter() *V1toV2MarshallerAdapter {
-	return &V1toV2MarshallerAdapter{&grpc_gateway_v1.JSONPb{OrigName: false, EmitDefaults: true}}
+func NewV1toV2MarshallerAdapter(logger *zap.Logger) *V1toV2MarshallerAdapter {
+	return &V1toV2MarshallerAdapter{&grpc_gateway_v1.JSONPb{OrigName: false, EmitDefaults: true}, logger}
 }
 
 func (m *V1toV2MarshallerAdapter) ContentType(_ interface{}) string {
@@ -40,13 +42,16 @@ func (m *V1toV2MarshallerAdapter) Marshal(v interface{}) ([]byte, error) {
 // inputs that fail to unmarshal against the protobuf.
 type decoderInterceptor struct {
 	grpc_gateway_v1.Decoder
+	logger *zap.Logger
 }
 
 func (c *decoderInterceptor) Decode(v interface{}) error {
 	err := c.Decoder.Decode(v)
 	if err != nil {
+		c.logger.Debug("JSON decoding failed for inputs", zap.Error(err))
+
 		if _, ok := err.(*json.UnmarshalTypeError); ok {
-			return fmt.Errorf("invalid values for key(s) in json body")
+			return errors.New("invalid values for key(s) in json body")
 		}
 
 		return err
@@ -56,7 +61,7 @@ func (c *decoderInterceptor) Decode(v interface{}) error {
 }
 
 func (m *V1toV2MarshallerAdapter) NewDecoder(r io.Reader) grpc_gateway_v2.Decoder {
-	return &decoderInterceptor{Decoder: m.JSONPb.NewDecoder(r)}
+	return &decoderInterceptor{Decoder: m.JSONPb.NewDecoder(r), logger: m.logger}
 }
 
 func (m *V1toV2MarshallerAdapter) NewEncoder(w io.Writer) grpc_gateway_v2.Encoder {

--- a/test/api.sh
+++ b/test/api.sh
@@ -263,6 +263,12 @@ step_5_test_evaluation()
         status 200
         matches "\"flagKey\":\"$flag_key\""
         matches "\"match\":false"
+
+    # evaluate returns 400 plus user friendly error message
+    authedShakedown POST "/api/v1/evaluate" -H 'Content-Type:application/json' -d "{\"flag_key\":\"$flag_key\",\"entity_id\":\"$(uuid_str)\",\"context\":\"hello\"}"
+        status 400
+        matches "\"code\":3"
+        contains "\"message\":\"invalid values for key(s) in json body\""
 }
 
 step_6_test_batch_evaluation()


### PR DESCRIPTION
Currently, we return a very "go" specific type of error messaging when body inputs fail to unmarshal against the protobuf schema:

```
{
    "code": 3,
    "message": "json: cannot unmarshal bool into Go value of type map[string]json.RawMessage",
    "details": []
}
```

This error messaging does not really tell users what is going on with their inputs to the API, so this PR serves to change the error messaging to something like the following:

```
{
    "code": 3,
    "message": "invalid values for key(s) in json body",
    "details": []
}
```

Fixes: FLI-129
Fixes: FLI-130