### PR TITLE
chore: add remaining storage layer tests

### DIFF
--- a/internal/storage/sql/evaluation_test.go
+++ b/internal/storage/sql/evaluation_test.go
@@ -94,6 +94,96 @@ func (s *DBTestSuite) TestGetEvaluationRules() {
 	assert.Equal(t, 2, len(evaluationRules[1].Constraints))
 }
 
+func (s *DBTestSuite) TestGetEvaluationRulesNamespace() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		MatchType:    flipt.MatchType_ANY_MATCH_TYPE,
+	})
+
+	require.NoError(t, err)
+
+	// constraint 1
+	_, err = s.store.CreateConstraint(context.TODO(), &flipt.CreateConstraintRequest{
+		NamespaceKey: s.namespace,
+		SegmentKey:   segment.Key,
+		Type:         flipt.ComparisonType_STRING_COMPARISON_TYPE,
+		Property:     "foo",
+		Operator:     "EQ",
+		Value:        "bar",
+	})
+
+	require.NoError(t, err)
+
+	// constraint 2
+	_, err = s.store.CreateConstraint(context.TODO(), &flipt.CreateConstraintRequest{
+		NamespaceKey: s.namespace,
+		SegmentKey:   segment.Key,
+		Type:         flipt.ComparisonType_STRING_COMPARISON_TYPE,
+		Property:     "foz",
+		Operator:     "EQ",
+		Value:        "baz",
+	})
+
+	require.NoError(t, err)
+
+	// rule rank 1
+	rule1, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		SegmentKey:   segment.Key,
+		Rank:         1,
+	})
+
+	require.NoError(t, err)
+
+	// rule rank 2
+	rule2, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		SegmentKey:   segment.Key,
+		Rank:         2,
+	})
+
+	require.NoError(t, err)
+
+	evaluationRules, err := s.store.GetEvaluationRules(context.TODO(), s.namespace, flag.Key)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, evaluationRules)
+	assert.Equal(t, 2, len(evaluationRules))
+
+	assert.Equal(t, rule1.Id, evaluationRules[0].ID)
+	assert.Equal(t, s.namespace, evaluationRules[0].NamespaceKey)
+	assert.Equal(t, rule1.FlagKey, evaluationRules[0].FlagKey)
+	assert.Equal(t, rule1.SegmentKey, evaluationRules[0].SegmentKey)
+	assert.Equal(t, segment.MatchType, evaluationRules[0].SegmentMatchType)
+	assert.Equal(t, rule1.Rank, evaluationRules[0].Rank)
+	assert.Equal(t, 2, len(evaluationRules[0].Constraints))
+
+	assert.Equal(t, rule2.Id, evaluationRules[1].ID)
+	assert.Equal(t, s.namespace, evaluationRules[1].NamespaceKey)
+	assert.Equal(t, rule2.FlagKey, evaluationRules[1].FlagKey)
+	assert.Equal(t, rule2.SegmentKey, evaluationRules[1].SegmentKey)
+	assert.Equal(t, segment.MatchType, evaluationRules[1].SegmentMatchType)
+	assert.Equal(t, rule2.Rank, evaluationRules[1].Rank)
+	assert.Equal(t, 2, len(evaluationRules[1].Constraints))
+}
+
 func (s *DBTestSuite) TestGetEvaluationDistributions() {
 	t := s.T()
 
@@ -146,6 +236,109 @@ func (s *DBTestSuite) TestGetEvaluationDistributions() {
 		FlagKey:    flag.Key,
 		SegmentKey: segment.Key,
 		Rank:       1,
+	})
+
+	require.NoError(t, err)
+
+	// 50/50 distribution
+	_, err = s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
+		FlagKey:   flag.Key,
+		RuleId:    rule.Id,
+		VariantId: variant1.Id,
+		Rollout:   50.00,
+	})
+
+	// required for MySQL since it only s.stores timestamps to the second and not millisecond granularity
+	time.Sleep(1 * time.Second)
+
+	require.NoError(t, err)
+
+	_, err = s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
+		FlagKey:   flag.Key,
+		RuleId:    rule.Id,
+		VariantId: variant2.Id,
+		Rollout:   50.00,
+	})
+
+	require.NoError(t, err)
+
+	evaluationDistributions, err := s.store.GetEvaluationDistributions(context.TODO(), rule.Id)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(evaluationDistributions))
+
+	assert.NotEmpty(t, evaluationDistributions[0].ID)
+	assert.Equal(t, rule.Id, evaluationDistributions[0].RuleID)
+	assert.Equal(t, variant1.Id, evaluationDistributions[0].VariantID)
+	assert.Equal(t, variant1.Key, evaluationDistributions[0].VariantKey)
+	assert.Equal(t, float32(50.00), evaluationDistributions[0].Rollout)
+
+	assert.NotEmpty(t, evaluationDistributions[1].ID)
+	assert.Equal(t, rule.Id, evaluationDistributions[1].RuleID)
+	assert.Equal(t, variant2.Id, evaluationDistributions[1].VariantID)
+	assert.Equal(t, variant2.Key, evaluationDistributions[1].VariantKey)
+	assert.Equal(t, `{"key2":"value2"}`, evaluationDistributions[1].VariantAttachment)
+	assert.Equal(t, float32(50.00), evaluationDistributions[1].Rollout)
+}
+
+func (s *DBTestSuite) TestGetEvaluationDistributionsNamespace() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+
+	// variant 1
+	variant1, err := s.store.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Key:          "foo",
+	})
+
+	require.NoError(t, err)
+
+	// variant 2
+	variant2, err := s.store.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Key:          "bar",
+		Attachment:   `{"key2":   "value2"}`,
+	})
+
+	require.NoError(t, err)
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		MatchType:    flipt.MatchType_ANY_MATCH_TYPE,
+	})
+
+	require.NoError(t, err)
+
+	_, err = s.store.CreateConstraint(context.TODO(), &flipt.CreateConstraintRequest{
+		NamespaceKey: s.namespace,
+		SegmentKey:   segment.Key,
+		Type:         flipt.ComparisonType_STRING_COMPARISON_TYPE,
+		Property:     "foo",
+		Operator:     "EQ",
+		Value:        "bar",
+	})
+
+	require.NoError(t, err)
+
+	rule, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		SegmentKey:   segment.Key,
+		Rank:         1,
 	})
 
 	require.NoError(t, err)

