### PR TITLE
feat(hack/build): add workflow to tag submodule releases when they change

### DIFF
--- a/.github/workflows/release-submodules.yml
+++ b/.github/workflows/release-submodules.yml
@@ -1,0 +1,45 @@
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Flipt release version tag
+        required: true
+
+name: Various Updates Post Release
+jobs:
+  release_client:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Change to build directory
+        run: "cd hack/build"
+
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private_key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          installation_id: ${{ secrets.FLIPT_RELEASE_BOT_INSTALLATION_ID }}
+
+      - name: "Tag Submodules (Dispatch)"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        uses: magefile/mage-action@v2
+        with:
+          args: "release:submodules ${{ inputs.tag }}"
+
+      - name: Tag Submodules (Release)
+        if: ${{ github.event_name == 'push' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        uses: magefile/mage-action@v2
+        with:
+          args: "release:submodules ${{ github.ref_name }}"

--- a/go.work.sum
+++ b/go.work.sum
@@ -605,6 +605,7 @@ github.com/phpdave11/gofpdi v1.0.12 h1:RZb9NG62cw/RW0rHAduVRo+98R8o/G1krcg2ns7Da
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/sftp v1.13.1 h1:I2qBYMChEhIjOgazfJmV3/mZM256btk6wkCDRmW7JYs=
 github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5w=
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c h1:ncq/mPwQF4JjgDlrVEn3C11VoGHZN7m8qihwgMEtzYw=
@@ -699,8 +700,6 @@ go.etcd.io/etcd/server/v3 v3.5.0 h1:jk8D/lwGEDlQU9kZXUFMSANkE22Sg5+mW27ip8xcF9E=
 go.mongodb.org/mongo-driver v1.7.0 h1:hHrvOBWlWB2c7+8Gh/Xi5jj82AgidK/t7KVXBZ+IyUA=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1 h1:A/5uWzF44DlIgdm/PQFwfMkW0JX+cIcQi/SwLAmZP5M=
 go.opentelemetry.io/contrib v0.20.0 h1:ubFQUn0VCZ0gPwIoJfBJVpeBlyRMxu8Mm/huKWYd9p0=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0 h1:5jD3teb4Qh7mx/nfzq4jO2WFFpvXD0vYWFDrdvNWmXk=
-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0/go.mod h1:UMklln0+MRhZC4e3PwmN3pCtq4DyIadWw4yikh6bNrw=
 go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.29.0 h1:Wjp9vsVSIEyvdiaECfqxY9xBqQ7JaSCGtvHgR4doXZk=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.29.0 h1:SLme4Porm+UwX0DdHMxlwRt7FzPSE0sys81bet2o0pU=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=

--- a/hack/build/magefile.go
+++ b/hack/build/magefile.go
@@ -15,6 +15,7 @@ import (
 	"go.flipt.io/flipt/build/internal"
 	"go.flipt.io/flipt/build/internal/publish"
 	"go.flipt.io/flipt/build/internal/test"
+	"go.flipt.io/flipt/build/release"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/sync/errgroup"
 )
@@ -205,6 +206,17 @@ func (t Test) Integration(ctx context.Context) error {
 	}
 
 	return test.Integration(ctx, client, base, flipt)
+}
+
+type Release mg.Namespace
+
+func (r Release) Submodules(ctx context.Context, tag string) error {
+	client, err := daggerClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	return release.Submodules(ctx, client, tag)
 }
 
 func daggerClient(ctx context.Context) (*dagger.Client, error) {

--- a/hack/build/release/release.go
+++ b/hack/build/release/release.go
@@ -1,0 +1,91 @@
+package release
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"dagger.io/dagger"
+	"golang.org/x/mod/semver"
+)
+
+func Submodules(ctx context.Context, client *dagger.Client, tag string) error {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return errors.New("GITHUB_TOKEN is required")
+	}
+
+	base := client.Container().From("golang:1.20-alpine3.17").
+		WithExec([]string{"apk", "add", "-U", "--no-cache", "git"}).
+		WithExec([]string{"git", "clone", "https://github.com/flipt-io/flipt.git", "/src/flipt"}).
+		WithWorkdir("/src/flipt")
+
+	authenticated := base.WithExec([]string{"git", "config", "--global", "user.name", "flipt-automation[bot]"}).
+		WithExec([]string{"git", "config", "--global", "user.email", "dev@flipt.io"}).
+		WithExec([]string{"git", "config", "--global",
+			"http.https://github.com/.extraheader",
+			fmt.Sprintf("AUTHORIZATION: Bearer %s", token),
+		})
+
+	tagList, err := authenticated.WithExec([]string{"git", "tag", "--list", "v*"}).Stdout(ctx)
+	if err != nil {
+		return err
+	}
+
+	tags := strings.Split(tagList, "\n")
+	semver.Sort(tags)
+
+	lastTwo := tags[len(tags)-2:]
+
+	// ensure we only attempt to publish updates when requested
+	// tag matches the latest semver in default branch.
+	if lastTwo[1] != tag {
+		return fmt.Errorf("Publish tag %q does not match latest semver tag %q. Aborting.", lastTwo[1], tag)
+	}
+
+	for _, submodule := range []string{
+		"errors",
+		"rpc/flipt",
+	} {
+		if err := tagSubmodule(ctx, authenticated, submodule, lastTwo[0], lastTwo[1]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func tagSubmodule(ctx context.Context, container *dagger.Container, submodule, fromTag, toTag string) error {
+	diff, err := container.WithExec([]string{"git", "diff", "--shortstat", fromTag, toTag, "--", submodule}).Stdout(ctx)
+	if err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(diff) == "" {
+		fmt.Printf("Nothing changed between %q and %q. Skipping sub-module release.", fromTag, toTag)
+		return nil
+	}
+
+	target := path.Join(submodule, toTag)
+	container = container.
+		// checkout destination version tag
+		WithExec([]string{"git", "checkout", toTag}).
+		// tag with target submodule tag
+		WithExec([]string{
+			"git", "tag", "-am",
+			fmt.Sprintf("Releasing go.flipt.io/flipt/%s version %s", submodule, toTag),
+			target,
+		})
+
+	_, err = container.WithExec([]string{"git", "tag", "-n", target}).ExitCode(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = container.WithExec([]string{"git", "push", "origin", target}).ExitCode(ctx)
+
+	return err
+}


### PR DESCRIPTION
This is a WIP.

The purpose is to tag the new submodules on each core Flipt release.
The submodules included in this change are:
- `errors`
- `rpc/flipt`

The change introduces a github action on tag push and workflow dispatch which tags the submodules appropriately based on their directory prefixes.
The tag must be the latest tag according to git and semver ordering.