### PR TITLE
fix: import for cockroach db

### DIFF
--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -45,7 +45,7 @@ func runExport(ctx context.Context, logger *zap.Logger) error {
 	switch driver {
 	case sql.SQLite:
 		store = sqlite.NewStore(db, logger)
-	case sql.Postgres:
+	case sql.Postgres, sql.CockroachDB:
 		store = postgres.NewStore(db, logger)
 	case sql.MySQL:
 		store = mysql.NewStore(db, logger)

--- a/cmd/flipt/import.go
+++ b/cmd/flipt/import.go
@@ -49,7 +49,7 @@ func runImport(ctx context.Context, logger *zap.Logger, args []string) error {
 	switch driver {
 	case sql.SQLite:
 		store = sqlite.NewStore(db, logger)
-	case sql.Postgres:
+	case sql.Postgres, sql.CockroachDB:
 		store = postgres.NewStore(db, logger)
 	case sql.MySQL:
 		store = mysql.NewStore(db, logger)

--- a/go.work.sum
+++ b/go.work.sum
@@ -825,6 +825,7 @@ golang.org/x/image v0.0.0-20210216034530-4410531fe030 h1:lP9pYkih3DUSC641giIXa2X
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
 golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/net v0.0.0-20221014081412-f15817d10f9b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
@@ -838,6 +839,7 @@ golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.4.0 h1:7mTAgkunk3fr4GAloyyCasadO6h9zSsQZbwvcaIciV4=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gonum.org/v1/gonum v0.9.3 h1:DnoIG+QAMaF5NvxnGe/oKsgKcAc6PcUyl8q0VetfQ8s=

--- a/internal/storage/sql/migrator.go
+++ b/internal/storage/sql/migrator.go
@@ -129,7 +129,7 @@ func (m *Migrator) Up(force bool) error {
 
 // Down returns the down migrations (drops the database)
 func (m *Migrator) Down() error {
-	m.logger.Debug("Running down migrations...")
+	m.logger.Debug("running down migrations...")
 
 	if err := m.migrator.Down(); err != nil {
 		return fmt.Errorf("reverting migrations: %w", err)


### PR DESCRIPTION
When working on #1396 I saw that if you tried to run import using cockroachDB you would get a nil pointer error. This is because we never added `cockroachDB` to the switch statement for import/export commands.. oops