--- a/internal/storage/sql/rule_test.go
+++ b/internal/storage/sql/rule_test.go
@@ -68,11 +68,77 @@ func (s *DBTestSuite) TestGetRule() {
 	assert.NotZero(t, got.UpdatedAt)
 }
 
+func (s *DBTestSuite) TestGetRuleNamespace() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	variant, err := s.store.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant)
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segment)
+
+	rule, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		SegmentKey:   segment.Key,
+		Rank:         1,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, rule)
+
+	got, err := s.store.GetRule(context.TODO(), s.namespace, rule.Id)
+
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+
+	assert.Equal(t, rule.Id, got.Id)
+	assert.Equal(t, s.namespace, got.NamespaceKey)
+	assert.Equal(t, rule.FlagKey, got.FlagKey)
+	assert.Equal(t, rule.SegmentKey, got.SegmentKey)
+	assert.Equal(t, rule.Rank, got.Rank)
+	assert.NotZero(t, got.CreatedAt)
+	assert.NotZero(t, got.UpdatedAt)
+}
+
 func (s *DBTestSuite) TestGetRule_NotFound() {
 	t := s.T()
 
 	_, err := s.store.GetRule(context.TODO(), storage.DefaultNamespace, "0")
 	assert.EqualError(t, err, "rule \"default/0\" not found")
+}
+
+func (s *DBTestSuite) TestGetRuleNamespace_NotFound() {
+	t := s.T()
+
+	_, err := s.store.GetRule(context.TODO(), s.namespace, "0")
+	assert.EqualError(t, err, fmt.Sprintf("rule \"%s/0\" not found", s.namespace))
 }
 
 func (s *DBTestSuite) TestListRules() {
@@ -133,6 +199,74 @@ func (s *DBTestSuite) TestListRules() {
 
 	for _, rule := range got {
 		assert.Equal(t, storage.DefaultNamespace, rule.NamespaceKey)
+		assert.NotZero(t, rule.CreatedAt)
+		assert.NotZero(t, rule.UpdatedAt)
+	}
+}
+
+func (s *DBTestSuite) TestListRulesNamespace() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	variant, err := s.store.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant)
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segment)
+
+	reqs := []*flipt.CreateRuleRequest{
+		{
+			NamespaceKey: s.namespace,
+			FlagKey:      flag.Key,
+			SegmentKey:   segment.Key,
+			Rank:         1,
+		},
+		{
+			NamespaceKey: s.namespace,
+			FlagKey:      flag.Key,
+			SegmentKey:   segment.Key,
+			Rank:         2,
+		},
+	}
+
+	for _, req := range reqs {
+		_, err := s.store.CreateRule(context.TODO(), req)
+		require.NoError(t, err)
+	}
+
+	res, err := s.store.ListRules(context.TODO(), s.namespace, flag.Key)
+	require.NoError(t, err)
+
+	got := res.Results
+	assert.NotZero(t, len(got))
+
+	for _, rule := range got {
+		assert.Equal(t, s.namespace, rule.NamespaceKey)
 		assert.NotZero(t, rule.CreatedAt)
 		assert.NotZero(t, rule.UpdatedAt)
 	}
