### PR TITLE
docs(sdk/go): add details regarding the HTTP transport

### DIFF
--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -6,6 +6,7 @@
 // [Transport] implementations can be found in the following sub-packages:
 //
 //   - [go.flipt.io/flipt/sdk/go/grpc.NewTransport]
+//   - [go.flipt.io/flipt/sdk/go/http.NewTransport]
 //
 // # GRPC Transport
 //
@@ -17,6 +18,15 @@
 //	    sdk := sdk.New(transport)
 //	}
 //
+// # HTTP Transport
+//
+// The following is an example of creating and instance of the SDK using the HTTP transport.
+//
+//	func main() {
+//	    transport := http.NewTransport("http://localhost:8080")
+//	    sdk := sdk.New(transport)
+//	}
+
 // # Authenticating the SDK
 //
 // The remote procedure calls mades by this SDK are authenticated via a [ClientTokenProvider] implementation.

--- a/sdk/go/example_test.go
+++ b/sdk/go/example_test.go
@@ -9,6 +9,7 @@ import (
 func ExampleNew() {
 	// see the following subpackages for transport implementations:
 	// - grpc
+	// - http
 	var transport Transport
 
 	client := New(transport)


### PR DESCRIPTION
Quick docs PR update to add HTTP transport details for consistency.