### PR TITLE
feat(sdk/go): prepare release v0.1.1

### DIFF
--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -3,6 +3,13 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.1.1
+
+### Changed
+
+- Upgraded `rpc/flipt` to `v1.19.3`
+- Upgraded `errors to `v1.19.3`
+
 ## v0.1.0
 
 ### Added

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Upgraded `rpc/flipt` to `v1.19.3`
-- Upgraded `errors to `v1.19.3`
+- Upgraded `errors` to `v1.19.3`
 
 ## v0.1.0
 

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -3,7 +3,7 @@ module go.flipt.io/flipt/sdk/go
 go 1.20
 
 require (
-	go.flipt.io/flipt/rpc/flipt v1.19.2
+	go.flipt.io/flipt/rpc/flipt v1.19.3
 	google.golang.org/genproto v0.0.0-20230320184635-7606e756e683
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 // indirect
-	go.flipt.io/flipt/errors v1.19.2 // indirect
+	go.flipt.io/flipt/errors v1.19.3 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect


### PR DESCRIPTION
This prepares the release of sdk/go to version `v0.1.1`.
It includes fixes to transient dependency versions.