@@ -333,25 +467,74 @@ func (s *DBTestSuite) TestCreateRuleAndDistribution() {
 	assert.Equal(t, float32(100), distribution.Rollout)
 	assert.NotZero(t, distribution.CreatedAt)
 	assert.Equal(t, distribution.CreatedAt.Seconds, distribution.UpdatedAt.Seconds)
+}
 
-	// TODO: create a rule with a different namespace
-	// rule, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
-	// 	NamespaceKey: "foo",
-	// 	FlagKey:    flag.Key,
-	// 	SegmentKey: segment.Key,
-	// 	Rank:       1,
-	// })
+func (s *DBTestSuite) TestCreateRuleAndDistributionNamespace() {
+	t := s.T()
 
-	// require.NoError(t, err)
-	// assert.NotNil(t, rule)
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
 
-	// assert.NotZero(t, rule.Id)
-	// assert.Equal(t, "foo", rule.NamespaceKey)
-	// assert.Equal(t, flag.Key, rule.FlagKey)
-	// assert.Equal(t, segment.Key, rule.SegmentKey)
-	// assert.Equal(t, int32(1), rule.Rank)
-	// assert.NotZero(t, rule.CreatedAt)
-	// assert.Equal(t, rule.CreatedAt.Seconds, rule.UpdatedAt.Seconds)
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	variant, err := s.store.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant)
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segment)
+
+	rule, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		SegmentKey:   segment.Key,
+		Rank:         1,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, rule)
+
+	assert.Equal(t, s.namespace, rule.NamespaceKey)
+	assert.NotZero(t, rule.Id)
+	assert.Equal(t, flag.Key, rule.FlagKey)
+	assert.Equal(t, segment.Key, rule.SegmentKey)
+	assert.Equal(t, int32(1), rule.Rank)
+	assert.NotZero(t, rule.CreatedAt)
+	assert.Equal(t, rule.CreatedAt.Seconds, rule.UpdatedAt.Seconds)
+
+	distribution, err := s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
+		RuleId:    rule.Id,
+		VariantId: variant.Id,
+		Rollout:   100,
+	})
+
+	require.NoError(t, err)
+	assert.NotZero(t, distribution.Id)
+	assert.Equal(t, rule.Id, distribution.RuleId)
+	assert.Equal(t, variant.Id, distribution.VariantId)
+	assert.Equal(t, float32(100), distribution.Rollout)
+	assert.NotZero(t, distribution.CreatedAt)
+	assert.Equal(t, distribution.CreatedAt.Seconds, distribution.UpdatedAt.Seconds)
 }
 
 func (s *DBTestSuite) TestCreateDistribution_NoRule() {
@@ -398,6 +581,19 @@ func (s *DBTestSuite) TestCreateRule_FlagNotFound() {
 	assert.EqualError(t, err, "flag \"default/foo\" or segment \"default/bar\" not found")
 }
 
+func (s *DBTestSuite) TestCreateRuleNamespace_FlagNotFound() {
+	t := s.T()
+
+	_, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      "foo",
+		SegmentKey:   "bar",
+		Rank:         1,
+	})
+
+	assert.EqualError(t, err, fmt.Sprintf("flag \"%s/foo\" or segment \"%s/bar\" not found", s.namespace, s.namespace))
+}
+
 func (s *DBTestSuite) TestCreateRule_SegmentNotFound() {
 	t := s.T()
 
@@ -418,6 +614,30 @@ func (s *DBTestSuite) TestCreateRule_SegmentNotFound() {
 	})
 
 	assert.EqualError(t, err, "flag \"default/TestDBTestSuite/TestCreateRule_SegmentNotFound\" or segment \"default/foo\" not found")
