### PR TITLE
feat: audit sinks basic structure

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -281,9 +281,14 @@ func NewGRPCServer(
 	// Based on audit sink configuration from the user, provision the audit sinks and add them to a slice,
 	// and if the slice has a non-zero length, add the audit sink interceptor.
 	if len(sinks) > 0 {
-		publisher := auditsink.NewPublisher(logger, cfg.Audit.Advanced.BufferSize, sinks, 2*time.Minute)
+		publisher := auditsink.NewPublisher(logger, cfg.Audit.Buffer.Capacity, sinks, 2*time.Minute)
 		interceptors = append(interceptors, middlewaregrpc.AuditSinkUnaryInterceptor(logger, publisher))
-		logger.Debug(fmt.Sprintf("sinks are enabled with buffer size %d", cfg.Audit.Advanced.BufferSize), zap.String("sinks", strings.TrimSuffix(sinksString, ",")))
+		logger.Debug(fmt.Sprintf("sinks are enabled with buffer size %d", cfg.Audit.Buffer.Capacity), zap.String("sinks", strings.TrimSuffix(sinksString, ",")))
+
+		server.onShutdown(func(context.Context) error {
+			publisher.Close()
+			return nil
+		})
 	}
 
 	grpcOpts := []grpc.ServerOption{grpc_middleware.WithUnaryServerChain(interceptors...)}

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -283,8 +283,8 @@ func NewGRPCServer(
 	// and if the slice has a non-zero length, add the audit sink interceptor.
 	if len(sinks) > 0 {
 		publisher := auditsink.NewSinkPublisher(logger, cfg.Audit.Buffer.Capacity, sinks, 2*time.Minute)
-		interceptors = append(interceptors, middlewaregrpc.AuditSinkUnaryInterceptor(logger, publisher))
-		logger.Debug(fmt.Sprintf("sinks are enabled with buffer size %d", cfg.Audit.Buffer.Capacity), zap.String("sinks", strings.TrimSuffix(sinksString, ",")))
+		interceptors = append(interceptors, middlewaregrpc.AuditSinkUnaryInterceptor(logger, publisher, cfg.Audit.Version))
+		logger.Debug("audit sinks are enabled", zap.String("sinks", strings.TrimSuffix(sinksString, ",")), zap.Int("buffer capacity", cfg.Audit.Buffer.Capacity), zap.String("version", cfg.Audit.Version))
 
 		server.onShutdown(func(context.Context) error {
 			publisher.Close()

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -265,6 +265,7 @@ func NewGRPCServer(
 		logger.Debug("cache enabled", zap.Stringer("backend", cacher))
 	}
 
+	// Audit sinks configuration.
 	sinks := make([]auditsink.AuditSink, 0)
 	var sinksString string
 
@@ -281,7 +282,7 @@ func NewGRPCServer(
 	// Based on audit sink configuration from the user, provision the audit sinks and add them to a slice,
 	// and if the slice has a non-zero length, add the audit sink interceptor.
 	if len(sinks) > 0 {
-		publisher := auditsink.NewPublisher(logger, cfg.Audit.Buffer.Capacity, sinks, 2*time.Minute)
+		publisher := auditsink.NewSinkPublisher(logger, cfg.Audit.Buffer.Capacity, sinks, 2*time.Minute)
 		interceptors = append(interceptors, middlewaregrpc.AuditSinkUnaryInterceptor(logger, publisher))
 		logger.Debug(fmt.Sprintf("sinks are enabled with buffer size %d", cfg.Audit.Buffer.Capacity), zap.String("sinks", strings.TrimSuffix(sinksString, ",")))
 

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -281,7 +281,7 @@ func NewGRPCServer(
 	// Based on audit sink configuration from the user, provision the audit sinks and add them to a slice,
 	// and if the slice has a non-zero length, add the audit sink interceptor.
 	if len(sinks) > 0 {
-		publisher := auditsink.NewPublisher(logger, cfg.Audit.Advanced.BufferSize, sinks)
+		publisher := auditsink.NewPublisher(logger, cfg.Audit.Advanced.BufferSize, sinks, 2*time.Minute)
 		interceptors = append(interceptors, middlewaregrpc.AuditSinkUnaryInterceptor(logger, publisher))
 		logger.Debug(fmt.Sprintf("sinks are enabled with buffer size %d", cfg.Audit.Advanced.BufferSize), zap.String("sinks", strings.TrimSuffix(sinksString, ",")))
 	}

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"go.flipt.io/flipt/internal/config"
 	"go.flipt.io/flipt/internal/info"
 	fliptserver "go.flipt.io/flipt/internal/server"
+	"go.flipt.io/flipt/internal/server/auditsink"
+	"go.flipt.io/flipt/internal/server/auditsink/logfile"
 	"go.flipt.io/flipt/internal/server/cache"
 	"go.flipt.io/flipt/internal/server/cache/memory"
 	"go.flipt.io/flipt/internal/server/cache/redis"
@@ -260,6 +264,48 @@ func NewGRPCServer(
 		interceptors = append(interceptors, middlewaregrpc.CacheUnaryInterceptor(cacher, logger))
 
 		logger.Debug("cache enabled", zap.Stringer("backend", cacher))
+	}
+
+	// Based on audit sink configuration from the user, provision the audit sinks and add them to a slice,
+	// and if the slice has a non-zero length, add the audit sink interceptor.
+	var sinksString string
+	sinks := make([]auditsink.AuditSink, 0)
+
+	if cfg.Audit.Sinks.LogFile.Enabled {
+		auditsink.AuditEvents = make([]*auditsink.AuditEvent, 0)
+		logFileSink, err := logfile.NewLogFileSink(cfg.Audit.Sinks.LogFile.FilePath)
+		if err != nil {
+			return nil, fmt.Errorf("opening file at path: %s", cfg.Audit.Sinks.LogFile.FilePath)
+		}
+
+		sinks = append(sinks, logFileSink)
+		sinksString += fmt.Sprintf("%s,", logFileSink.String())
+	}
+
+	if len(sinks) > 0 {
+		ch := make(chan []*auditsink.AuditEvent)
+		// Due to RPC requests being processed in goroutines by the server, we have to pass in a
+		// mutex to protect the global variable auditsink.AuditEvents.
+		interceptors = append(interceptors, middlewaregrpc.AuditSinkUnaryInterceptor(logger, ch, &sync.Mutex{}, cfg.Audit.Advanced.BufferSize))
+		go func(ctx context.Context, sinks []auditsink.AuditSink) {
+			defer close(ch)
+
+			for {
+				select {
+				case c := <-ch:
+					for _, sink := range sinks {
+						err := sink.SendAudits(c)
+						if err != nil {
+							logger.Warn("Failed to send audits to configured sink", zap.Stringer("sink", sink))
+						}
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}(ctx, sinks)
+
+		logger.Debug(fmt.Sprintf("sinks are enabled with buffer size %d", cfg.Audit.Advanced.BufferSize), zap.String("sinks", strings.TrimSuffix(sinksString, ",")))
 	}
 
 	grpcOpts := []grpc.ServerOption{grpc_middleware.WithUnaryServerChain(interceptors...)}

--- a/internal/config/auditsink.go
+++ b/internal/config/auditsink.go
@@ -7,8 +7,8 @@ import (
 // AuditSinkConfig contains fields, which enable and configure
 // Flipt's various audit sink mechanisms.
 type AuditSinkConfig struct {
-	Sinks    SinksConfig    `json:"sinks,omitempty" mapstructure:"sinks"`
-	Advanced AdvancedConfig `json:"advanced,omitempty" mapstructure:"advanced"`
+	Sinks  SinksConfig  `json:"sinks,omitempty" mapstructure:"sinks"`
+	Buffer BufferConfig `json:"buffer,omitempty" mapstructure:"buffer"`
 }
 
 func (c *AuditSinkConfig) setDefaults(v *viper.Viper) {
@@ -19,8 +19,8 @@ func (c *AuditSinkConfig) setDefaults(v *viper.Viper) {
 				"filePath": "./path/to/log/file",
 			},
 		},
-		"advanced": map[string]any{
-			"bufferSize": 2,
+		"buffer": map[string]any{
+			"capacity": 2,
 		},
 	})
 }
@@ -38,8 +38,8 @@ type LogFileSinkConfig struct {
 	FilePath string `json:"filePath,omitempty" mapstructure:"filePath"`
 }
 
-// AdvancedConfig holds configuration for advanced configuration of sending the audit
+// BufferConfig holds configuration for the buffering of sending the audit
 // events to the sinks.
-type AdvancedConfig struct {
-	BufferSize int `json:"bufferSize,omitempty" mapstructure:"bufferSize"`
+type BufferConfig struct {
+	Capacity int `json:"capacity,omitempty" mapstructure:"capacity"`
 }

--- a/internal/config/auditsink.go
+++ b/internal/config/auditsink.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spf13/viper"
 )
@@ -29,7 +30,8 @@ func (c *AuditSinkConfig) setDefaults(v *viper.Viper) {
 			},
 		},
 		"buffer": map[string]any{
-			"capacity": 2,
+			"capacity":    2,
+			"flushPeriod": "2m",
 		},
 	})
 }
@@ -53,6 +55,10 @@ func (c *AuditSinkConfig) validate() error {
 		return errors.New("buffer capacity below 2 or above 10")
 	}
 
+	if c.Buffer.FlushPeriod < 2*time.Minute || c.Buffer.FlushPeriod > 5*time.Minute {
+		return errors.New("flush period below 2 minutes or greater than 5 minutes")
+	}
+
 	return nil
 }
 
@@ -72,5 +78,6 @@ type LogFileSinkConfig struct {
 // BufferConfig holds configuration for the buffering of sending the audit
 // events to the sinks.
 type BufferConfig struct {
-	Capacity int `json:"capacity,omitempty" mapstructure:"capacity"`
+	Capacity    int           `json:"capacity,omitempty" mapstructure:"capacity"`
+	FlushPeriod time.Duration `json:"flushPeriod,omitempty" mapstructure:"flushPeriod"`
 }

--- a/internal/config/auditsink.go
+++ b/internal/config/auditsink.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+// AuditSinkConfig contains fields, which enable and configure
+// Flipt's various audit sink mechanisms.
+type AuditSinkConfig struct {
+	Sinks    SinksConfig    `json:"sinks,omitempty" mapstructure:"sinks"`
+	Advanced AdvancedConfig `json:"advanced,omitempty" mapstructure:"advanced"`
+}
+
+func (c *AuditSinkConfig) setDefaults(v *viper.Viper) {
+	v.SetDefault("audit", map[string]any{
+		"sinks": map[string]any{
+			"logFile": map[string]any{
+				"enabled":  "false",
+				"filePath": "./path/to/log/file",
+			},
+		},
+		"advanced": map[string]any{
+			"bufferSize": 2,
+		},
+	})
+}
+
+// SinksConfig contains configuration held in structures for the different sinks
+// that we will send audits to.
+type SinksConfig struct {
+	LogFile LogFileSinkConfig `json:"logFile,omitempty" mapstructure:"logFile"`
+}
+
+// LogFileSinkConfig contains fields that hold configuration for sending audits
+// to a log file.
+type LogFileSinkConfig struct {
+	Enabled  bool   `json:"enabled,omitempty" mapstructure:"enabled"`
+	FilePath string `json:"filePath,omitempty" mapstructure:"filePath"`
+}
+
+// AdvancedConfig holds configuration for advanced configuration of sending the audit
+// events to the sinks.
+type AdvancedConfig struct {
+	BufferSize int `json:"bufferSize,omitempty" mapstructure:"bufferSize"`
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	Database       DatabaseConfig       `json:"db,omitempty" mapstructure:"db"`
 	Meta           MetaConfig           `json:"meta,omitempty" mapstructure:"meta"`
 	Authentication AuthenticationConfig `json:"authentication,omitempty" mapstructure:"authentication"`
+	Audit          AuditSinkConfig      `json:"audit,omitempty" mapstructure:"audit"`
 }
 
 type Result struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -279,6 +279,7 @@ func defaultConfig() *Config {
 		},
 
 		Audit: AuditSinkConfig{
+			Version: "v0.1",
 			Sinks: SinksConfig{
 				LogFile: LogFileSinkConfig{
 					Enabled:  false,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -277,6 +277,18 @@ func defaultConfig() *Config {
 				StateLifetime: 10 * time.Minute,
 			},
 		},
+
+		Audit: AuditSinkConfig{
+			Sinks: SinksConfig{
+				LogFile: LogFileSinkConfig{
+					Enabled:  false,
+					FilePath: "./path/to/log/file",
+				},
+			},
+			Advanced: AdvancedConfig{
+				BufferSize: 2,
+			},
+		},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -287,7 +287,8 @@ func defaultConfig() *Config {
 				},
 			},
 			Buffer: BufferConfig{
-				Capacity: 2,
+				Capacity:    2,
+				FlushPeriod: 2 * time.Minute,
 			},
 		},
 	}
@@ -670,6 +671,11 @@ func TestLoad(t *testing.T) {
 			name:    "buffer size not within range",
 			path:    "./testdata/auditsink/invalid_buffersize.yml",
 			wantErr: errors.New("buffer capacity below 2 or above 10"),
+		},
+		{
+			name:    "flush period invalid",
+			path:    "./testdata/auditsink/invalid_flushperiod.yml",
+			wantErr: errors.New("flush period below 2 minutes or greater than 5 minutes"),
 		},
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -285,8 +285,8 @@ func defaultConfig() *Config {
 					FilePath: "./path/to/log/file",
 				},
 			},
-			Advanced: AdvancedConfig{
-				BufferSize: 2,
+			Buffer: BufferConfig{
+				Capacity: 2,
 			},
 		},
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -661,6 +661,16 @@ func TestLoad(t *testing.T) {
 			path:    "./testdata/version/invalid.yml",
 			wantErr: errors.New("invalid version: 2.0"),
 		},
+		{
+			name:    "audit sink version invalid",
+			path:    "./testdata/auditsink/invalid_version.yml",
+			wantErr: errors.New("unrecognized version v1000"),
+		},
+		{
+			name:    "buffer size not within range",
+			path:    "./testdata/auditsink/invalid_buffersize.yml",
+			wantErr: errors.New("buffer capacity below 2 or above 10"),
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/testdata/auditsink/invalid_buffersize.yml
+++ b/internal/config/testdata/auditsink/invalid_buffersize.yml
@@ -5,3 +5,4 @@ audit:
       filePath: ./log.txt
   buffer:
     capacity: 1000
+    flushPeriod: 3m

--- a/internal/config/testdata/auditsink/invalid_buffersize.yml
+++ b/internal/config/testdata/auditsink/invalid_buffersize.yml
@@ -1,0 +1,7 @@
+audit:
+  sinks:
+    logFile:
+      enabled: true
+      filePath: ./log.txt
+  buffer:
+    capacity: 1000

--- a/internal/config/testdata/auditsink/invalid_flushperiod.yml
+++ b/internal/config/testdata/auditsink/invalid_flushperiod.yml
@@ -1,9 +1,9 @@
 audit:
-  version: v1000
+  version: v0.1
   sinks:
     logFile:
       enabled: true
       filePath: ./log.txt
   buffer:
     capacity: 2
-    flushPeriod: 3m
+    flushPeriod: 30m

--- a/internal/config/testdata/auditsink/invalid_version.yml
+++ b/internal/config/testdata/auditsink/invalid_version.yml
@@ -1,7 +1,8 @@
 audit:
+  version: v1000
   sinks:
     logFile:
       enabled: true
       filePath: ./log.txt
-  advanced:
-    bufferSize: 2
+  buffer:
+    capacity: 2

--- a/internal/config/testdata/auditsink/sample.yml
+++ b/internal/config/testdata/auditsink/sample.yml
@@ -1,0 +1,7 @@
+audit:
+  sinks:
+    logFile:
+      enabled: true
+      filePath: ./log.txt
+  advanced:
+    bufferSize: 2

--- a/internal/server/auditsink/auditsink.go
+++ b/internal/server/auditsink/auditsink.go
@@ -1,0 +1,22 @@
+package auditsink
+
+import (
+	"fmt"
+)
+
+// AuditEvents is a shared package variable that will be mutated during
+// RPC requests. This allows us to send audit events to the configured
+// sinks asynchronously.
+var AuditEvents []*AuditEvent
+
+// AuditEvent holds information that represents an audit internally.
+type AuditEvent struct {
+	ResourceName string `json:"resourceName"`
+}
+
+// AuditSink is the abstraction for various audit sink configurations
+// that Flipt will support.
+type AuditSink interface {
+	SendAudits([]*AuditEvent) error
+	fmt.Stringer
+}

--- a/internal/server/auditsink/auditsink.go
+++ b/internal/server/auditsink/auditsink.go
@@ -15,15 +15,16 @@ type AuditType string
 type AuditAction string
 
 const (
-	FlagType         AuditType = "flag"
-	VariantType      AuditType = "variant"
-	SegmentType      AuditType = "segment"
 	ConstraintType   AuditType = "constraint"
 	DistributionType AuditType = "distribution"
+	FlagType         AuditType = "flag"
+	RuleType         AuditType = "rule"
+	SegmentType      AuditType = "segment"
+	VariantType      AuditType = "variant"
 
 	CreateAction AuditAction = "created"
-	UpdateAction AuditAction = "updated"
 	DeleteAction AuditAction = "deleted"
+	UpdateAction AuditAction = "updated"
 )
 
 // AuditEvent holds information that represents an audit internally.

--- a/internal/server/auditsink/auditsink.go
+++ b/internal/server/auditsink/auditsink.go
@@ -2,12 +2,10 @@ package auditsink
 
 import (
 	"fmt"
-)
+	"sync"
 
-// AuditEvents is a shared package variable that will be mutated during
-// RPC requests. This allows us to send audit events to the configured
-// sinks asynchronously.
-var AuditEvents []*AuditEvent
+	"go.uber.org/zap"
+)
 
 // AuditEvent holds information that represents an audit internally.
 type AuditEvent struct {
@@ -17,6 +15,55 @@ type AuditEvent struct {
 // AuditSink is the abstraction for various audit sink configurations
 // that Flipt will support.
 type AuditSink interface {
-	SendAudits([]*AuditEvent) error
+	SendAudits([]AuditEvent) error
 	fmt.Stringer
+}
+
+// Publisher holds information about the configured sinks that we are going
+// to send audit events to.
+type Publisher struct {
+	mtx         sync.Mutex
+	logger      *zap.Logger
+	bufferSize  int
+	sinks       []AuditSink
+	auditEvents []AuditEvent
+}
+
+// NewPublisher is the constructor for a Publisher.
+func NewPublisher(logger *zap.Logger, bufferSize int, sinks []AuditSink) *Publisher {
+	return &Publisher{
+		logger:      logger,
+		bufferSize:  bufferSize,
+		sinks:       sinks,
+		auditEvents: make([]AuditEvent, 0),
+	}
+}
+
+// Publish sends audit events over to the configured sinks when the buffer sized is reached.
+// The shared state here are the audit events which are initialized when a Publisher is constructed.
+//
+// This Publish method has to be concurrent-safe, due to the nature of gRPC requests to the server.
+func (p *Publisher) Publish(auditEvent *AuditEvent) {
+	if len(p.auditEvents) < p.bufferSize {
+		p.mtx.Lock()
+		defer p.mtx.Unlock()
+		p.auditEvents = append(p.auditEvents, *auditEvent)
+		return
+	}
+
+	p.mtx.Lock()
+	copiedEvents := make([]AuditEvent, len(p.auditEvents))
+	copy(copiedEvents, p.auditEvents)
+	p.auditEvents = make([]AuditEvent, 0)
+	p.auditEvents = append(p.auditEvents, *auditEvent)
+	p.mtx.Unlock()
+
+	for _, sink := range p.sinks {
+		go func(s AuditSink) {
+			err := s.SendAudits(copiedEvents)
+			if err != nil {
+				p.logger.Warn("Failed to send audits to sink", zap.Stringer("sink", s))
+			}
+		}(sink)
+	}
 }

--- a/internal/server/auditsink/auditsink_test.go
+++ b/internal/server/auditsink/auditsink_test.go
@@ -1,0 +1,58 @@
+package auditsink
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"gotest.tools/assert"
+)
+
+const (
+	retries = 10
+)
+
+type sampleSink struct {
+	mtx  sync.Mutex
+	hits int
+	fmt.Stringer
+}
+
+func (s *sampleSink) SendAudits([]AuditEvent) error {
+	s.mtx.Lock()
+	s.hits++
+	s.mtx.Unlock()
+
+	return nil
+}
+
+func TestPublisher(t *testing.T) {
+	ss := &sampleSink{}
+	publisher := NewPublisher(zap.NewNop(), 2, []AuditSink{ss}, 10*time.Second)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			publisher.Publish(&AuditEvent{
+				ResourceName: "sample-flag",
+			})
+		}()
+	}
+
+	wg.Wait()
+
+	<-time.After(10 * time.Second)
+
+	for i := 0; i < retries; i++ {
+		if ss.hits == 5 {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	assert.Equal(t, ss.hits, 5)
+}

--- a/internal/server/auditsink/auditsink_test.go
+++ b/internal/server/auditsink/auditsink_test.go
@@ -36,7 +36,7 @@ func (s *sampleSink) GetHits() int {
 
 func TestPublisher(t *testing.T) {
 	ss := &sampleSink{}
-	publisher := NewPublisher(zap.NewNop(), 2, []AuditSink{ss}, 10*time.Second)
+	publisher := NewSinkPublisher(zap.NewNop(), 2, []AuditSink{ss}, 10*time.Second)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {

--- a/internal/server/auditsink/auditsink_test.go
+++ b/internal/server/auditsink/auditsink_test.go
@@ -28,6 +28,12 @@ func (s *sampleSink) SendAudits([]AuditEvent) error {
 	return nil
 }
 
+func (s *sampleSink) GetHits() int {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	return s.hits
+}
+
 func TestPublisher(t *testing.T) {
 	ss := &sampleSink{}
 	publisher := NewPublisher(zap.NewNop(), 2, []AuditSink{ss}, 10*time.Second)
@@ -48,11 +54,11 @@ func TestPublisher(t *testing.T) {
 	<-time.After(10 * time.Second)
 
 	for i := 0; i < retries; i++ {
-		if ss.hits == 5 {
+		if ss.GetHits() == 5 {
 			break
 		}
 		time.Sleep(1 * time.Second)
 	}
 
-	assert.Equal(t, ss.hits, 5)
+	assert.Equal(t, ss.GetHits(), 5)
 }

--- a/internal/server/auditsink/auditsink_test.go
+++ b/internal/server/auditsink/auditsink_test.go
@@ -43,9 +43,7 @@ func TestPublisher(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			publisher.Publish(&AuditEvent{
-				ResourceName: "sample-flag",
-			})
+			publisher.Publish(&AuditEvent{})
 		}()
 	}
 

--- a/internal/server/auditsink/logfile/logfile.go
+++ b/internal/server/auditsink/logfile/logfile.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"go.flipt.io/flipt/internal/server/auditsink"
+	"go.uber.org/zap"
 )
 
 const sinkType = "logfile"
@@ -11,22 +12,27 @@ const sinkType = "logfile"
 // LogFileSink is the structure in charge of sending Audits
 // to a specified file location.
 type LogFileSink struct {
-	File *os.File
+	logger *zap.Logger
+	file   *os.File
 }
 
 // NewLogFileSink is the constructor for a LogFileSink.
-func NewLogFileSink(filePath string) (*LogFileSink, error) {
+func NewLogFileSink(logger *zap.Logger, filePath string) (*LogFileSink, error) {
 	file, err := os.Create(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	return &LogFileSink{
-		File: file,
-	}, nil
+	lfs := &LogFileSink{
+		logger: logger,
+		file:   file,
+	}
+
+	return lfs, nil
 }
 
-func (l *LogFileSink) SendAudits(auditEvents []*auditsink.AuditEvent) error {
+func (l *LogFileSink) SendAudits(auditEvents []auditsink.AuditEvent) error {
+	l.logger.Debug("performing batched sending of audits", zap.Stringer("sink", l))
 	return nil
 }
 

--- a/internal/server/auditsink/logfile/logfile.go
+++ b/internal/server/auditsink/logfile/logfile.go
@@ -1,7 +1,9 @@
 package logfile
 
 import (
+	"encoding/json"
 	"os"
+	"sync"
 
 	"go.flipt.io/flipt/internal/server/auditsink"
 	"go.uber.org/zap"
@@ -9,11 +11,11 @@ import (
 
 const sinkType = "logfile"
 
-// LogFileSink is the structure in charge of sending Audits
-// to a specified file location.
+// LogFileSink is the structure in charge of sending Audits to a specified file location.
 type LogFileSink struct {
 	logger *zap.Logger
 	file   *os.File
+	mtx    sync.Mutex
 }
 
 // NewLogFileSink is the constructor for a LogFileSink.
@@ -33,6 +35,20 @@ func NewLogFileSink(logger *zap.Logger, filePath string) (*LogFileSink, error) {
 
 func (l *LogFileSink) SendAudits(auditEvents []auditsink.AuditEvent) error {
 	l.logger.Debug("performing batched sending of audits", zap.Stringer("sink", l))
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	for _, ae := range auditEvents {
+		b, err := json.Marshal(ae)
+		if err != nil {
+			l.logger.Error("failed to encode audit event", zap.Stringer("sink", l))
+			continue
+		}
+		_, err = l.file.Write(append(b, '\n'))
+		if err != nil {
+			l.logger.Error("failed to write audit event to file", zap.String("file", l.file.Name()))
+			continue
+		}
+	}
 	return nil
 }
 

--- a/internal/server/auditsink/logfile/logfile.go
+++ b/internal/server/auditsink/logfile/logfile.go
@@ -1,0 +1,35 @@
+package logfile
+
+import (
+	"os"
+
+	"go.flipt.io/flipt/internal/server/auditsink"
+)
+
+const sinkType = "logfile"
+
+// LogFileSink is the structure in charge of sending Audits
+// to a specified file location.
+type LogFileSink struct {
+	File *os.File
+}
+
+// NewLogFileSink is the constructor for a LogFileSink.
+func NewLogFileSink(filePath string) (*LogFileSink, error) {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LogFileSink{
+		File: file,
+	}, nil
+}
+
+func (l *LogFileSink) SendAudits(auditEvents []*auditsink.AuditEvent) error {
+	return nil
+}
+
+func (l *LogFileSink) String() string {
+	return sinkType
+}

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -236,7 +236,9 @@ func CacheUnaryInterceptor(cache cache.Cacher, logger *zap.Logger) grpc.UnarySer
 }
 
 // AuditSinkUnaryInterceptor sends audit logs to configured sinks upon successful RPC requests for auditable events.
-func AuditSinkUnaryInterceptor(logger *zap.Logger, publisher *auditsink.Publisher) grpc.UnaryServerInterceptor {
+func AuditSinkUnaryInterceptor(logger *zap.Logger, publisher interface {
+	Publish(*auditsink.AuditEvent)
+}) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		resp, err := handler(ctx, req)
 		if err != nil {

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -278,6 +278,12 @@ func AuditSinkUnaryInterceptor(logger *zap.Logger, publisher interface {
 			auditEvent = auditsink.NewAuditEvent(auditsink.DistributionType, auditsink.UpdateAction, r, auditEventVersion)
 		case *flipt.DeleteDistributionRequest:
 			auditEvent = auditsink.NewAuditEvent(auditsink.DistributionType, auditsink.DeleteAction, r, auditEventVersion)
+		case *flipt.CreateRuleRequest:
+			auditEvent = auditsink.NewAuditEvent(auditsink.RuleType, auditsink.CreateAction, r, auditEventVersion)
+		case *flipt.UpdateRuleRequest:
+			auditEvent = auditsink.NewAuditEvent(auditsink.RuleType, auditsink.UpdateAction, r, auditEventVersion)
+		case *flipt.DeleteRuleRequest:
+			auditEvent = auditsink.NewAuditEvent(auditsink.RuleType, auditsink.DeleteAction, r, auditEventVersion)
 		}
 
 		if auditEvent != nil {

--- a/internal/server/middleware/grpc/support_test.go
+++ b/internal/server/middleware/grpc/support_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/stretchr/testify/mock"
+	"go.flipt.io/flipt/internal/server/auditsink"
 	"go.flipt.io/flipt/internal/server/cache"
 	"go.flipt.io/flipt/internal/storage"
 	flipt "go.flipt.io/flipt/rpc/flipt"
@@ -207,4 +208,25 @@ func (c *cacheSpy) Delete(ctx context.Context, key string) error {
 	c.deleteCalled++
 	c.deleteKeys[key] = struct{}{}
 	return c.Cacher.Delete(ctx, key)
+}
+
+type publisherSpy struct {
+	publisher interface {
+		Publish(*auditsink.AuditEvent)
+	}
+
+	publishCalled int
+}
+
+func newPublisherSpy(publisher interface {
+	Publish(*auditsink.AuditEvent)
+}) *publisherSpy {
+	return &publisherSpy{
+		publisher: publisher,
+	}
+}
+
+func (p *publisherSpy) Publish(auditEvent *auditsink.AuditEvent) {
+	p.publisher.Publish(auditEvent)
+	p.publishCalled++
 }


### PR DESCRIPTION
Providing the configuration and implementation for Audit Logging to configured sinks.

We eventually went to extend to include other native sinks but for now and purposes of this PR we will just provide a log file implementation.

The functionality works like this:
```
RPC request -> add to audit event buffer via `Publish` -> (buffer sized reached) send audits to sink asynchronously
```

More details on the internals of this PR are as follows:

## Publisher
1. Responsible for batching of audit event messages to send to configured sinks through configuration. Each call to the `Publish` method of the publisher can either add the event to the batch or flush the buffer down to the sinks
2. Runs an asynchronous method called `flushWhenNecessary` which will flush the buffer when a tick from a ticker goes off. This is to prevent events from lying in the buffer for an indefinite amount of time

## AuditSink
1. An abstraction of what we will use for audit events to be sent to the sinks. Each sink will provide an implementation of an `AuditSink`
2. Each time a `AuditSink` is added will warrant a new version of Flipt under the current paradigm. This might be not be ideal as this feature gets popular, and might lead us to move the abstraction to a library or make it pluggable

## Configuration
1. Sample configuration is as follows:
```yaml
audit:
  version: v0.1
  sinks:
    logFile:
      enabled: true
      filePath: ./log.txt
  buffer:
    capacity: 2
    flushPeriod: 2m
```
under the `sinks` key is where users will provide configuration for their sinks. There are validation constraints on the buffer capacity and version

# Linear Issues

Completes FLI-266
Completes FLI-265
Completes FLI-264
Completes FLI-263
Completes FLI-261
Completes FLI-259