### PR TITLE
chore: add go mod tidy lint step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,3 +59,21 @@ jobs:
         with:
           input: "rpc/flipt"
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=main"
+
+  go-mod-tidy:
+    name: "Go Mod Tidy"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+          check-latest: true
+          cache: true
+
+      - name: Run go mod tidy.
+        run: go mod tidy
+
+      - name: Ensure clean git state.
+        run: git describe --dirty | grep -v dirty || echo "Please run go mod tidy." && exit 1


### PR DESCRIPTION
Fixes #1432 

Adds a step to the linting which runs `go mod tidy` and looks for clean git state.