+}
+
+func (s *DBTestSuite) TestCreateRuleNamespace_SegmentNotFound() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	_, err = s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		SegmentKey:   "foo",
+		Rank:         1,
+	})
+
+	assert.EqualError(t, err, fmt.Sprintf("flag \"%s/%s\" or segment \"%s/foo\" not found", s.namespace, t.Name(), s.namespace))
 }
 
 func (s *DBTestSuite) TestUpdateRuleAndDistribution() {
@@ -530,6 +750,124 @@ func (s *DBTestSuite) TestUpdateRuleAndDistribution() {
 	require.NoError(t, err)
 }
 
+func (s *DBTestSuite) TestUpdateRuleAndDistributionNamespace() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	variant, err := s.store.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant)
+
+	segmentOne, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          fmt.Sprintf("%s_one", t.Name()),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segmentOne)
+
+	rule, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		SegmentKey:   segmentOne.Key,
+		Rank:         1,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, rule)
+
+	assert.Equal(t, s.namespace, rule.NamespaceKey)
+	assert.NotZero(t, rule.Id)
+	assert.Equal(t, flag.Key, rule.FlagKey)
+	assert.Equal(t, segmentOne.Key, rule.SegmentKey)
+	assert.Equal(t, int32(1), rule.Rank)
+	assert.NotZero(t, rule.CreatedAt)
+	assert.Equal(t, rule.CreatedAt.Seconds, rule.UpdatedAt.Seconds)
+
+	distribution, err := s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
+		RuleId:    rule.Id,
+		VariantId: variant.Id,
+		Rollout:   100,
+	})
+
+	require.NoError(t, err)
+	assert.NotZero(t, distribution.Id)
+	assert.Equal(t, rule.Id, distribution.RuleId)
+	assert.Equal(t, variant.Id, distribution.VariantId)
+	assert.Equal(t, float32(100), distribution.Rollout)
+	assert.NotZero(t, distribution.CreatedAt)
+	assert.Equal(t, distribution.CreatedAt.Seconds, distribution.UpdatedAt.Seconds)
+
+	segmentTwo, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          fmt.Sprintf("%s_two", t.Name()),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segmentTwo)
+
+	updatedRule, err := s.store.UpdateRule(context.TODO(), &flipt.UpdateRuleRequest{
+		NamespaceKey: s.namespace,
+		Id:           rule.Id,
+		FlagKey:      flag.Key,
+		SegmentKey:   segmentTwo.Key,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, updatedRule)
+
+	assert.Equal(t, s.namespace, rule.NamespaceKey)
+	assert.Equal(t, rule.Id, updatedRule.Id)
+	assert.Equal(t, rule.FlagKey, updatedRule.FlagKey)
+	assert.Equal(t, segmentTwo.Key, updatedRule.SegmentKey)
+	assert.Equal(t, int32(1), updatedRule.Rank)
+	// assert.Equal(t, rule.CreatedAt.Seconds, updatedRule.CreatedAt.Seconds)
+	assert.NotZero(t, rule.UpdatedAt)
+
+	updatedDistribution, err := s.store.UpdateDistribution(context.TODO(), &flipt.UpdateDistributionRequest{
+		Id:        distribution.Id,
+		RuleId:    rule.Id,
+		VariantId: variant.Id,
+		Rollout:   10,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, distribution.Id, updatedDistribution.Id)
+	assert.Equal(t, rule.Id, updatedDistribution.RuleId)
+	assert.Equal(t, variant.Id, updatedDistribution.VariantId)
+	assert.Equal(t, float32(10), updatedDistribution.Rollout)
+	// assert.Equal(t, distribution.CreatedAt.Seconds, updatedDistribution.CreatedAt.Seconds)
+	assert.NotZero(t, rule.UpdatedAt)
+
+	err = s.store.DeleteDistribution(context.TODO(), &flipt.DeleteDistributionRequest{
+		Id:        distribution.Id,
+		RuleId:    rule.Id,
+		VariantId: variant.Id,
+	})
+	require.NoError(t, err)
+}
+
 func (s *DBTestSuite) TestUpdateRule_NotFound() {
 	t := s.T()
 
@@ -559,6 +897,40 @@ func (s *DBTestSuite) TestUpdateRule_NotFound() {
 	})
 
 	assert.EqualError(t, err, "rule \"default/foo\" not found")
+}
+
+func (s *DBTestSuite) TestUpdateRuleNamespace_NotFound() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segment)
+
+	_, err = s.store.UpdateRule(context.TODO(), &flipt.UpdateRuleRequest{
+		NamespaceKey: s.namespace,
+		Id:           "foo",
+		FlagKey:      flag.Key,
+		SegmentKey:   segment.Key,
+	})
+
+	assert.EqualError(t, err, fmt.Sprintf("rule \"%s/foo\" not found", s.namespace))
 }
 
 func (s *DBTestSuite) TestDeleteRule() {
@@ -631,6 +1003,81 @@ func (s *DBTestSuite) TestDeleteRule() {
 	assert.Equal(t, storage.DefaultNamespace, got[1].NamespaceKey)
 }
 
+func (s *DBTestSuite) TestDeleteRuleNamespace() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	variant, err := s.store.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant)
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segment)
+
+	var rules []*flipt.Rule
+
+	// create 3 rules
+	for i := 0; i < 3; i++ {
+		rule, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+			NamespaceKey: s.namespace,
+			FlagKey:      flag.Key,
+			SegmentKey:   segment.Key,
+			Rank:         int32(i + 1),
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, rule)
+		rules = append(rules, rule)
+	}
+
+	// delete second rule
+	err = s.store.DeleteRule(context.TODO(), &flipt.DeleteRuleRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Id:           rules[1].Id,
+	})
+
+	require.NoError(t, err)
+
+	res, err := s.store.ListRules(context.TODO(), s.namespace, flag.Key)
+	// ensure rules are in correct order
+	require.NoError(t, err)
+
+	got := res.Results
+	assert.NotNil(t, got)
+	assert.Equal(t, 2, len(got))
+	assert.Equal(t, rules[0].Id, got[0].Id)
+	assert.Equal(t, int32(1), got[0].Rank)
+	assert.Equal(t, s.namespace, got[0].NamespaceKey)
+	assert.Equal(t, rules[2].Id, got[1].Id)
+	assert.Equal(t, int32(2), got[1].Rank)
+	assert.Equal(t, s.namespace, got[1].NamespaceKey)
+}
+
 func (s *DBTestSuite) TestDeleteRule_NotFound() {
 	t := s.T()
 
@@ -647,6 +1094,29 @@ func (s *DBTestSuite) TestDeleteRule_NotFound() {
 	err = s.store.DeleteRule(context.TODO(), &flipt.DeleteRuleRequest{
 		Id:      "foo",
 		FlagKey: flag.Key,
+	})
+
+	require.NoError(t, err)
+}
+
+func (s *DBTestSuite) TestDeleteRuleNamespace_NotFound() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	err = s.store.DeleteRule(context.TODO(), &flipt.DeleteRuleRequest{
+		NamespaceKey: s.namespace,
+		Id:           "foo",
+		FlagKey:      flag.Key,
 	})
 
 	require.NoError(t, err)
@@ -734,4 +1204,93 @@ func (s *DBTestSuite) TestOrderRules() {
 	assert.Equal(t, rules[2].Id, got[2].Id)
 	assert.Equal(t, int32(3), got[2].Rank)
 	assert.Equal(t, storage.DefaultNamespace, got[2].NamespaceKey)
+}
+
+func (s *DBTestSuite) TestOrderRulesNamespace() {
+	t := s.T()
+
+	flag, err := s.store.CreateFlag(context.TODO(), &flipt.CreateFlagRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+		Enabled:      true,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, flag)
+
+	variant, err := s.store.CreateVariant(context.TODO(), &flipt.CreateVariantRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, variant)
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		NamespaceKey: s.namespace,
+		Key:          t.Name(),
+		Name:         "foo",
+		Description:  "bar",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segment)
+
+	var rules []*flipt.Rule
+
+	// create 3 rules
+	for i := 0; i < 3; i++ {
+		rule, err := s.store.CreateRule(context.TODO(), &flipt.CreateRuleRequest{
+			NamespaceKey: s.namespace,
+			FlagKey:      flag.Key,
+			SegmentKey:   segment.Key,
+			Rank:         int32(i + 1),
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, rule)
+		rules = append(rules, rule)
+	}
+
+	// order rules in reverse order
+	sort.Slice(rules, func(i, j int) bool { return rules[i].Rank > rules[j].Rank })
+
+	var ruleIds []string
+	for _, rule := range rules {
+		ruleIds = append(ruleIds, rule.Id)
+	}
+
+	// re-order rules
+	err = s.store.OrderRules(context.TODO(), &flipt.OrderRulesRequest{
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		RuleIds:      ruleIds,
+	})
+
+	require.NoError(t, err)
+
+	res, err := s.store.ListRules(context.TODO(), s.namespace, flag.Key)
+
+	// ensure rules are in correct order
+	require.NoError(t, err)
+	got := res.Results
+	assert.NotNil(t, got)
+	assert.Equal(t, 3, len(got))
+
+	assert.Equal(t, rules[0].Id, got[0].Id)
+	assert.Equal(t, int32(1), got[0].Rank)
+	assert.Equal(t, s.namespace, got[0].NamespaceKey)
+
+	assert.Equal(t, rules[1].Id, got[1].Id)
+	assert.Equal(t, int32(2), got[1].Rank)
+	assert.Equal(t, s.namespace, got[1].NamespaceKey)
+
+	assert.Equal(t, rules[2].Id, got[2].Id)
+	assert.Equal(t, int32(3), got[2].Rank)
+	assert.Equal(t, s.namespace, got[2].NamespaceKey)
 }


### PR DESCRIPTION
Fixes: FLI-244

Adds remaining rule and evaluation namespace tests for storage layer