### PR TITLE
feat(hack/build): add cases for namespace scoped integration tests

### DIFF
--- a/hack/build/integration/integration.go
+++ b/hack/build/integration/integration.go
@@ -22,8 +22,14 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 
 		ctx := context.Background()
 
-		if namespace != "" {
-			t.Run("Namespaces", func(t *testing.T) {
+		t.Run("Namespaces", func(t *testing.T) {
+			_, err := client.Flipt().CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
+				Key:  "default",
+				Name: "Default",
+			})
+			require.EqualError(t, err, "rpc error: code = InvalidArgument desc = namespace \"default\" is not unique")
+
+			if namespace != "" {
 				t.Log(`Create namespace.`)
 
 				created, err := client.Flipt().CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
@@ -63,8 +69,8 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 				require.NoError(t, err)
 
 				assert.Equal(t, "Some kind of description", updated.Description)
-			})
-		}
+			}
+		})
 
 		t.Run("Flags and Variants", func(t *testing.T) {
 			t.Log("Create a new flag with key \"test\".")

--- a/hack/build/integration/integration.go
+++ b/hack/build/integration/integration.go
@@ -23,12 +23,6 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 		ctx := context.Background()
 
 		t.Run("Namespaces", func(t *testing.T) {
-			_, err := client.Flipt().CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
-				Key:  "default",
-				Name: "Default",
-			})
-			require.EqualError(t, err, "rpc error: code = InvalidArgument desc = namespace \"default\" is not unique")
-
 			if namespace != "" {
 				t.Log(`Create namespace.`)
 
@@ -69,6 +63,31 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 				require.NoError(t, err)
 
 				assert.Equal(t, "Some kind of description", updated.Description)
+			} else {
+				t.Log(`Ensure default cannot be created.`)
+
+				_, err := client.Flipt().CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
+					Key:  "default",
+					Name: "Default",
+				})
+				require.EqualError(t, err, "rpc error: code = InvalidArgument desc = namespace \"default\" is not unique")
+
+				t.Log(`Ensure default can be updated.`)
+
+				updated, err := client.Flipt().UpdateNamespace(ctx, &flipt.UpdateNamespaceRequest{
+					Key:         "default",
+					Name:        "Default",
+					Description: "Some namespace description.",
+				})
+				require.NoError(t, err)
+				assert.Equal(t, "Default", updated.Name)
+
+				t.Log(`Ensure default cannot be deleted.`)
+
+				err = client.Flipt().DeleteNamespace(ctx, &flipt.DeleteNamespaceRequest{
+					Key: "default",
+				})
+				require.EqualError(t, err, "rpc error: code = InvalidArgument desc = namespace \"default\" is protected")
 			}
 		})
 

--- a/hack/build/integration/integration.go
+++ b/hack/build/integration/integration.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/gofrs/uuid"
@@ -469,6 +470,16 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 		})
 
 		t.Run("Delete", func(t *testing.T) {
+			if namespace != "" {
+				t.Log(`Namespace with flags fails.`)
+				err := client.Flipt().DeleteNamespace(ctx, &flipt.DeleteNamespaceRequest{
+					Key: namespace,
+				})
+
+				msg := fmt.Sprintf("rpc error: code = InvalidArgument desc = namespace %q cannot be deleted; flags must be deleted first", namespace)
+				require.EqualError(t, err, msg)
+			}
+
 			t.Log(`Rules.`)
 			rules, err := client.Flipt().ListRules(ctx, &flipt.ListRuleRequest{
 				NamespaceKey: namespace,

--- a/hack/build/integration/integration.go
+++ b/hack/build/integration/integration.go
@@ -16,20 +16,65 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
+func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 	t.Run("Core Suite", func(t *testing.T) {
-		client := fn(t)
+		client, namespace := fn(t)
 
 		ctx := context.Background()
+
+		if namespace != "" {
+			t.Run("Namespaces", func(t *testing.T) {
+				t.Log(`Create namespace.`)
+
+				created, err := client.Flipt().CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
+					Key:  namespace,
+					Name: namespace,
+				})
+				require.NoError(t, err)
+
+				assert.Equal(t, namespace, created.Key)
+				assert.Equal(t, namespace, created.Name)
+
+				t.Log(`Get namespace by key.`)
+
+				retrieved, err := client.Flipt().GetNamespace(ctx, &flipt.GetNamespaceRequest{
+					Key: namespace,
+				})
+
+				assert.Equal(t, created.Name, retrieved.Name)
+
+				t.Log(`List namespaces.`)
+
+				namespaces, err := client.Flipt().ListNamespaces(ctx, &flipt.ListNamespaceRequest{})
+				require.NoError(t, err)
+
+				assert.Len(t, namespaces.Namespaces, 2)
+
+				assert.Equal(t, "default", namespaces.Namespaces[0].Key)
+				assert.Equal(t, namespace, namespaces.Namespaces[1].Key)
+
+				t.Log(`Update namespace.`)
+
+				updated, err := client.Flipt().UpdateNamespace(ctx, &flipt.UpdateNamespaceRequest{
+					Key:         namespace,
+					Name:        namespace,
+					Description: "Some kind of description",
+				})
+				require.NoError(t, err)
+
+				assert.Equal(t, "Some kind of description", updated.Description)
+			})
+		}
 
 		t.Run("Flags and Variants", func(t *testing.T) {
 			t.Log("Create a new flag with key \"test\".")
 
 			created, err := client.Flipt().CreateFlag(ctx, &flipt.CreateFlagRequest{
-				Key:         "test",
-				Name:        "Test",
-				Description: "This is a test flag",
-				Enabled:     true,
+				NamespaceKey: namespace,
+				Key:          "test",
+				Name:         "Test",
+				Description:  "This is a test flag",
+				Enabled:      true,
 			})
 			require.NoError(t, err)
 
@@ -40,7 +85,10 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 
 			t.Log("Retrieve flag with key \"test\".")
 
-			flag, err := client.Flipt().GetFlag(ctx, &flipt.GetFlagRequest{Key: "test"})
+			flag, err := client.Flipt().GetFlag(ctx, &flipt.GetFlagRequest{
+				NamespaceKey: namespace,
+				Key:          "test",
+			})
 			require.NoError(t, err)
 
 			assert.Equal(t, created, flag)
@@ -48,10 +96,11 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log("Update flag with key \"test\".")
 
 			updated, err := client.Flipt().UpdateFlag(ctx, &flipt.UpdateFlagRequest{
-				Key:         created.Key,
-				Name:        "Test 2",
-				Description: created.Description,
-				Enabled:     true,
+				NamespaceKey: namespace,
+				Key:          created.Key,
+				Name:         "Test 2",
+				Description:  created.Description,
+				Enabled:      true,
 			})
 			require.NoError(t, err)
 
@@ -59,7 +108,9 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 
 			t.Log("List all flags.")
 
-			flags, err := client.Flipt().ListFlags(ctx, &flipt.ListFlagRequest{})
+			flags, err := client.Flipt().ListFlags(ctx, &flipt.ListFlagRequest{
+				NamespaceKey: namespace,
+			})
 			require.NoError(t, err)
 
 			assert.Len(t, flags.Flags, 1)
@@ -71,9 +122,10 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 				t.Logf("Create variant with key %q.", key)
 
 				createdVariant, err := client.Flipt().CreateVariant(ctx, &flipt.CreateVariantRequest{
-					Key:     key,
-					Name:    key,
-					FlagKey: "test",
+					NamespaceKey: namespace,
+					Key:          key,
+					Name:         key,
+					FlagKey:      "test",
 				})
 				require.NoError(t, err)
 
@@ -83,7 +135,10 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 
 			t.Log("Get flag \"test\" and check variants.")
 
-			flag, err = client.Flipt().GetFlag(ctx, &flipt.GetFlagRequest{Key: "test"})
+			flag, err = client.Flipt().GetFlag(ctx, &flipt.GetFlagRequest{
+				NamespaceKey: namespace,
+				Key:          "test",
+			})
 			require.NoError(t, err)
 
 			assert.Len(t, flag.Variants, 2)
@@ -91,10 +146,11 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Update variant "one" (rename from "one" to "One").`)
 
 			updatedVariant, err := client.Flipt().UpdateVariant(ctx, &flipt.UpdateVariantRequest{
-				FlagKey: "test",
-				Id:      flag.Variants[0].Id,
-				Key:     "one",
-				Name:    "One",
+				NamespaceKey: namespace,
+				FlagKey:      "test",
+				Id:           flag.Variants[0].Id,
+				Key:          "one",
+				Name:         "One",
 			})
 			require.NoError(t, err)
 
@@ -106,9 +162,10 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Create segment "everyone".`)
 
 			createdSegment, err := client.Flipt().CreateSegment(ctx, &flipt.CreateSegmentRequest{
-				Key:       "everyone",
-				Name:      "Everyone",
-				MatchType: flipt.MatchType_ALL_MATCH_TYPE,
+				NamespaceKey: namespace,
+				Key:          "everyone",
+				Name:         "Everyone",
+				MatchType:    flipt.MatchType_ALL_MATCH_TYPE,
 			})
 			require.NoError(t, err)
 
@@ -119,7 +176,8 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Get segment "everyone".`)
 
 			retrievedSegment, err := client.Flipt().GetSegment(ctx, &flipt.GetSegmentRequest{
-				Key: "everyone",
+				NamespaceKey: namespace,
+				Key:          "everyone",
 			})
 			require.NoError(t, err)
 
@@ -131,8 +189,9 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Update segment "everyone" (rename "Everyone" to "All the peeps").`)
 
 			updatedSegment, err := client.Flipt().UpdateSegment(ctx, &flipt.UpdateSegmentRequest{
-				Key:  "everyone",
-				Name: "All the peeps",
+				NamespaceKey: namespace,
+				Key:          "everyone",
+				Name:         "All the peeps",
 			})
 			require.NoError(t, err)
 
@@ -153,11 +212,12 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 				)
 
 				createdConstraint, err := client.Flipt().CreateConstraint(ctx, &flipt.CreateConstraintRequest{
-					SegmentKey: "everyone",
-					Type:       flipt.ComparisonType_STRING_COMPARISON_TYPE,
-					Property:   constraint.property,
-					Operator:   constraint.operator,
-					Value:      constraint.value,
+					NamespaceKey: namespace,
+					SegmentKey:   "everyone",
+					Type:         flipt.ComparisonType_STRING_COMPARISON_TYPE,
+					Property:     constraint.property,
+					Operator:     constraint.operator,
+					Value:        constraint.value,
 				})
 				require.NoError(t, err)
 
@@ -169,7 +229,8 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Get segment "everyone" with constraints.`)
 
 			retrievedSegment, err = client.Flipt().GetSegment(ctx, &flipt.GetSegmentRequest{
-				Key: "everyone",
+				NamespaceKey: namespace,
+				Key:          "everyone",
 			})
 			require.NoError(t, err)
 
@@ -179,12 +240,13 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 
 			t.Log(`Update constraint value (from "bar" to "baz").`)
 			updatedConstraint, err := client.Flipt().UpdateConstraint(ctx, &flipt.UpdateConstraintRequest{
-				SegmentKey: "everyone",
-				Type:       retrievedSegment.Constraints[0].Type,
-				Id:         retrievedSegment.Constraints[0].Id,
-				Property:   retrievedSegment.Constraints[0].Property,
-				Operator:   retrievedSegment.Constraints[0].Operator,
-				Value:      "baz",
+				NamespaceKey: namespace,
+				SegmentKey:   "everyone",
+				Type:         retrievedSegment.Constraints[0].Type,
+				Id:           retrievedSegment.Constraints[0].Id,
+				Property:     retrievedSegment.Constraints[0].Property,
+				Operator:     retrievedSegment.Constraints[0].Operator,
+				Value:        "baz",
 			})
 			require.NoError(t, err)
 
@@ -198,9 +260,10 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Create rule "rank 1".`)
 
 			ruleOne, err := client.Flipt().CreateRule(ctx, &flipt.CreateRuleRequest{
-				FlagKey:    "test",
-				SegmentKey: "everyone",
-				Rank:       1,
+				NamespaceKey: namespace,
+				FlagKey:      "test",
+				SegmentKey:   "everyone",
+				Rank:         1,
 			})
 
 			require.NoError(t, err)
@@ -212,8 +275,9 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Get rules "rank 1".`)
 
 			retrievedRule, err := client.Flipt().GetRule(ctx, &flipt.GetRuleRequest{
-				FlagKey: "test",
-				Id:      ruleOne.Id,
+				NamespaceKey: namespace,
+				FlagKey:      "test",
+				Id:           ruleOne.Id,
 			})
 			require.NoError(t, err)
 
@@ -224,9 +288,10 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Create rule "rank 2".`)
 
 			ruleTwo, err := client.Flipt().CreateRule(ctx, &flipt.CreateRuleRequest{
-				FlagKey:    "test",
-				SegmentKey: "everyone",
-				Rank:       2,
+				NamespaceKey: namespace,
+				FlagKey:      "test",
+				SegmentKey:   "everyone",
+				Rank:         2,
 			})
 
 			require.NoError(t, err)
@@ -238,7 +303,8 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`List rules.`)
 
 			allRules, err := client.Flipt().ListRules(ctx, &flipt.ListRuleRequest{
-				FlagKey: "test",
+				NamespaceKey: namespace,
+				FlagKey:      "test",
 			})
 			require.NoError(t, err)
 
@@ -250,15 +316,17 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Re-order rules.`)
 
 			err = client.Flipt().OrderRules(ctx, &flipt.OrderRulesRequest{
-				FlagKey: "test",
-				RuleIds: []string{ruleTwo.Id, ruleOne.Id},
+				NamespaceKey: namespace,
+				FlagKey:      "test",
+				RuleIds:      []string{ruleTwo.Id, ruleOne.Id},
 			})
 			require.NoError(t, err)
 
 			t.Log(`List rules again.`)
 
 			allRules, err = client.Flipt().ListRules(ctx, &flipt.ListRuleRequest{
-				FlagKey: "test",
+				NamespaceKey: namespace,
+				FlagKey:      "test",
 			})
 			require.NoError(t, err)
 
@@ -273,15 +341,17 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Create distribution "rollout 100".`)
 
 			flag, err := client.Flipt().GetFlag(ctx, &flipt.GetFlagRequest{
-				Key: "test",
+				NamespaceKey: namespace,
+				Key:          "test",
 			})
 			require.NoError(t, err)
 
 			distribution, err := client.Flipt().CreateDistribution(ctx, &flipt.CreateDistributionRequest{
-				FlagKey:   "test",
-				RuleId:    ruleTwo.Id,
-				VariantId: flag.Variants[0].Id,
-				Rollout:   100,
+				NamespaceKey: namespace,
+				FlagKey:      "test",
+				RuleId:       ruleTwo.Id,
+				VariantId:    flag.Variants[0].Id,
+				Rollout:      100,
 			})
 			require.NoError(t, err)
 
@@ -293,8 +363,9 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Successful match.`)
 
 			result, err := client.Flipt().Evaluate(ctx, &flipt.EvaluationRequest{
-				FlagKey:  "test",
-				EntityId: uuid.Must(uuid.NewV4()).String(),
+				NamespaceKey: namespace,
+				FlagKey:      "test",
+				EntityId:     uuid.Must(uuid.NewV4()).String(),
 				Context: map[string]string{
 					"foo":  "baz",
 					"fizz": "bozz",
@@ -310,8 +381,9 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Unsuccessful match.`)
 
 			result, err = client.Flipt().Evaluate(ctx, &flipt.EvaluationRequest{
-				FlagKey:  "test",
-				EntityId: uuid.Must(uuid.NewV4()).String(),
+				NamespaceKey: namespace,
+				FlagKey:      "test",
+				EntityId:     uuid.Must(uuid.NewV4()).String(),
 				Context: map[string]string{
 					"fizz": "buzz",
 				},
@@ -325,10 +397,12 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Successful match.`)
 
 			results, err := client.Flipt().BatchEvaluate(ctx, &flipt.BatchEvaluationRequest{
+				NamespaceKey: namespace,
 				Requests: []*flipt.EvaluationRequest{
 					{
-						FlagKey:  "test",
-						EntityId: uuid.Must(uuid.NewV4()).String(),
+						NamespaceKey: namespace,
+						FlagKey:      "test",
+						EntityId:     uuid.Must(uuid.NewV4()).String(),
 						Context: map[string]string{
 							"foo":  "baz",
 							"fizz": "bozz",
@@ -349,10 +423,12 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 			t.Log(`Unsuccessful match.`)
 
 			results, err = client.Flipt().BatchEvaluate(ctx, &flipt.BatchEvaluationRequest{
+				NamespaceKey: namespace,
 				Requests: []*flipt.EvaluationRequest{
 					{
-						FlagKey:  "test",
-						EntityId: uuid.Must(uuid.NewV4()).String(),
+						NamespaceKey: namespace,
+						FlagKey:      "test",
+						EntityId:     uuid.Must(uuid.NewV4()).String(),
 						Context: map[string]string{
 							"fizz": "buzz",
 						},
@@ -370,26 +446,40 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 		t.Run("Delete", func(t *testing.T) {
 			t.Log(`Rules.`)
 			rules, err := client.Flipt().ListRules(ctx, &flipt.ListRuleRequest{
-				FlagKey: "test",
+				NamespaceKey: namespace,
+				FlagKey:      "test",
 			})
 			require.NoError(t, err)
 
 			for _, rule := range rules.Rules {
 				client.Flipt().DeleteRule(ctx, &flipt.DeleteRuleRequest{
-					FlagKey: "test",
-					Id:      rule.Id,
+					NamespaceKey: namespace,
+					FlagKey:      "test",
+					Id:           rule.Id,
 				})
 			}
 
 			t.Log(`Flag.`)
-			client.Flipt().DeleteFlag(ctx, &flipt.DeleteFlagRequest{
-				Key: "test",
+			err = client.Flipt().DeleteFlag(ctx, &flipt.DeleteFlagRequest{
+				NamespaceKey: namespace,
+				Key:          "test",
 			})
+			require.NoError(t, err)
 
 			t.Log(`Segment.`)
-			client.Flipt().DeleteSegment(ctx, &flipt.DeleteSegmentRequest{
-				Key: "everyone",
+			err = client.Flipt().DeleteSegment(ctx, &flipt.DeleteSegmentRequest{
+				NamespaceKey: namespace,
+				Key:          "everyone",
 			})
+			require.NoError(t, err)
+
+			if namespace != "" {
+				t.Log(`Namespace.`)
+				err = client.Flipt().DeleteNamespace(ctx, &flipt.DeleteNamespaceRequest{
+					Key: namespace,
+				})
+				require.NoError(t, err)
+			}
 		})
 
 		t.Run("Meta", func(t *testing.T) {
@@ -436,9 +526,9 @@ func Core(t *testing.T, fn func(t *testing.T) sdk.SDK) {
 	})
 }
 
-func Authenticated(t *testing.T, fn func(t *testing.T) sdk.SDK) {
+func Authenticated(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 	t.Run("Authentication Methods", func(t *testing.T) {
-		client := fn(t)
+		client, _ := fn(t)
 
 		ctx := context.Background()
 

--- a/hack/build/integration/integration_test.go
+++ b/hack/build/integration/integration_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 var (
-	fliptAddr  = flag.String("flipt-addr", "grpc://localhost:9000", "Address for running Flipt instance (gRPC only)")
-	fliptToken = flag.String("flipt-token", "", "Authentication token to be used during test suite")
+	fliptAddr      = flag.String("flipt-addr", "grpc://localhost:9000", "Address for running Flipt instance (gRPC only)")
+	fliptToken     = flag.String("flipt-token", "", "Authentication token to be used during test suite")
+	fliptNamespace = flag.String("flipt-namespace", "", "Namespace used to scope API calls.")
 )
 
 func TestFlipt(t *testing.T) {
@@ -47,9 +48,13 @@ func TestFlipt(t *testing.T) {
 		))
 	}
 
+	if *fliptNamespace != "" {
+		name = fmt.Sprintf("%s [Namespace %q]", name, *fliptNamespace)
+	}
+
 	t.Run(name, func(t *testing.T) {
-		fn := func(t *testing.T) sdk.SDK {
-			return sdk.New(transport, opts...)
+		fn := func(t *testing.T) (sdk.SDK, string) {
+			return sdk.New(transport, opts...), *fliptNamespace
 		}
 
 		integration.Core(t, fn)

--- a/hack/build/internal/test/integration.go
+++ b/hack/build/internal/test/integration.go
@@ -32,23 +32,27 @@ func Integration(ctx context.Context, client *dagger.Client, base, flipt *dagger
 	}
 
 	var g errgroup.Group
-
-	for _, addr := range []string{
-		"grpc://flipt:9000",
-		"http://flipt:8080",
+	for _, namespace := range []string{
+		"",
+		"flags",
 	} {
-		addr := addr
-		g.Go(integration(flipt, "-flipt-addr", addr))
+		for _, addr := range []string{
+			"grpc://flipt:9000",
+			"http://flipt:8080",
+		} {
+			addr := addr
+			g.Go(integration(flipt, "-flipt-addr", addr, "-flipt-namespace", namespace))
 
-		token := "abcdefghij"
-		g.Go(integration(
-			flipt.
-				WithEnvVariable("FLIPT_AUTHENTICATION_REQUIRED", "true").
-				WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_ENABLED", "true").
-				WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_BOOTSTRAP_TOKEN", token),
-			"-flipt-addr", addr,
-			"-flipt-token", token,
-		))
+			token := "abcdefghij"
+			g.Go(integration(
+				flipt.
+					WithEnvVariable("FLIPT_AUTHENTICATION_REQUIRED", "true").
+					WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_ENABLED", "true").
+					WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_BOOTSTRAP_TOKEN", token),
+				"-flipt-addr", addr,
+				"-flipt-token", token,
+			))
+		}
 	}
 
 	return g.Wait()

--- a/hack/build/internal/test/integration.go
+++ b/hack/build/internal/test/integration.go
@@ -2,6 +2,9 @@ package test
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
+	"time"
 
 	"dagger.io/dagger"
 	"github.com/google/uuid"
@@ -31,10 +34,12 @@ func Integration(ctx context.Context, client *dagger.Client, base, flipt *dagger
 		}
 	}
 
+	rand.Seed(time.Now().Unix())
+
 	var g errgroup.Group
 	for _, namespace := range []string{
 		"",
-		"flags",
+		fmt.Sprintf("%x", rand.Int()),
 	} {
 		for _, addr := range []string{
 			"grpc://flipt:9000",

--- a/rpc/flipt/flipt.pb.gw.go
+++ b/rpc/flipt/flipt.pb.gw.go
@@ -235,6 +235,248 @@ func local_request_Flipt_BatchEvaluate_1(ctx context.Context, marshaler runtime.
 
 }
 
+func request_Flipt_GetNamespace_0(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+
+	msg, err := client.GetNamespace(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Flipt_GetNamespace_0(ctx context.Context, marshaler runtime.Marshaler, server FliptServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq GetNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+
+	msg, err := server.GetNamespace(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+var (
+	filter_Flipt_ListNamespaces_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+)
+
+func request_Flipt_ListNamespaces_0(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Flipt_ListNamespaces_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.ListNamespaces(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Flipt_ListNamespaces_0(ctx context.Context, marshaler runtime.Marshaler, server FliptServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ListNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Flipt_ListNamespaces_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.ListNamespaces(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Flipt_CreateNamespace_0(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CreateNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.CreateNamespace(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Flipt_CreateNamespace_0(ctx context.Context, marshaler runtime.Marshaler, server FliptServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CreateNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.CreateNamespace(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Flipt_UpdateNamespace_0(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UpdateNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+
+	msg, err := client.UpdateNamespace(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Flipt_UpdateNamespace_0(ctx context.Context, marshaler runtime.Marshaler, server FliptServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UpdateNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+
+	msg, err := server.UpdateNamespace(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Flipt_DeleteNamespace_0(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+
+	msg, err := client.DeleteNamespace(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Flipt_DeleteNamespace_0(ctx context.Context, marshaler runtime.Marshaler, server FliptServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteNamespaceRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "key")
+	}
+
+	protoReq.Key, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+
+	msg, err := server.DeleteNamespace(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 var (
 	filter_Flipt_GetFlag_0 = &utilities.DoubleArray{Encoding: map[string]int{"key": 0}, Base: []int{1, 2, 0, 0}, Check: []int{0, 1, 2, 2}}
 )
@@ -4043,6 +4285,131 @@ func RegisterFliptHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 
 	})
 
+	mux.Handle("GET", pattern_Flipt_GetNamespace_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.Flipt/GetNamespace", runtime.WithHTTPPathPattern("/api/v1/namespaces/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Flipt_GetNamespace_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_GetNamespace_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Flipt_ListNamespaces_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.Flipt/ListNamespaces", runtime.WithHTTPPathPattern("/api/v1/namespaces"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Flipt_ListNamespaces_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_ListNamespaces_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_Flipt_CreateNamespace_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.Flipt/CreateNamespace", runtime.WithHTTPPathPattern("/api/v1/namespaces"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Flipt_CreateNamespace_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_CreateNamespace_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("PUT", pattern_Flipt_UpdateNamespace_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.Flipt/UpdateNamespace", runtime.WithHTTPPathPattern("/api/v1/namespaces/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Flipt_UpdateNamespace_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_UpdateNamespace_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("DELETE", pattern_Flipt_DeleteNamespace_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.Flipt/DeleteNamespace", runtime.WithHTTPPathPattern("/api/v1/namespaces/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Flipt_DeleteNamespace_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_DeleteNamespace_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_Flipt_GetFlag_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -5347,6 +5714,116 @@ func RegisterFliptHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Flipt_GetNamespace_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/flipt.Flipt/GetNamespace", runtime.WithHTTPPathPattern("/api/v1/namespaces/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Flipt_GetNamespace_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_GetNamespace_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Flipt_ListNamespaces_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/flipt.Flipt/ListNamespaces", runtime.WithHTTPPathPattern("/api/v1/namespaces"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Flipt_ListNamespaces_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_ListNamespaces_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("POST", pattern_Flipt_CreateNamespace_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/flipt.Flipt/CreateNamespace", runtime.WithHTTPPathPattern("/api/v1/namespaces"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Flipt_CreateNamespace_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_CreateNamespace_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("PUT", pattern_Flipt_UpdateNamespace_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/flipt.Flipt/UpdateNamespace", runtime.WithHTTPPathPattern("/api/v1/namespaces/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Flipt_UpdateNamespace_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_UpdateNamespace_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("DELETE", pattern_Flipt_DeleteNamespace_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/flipt.Flipt/DeleteNamespace", runtime.WithHTTPPathPattern("/api/v1/namespaces/{key}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Flipt_DeleteNamespace_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_DeleteNamespace_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_Flipt_GetFlag_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -6393,6 +6870,16 @@ var (
 
 	pattern_Flipt_BatchEvaluate_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"api", "v1", "namespaces", "namespace_key", "batch-evaluate"}, ""))
 
+	pattern_Flipt_GetNamespace_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "namespaces", "key"}, ""))
+
+	pattern_Flipt_ListNamespaces_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "namespaces"}, ""))
+
+	pattern_Flipt_CreateNamespace_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "namespaces"}, ""))
+
+	pattern_Flipt_UpdateNamespace_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "namespaces", "key"}, ""))
+
+	pattern_Flipt_DeleteNamespace_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "namespaces", "key"}, ""))
+
 	pattern_Flipt_GetFlag_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "flags", "key"}, ""))
 
 	pattern_Flipt_GetFlag_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5}, []string{"api", "v1", "namespaces", "namespace_key", "flags", "key"}, ""))
@@ -6496,6 +6983,16 @@ var (
 	forward_Flipt_BatchEvaluate_0 = runtime.ForwardResponseMessage
 
 	forward_Flipt_BatchEvaluate_1 = runtime.ForwardResponseMessage
+
+	forward_Flipt_GetNamespace_0 = runtime.ForwardResponseMessage
+
+	forward_Flipt_ListNamespaces_0 = runtime.ForwardResponseMessage
+
+	forward_Flipt_CreateNamespace_0 = runtime.ForwardResponseMessage
+
+	forward_Flipt_UpdateNamespace_0 = runtime.ForwardResponseMessage
+
+	forward_Flipt_DeleteNamespace_0 = runtime.ForwardResponseMessage
 
 	forward_Flipt_GetFlag_0 = runtime.ForwardResponseMessage
 

--- a/rpc/flipt/flipt.yaml
+++ b/rpc/flipt/flipt.yaml
@@ -6,10 +6,6 @@ http:
   rules:
   # namespaces
   #
-  # TODO
-
-  # namespaces
-  #
   - selector: flipt.Flipt.GetNamespace
     get: /api/v1/namespaces/{key}
 

--- a/rpc/flipt/flipt.yaml
+++ b/rpc/flipt/flipt.yaml
@@ -8,6 +8,25 @@ http:
   #
   # TODO
 
+  # namespaces
+  #
+  - selector: flipt.Flipt.GetNamespace
+    get: /api/v1/namespaces/{key}
+
+  - selector: flipt.Flipt.ListNamespaces
+    get: /api/v1/namespaces
+
+  - selector: flipt.Flipt.CreateNamespace
+    post: /api/v1/namespaces
+    body: "*"
+
+  - selector: flipt.Flipt.UpdateNamespace
+    put: /api/v1/namespaces/{key}
+    body: "*"
+
+  - selector: flipt.Flipt.DeleteNamespace
+    delete: /api/v1/namespaces/{key}
+
   # evaluation
   #
   - selector: flipt.Flipt.Evaluate

--- a/sdk/go/flipt.sdk.gen.go
+++ b/sdk/go/flipt.sdk.gen.go
@@ -29,68 +29,43 @@ func (x *Flipt) BatchEvaluate(ctx context.Context, v *flipt.BatchEvaluationReque
 }
 
 func (x *Flipt) GetNamespace(ctx context.Context, v *flipt.GetNamespaceRequest) (*flipt.Namespace, error) {
-	if x.tokenProvider != nil {
-		token, err := x.tokenProvider.ClientToken()
-		if err != nil {
-			return nil, err
-		}
-
-		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	ctx, err := authenticate(ctx, x.tokenProvider)
+	if err != nil {
+		return nil, err
 	}
-
 	return x.transport.GetNamespace(ctx, v)
 }
 
 func (x *Flipt) ListNamespaces(ctx context.Context, v *flipt.ListNamespaceRequest) (*flipt.NamespaceList, error) {
-	if x.tokenProvider != nil {
-		token, err := x.tokenProvider.ClientToken()
-		if err != nil {
-			return nil, err
-		}
-
-		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	ctx, err := authenticate(ctx, x.tokenProvider)
+	if err != nil {
+		return nil, err
 	}
-
 	return x.transport.ListNamespaces(ctx, v)
 }
 
 func (x *Flipt) CreateNamespace(ctx context.Context, v *flipt.CreateNamespaceRequest) (*flipt.Namespace, error) {
-	if x.tokenProvider != nil {
-		token, err := x.tokenProvider.ClientToken()
-		if err != nil {
-			return nil, err
-		}
-
-		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	ctx, err := authenticate(ctx, x.tokenProvider)
+	if err != nil {
+		return nil, err
 	}
-
 	return x.transport.CreateNamespace(ctx, v)
 }
 
 func (x *Flipt) UpdateNamespace(ctx context.Context, v *flipt.UpdateNamespaceRequest) (*flipt.Namespace, error) {
-	if x.tokenProvider != nil {
-		token, err := x.tokenProvider.ClientToken()
-		if err != nil {
-			return nil, err
-		}
-
-		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	ctx, err := authenticate(ctx, x.tokenProvider)
+	if err != nil {
+		return nil, err
 	}
-
 	return x.transport.UpdateNamespace(ctx, v)
 }
 
 func (x *Flipt) DeleteNamespace(ctx context.Context, v *flipt.DeleteNamespaceRequest) error {
-	if x.tokenProvider != nil {
-		token, err := x.tokenProvider.ClientToken()
-		if err != nil {
-			return err
-		}
-
-		ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	ctx, err := authenticate(ctx, x.tokenProvider)
+	if err != nil {
+		return err
 	}
-
-	_, err := x.transport.DeleteNamespace(ctx, v)
+	_, err = x.transport.DeleteNamespace(ctx, v)
 	return err
 }
 

--- a/sdk/go/http/flipt.sdk.gen.go
+++ b/sdk/go/http/flipt.sdk.gen.go
@@ -84,6 +84,154 @@ func (x *FliptClient) BatchEvaluate(ctx context.Context, v *flipt.BatchEvaluatio
 	return &output, nil
 }
 
+func (x *FliptClient) GetNamespace(ctx context.Context, v *flipt.GetNamespaceRequest, _ ...grpc.CallOption) (*flipt.Namespace, error) {
+	var body io.Reader
+	var values url.Values
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, x.addr+fmt.Sprintf("/api/v1/namespaces/%v", v.Key), body)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = values.Encode()
+	resp, err := x.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var output flipt.Namespace
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResponse(resp, respData); err != nil {
+		return nil, err
+	}
+	if err := protojson.Unmarshal(respData, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+func (x *FliptClient) ListNamespaces(ctx context.Context, v *flipt.ListNamespaceRequest, _ ...grpc.CallOption) (*flipt.NamespaceList, error) {
+	var body io.Reader
+	values := url.Values{}
+	values.Set("limit", fmt.Sprintf("%v", v.Limit))
+	values.Set("offset", fmt.Sprintf("%v", v.Offset))
+	values.Set("pageToken", v.PageToken)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, x.addr+"/api/v1/namespaces", body)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = values.Encode()
+	resp, err := x.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var output flipt.NamespaceList
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResponse(resp, respData); err != nil {
+		return nil, err
+	}
+	if err := protojson.Unmarshal(respData, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+func (x *FliptClient) CreateNamespace(ctx context.Context, v *flipt.CreateNamespaceRequest, _ ...grpc.CallOption) (*flipt.Namespace, error) {
+	var body io.Reader
+	var values url.Values
+	reqData, err := protojson.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	body = bytes.NewReader(reqData)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, x.addr+"/api/v1/namespaces", body)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = values.Encode()
+	resp, err := x.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var output flipt.Namespace
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResponse(resp, respData); err != nil {
+		return nil, err
+	}
+	if err := protojson.Unmarshal(respData, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+func (x *FliptClient) UpdateNamespace(ctx context.Context, v *flipt.UpdateNamespaceRequest, _ ...grpc.CallOption) (*flipt.Namespace, error) {
+	var body io.Reader
+	var values url.Values
+	reqData, err := protojson.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	body = bytes.NewReader(reqData)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, x.addr+fmt.Sprintf("/api/v1/namespaces/%v", v.Key), body)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = values.Encode()
+	resp, err := x.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var output flipt.Namespace
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResponse(resp, respData); err != nil {
+		return nil, err
+	}
+	if err := protojson.Unmarshal(respData, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
+func (x *FliptClient) DeleteNamespace(ctx context.Context, v *flipt.DeleteNamespaceRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+	var body io.Reader
+	var values url.Values
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, x.addr+fmt.Sprintf("/api/v1/namespaces/%v", v.Key), body)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.RawQuery = values.Encode()
+	resp, err := x.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var output emptypb.Empty
+	respData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if err := checkResponse(resp, respData); err != nil {
+		return nil, err
+	}
+	if err := protojson.Unmarshal(respData, &output); err != nil {
+		return nil, err
+	}
+	return &output, nil
+}
+
 func (x *FliptClient) GetFlag(ctx context.Context, v *flipt.GetFlagRequest, _ ...grpc.CallOption) (*flipt.Flag, error) {
 	var body io.Reader
 	var values url.Values


### PR DESCRIPTION
Fixes FLI-279
Fixes FLI-277
Fixes FLI-228

This PR contains a few changes:

1. ~It merges `main` into `namespaces` branch.~ (Did this separately).
2. Defines the gateway routes for the Namespaces RPCs.
3. Updates the integration tests for Namespaces:

It updates the integration tests to run both with and without a namespace key.
Effectively testing the API both in the default namespace and an explicit namespace.
When a namespace key is provided, it first tests the namespaces RPC and in doing so creates a namespace to then be used as a scope for the rest of the Flipt APIs.

Namespace is now an outler loop around the integration test matrix.
Meaning we test the combination of: Namespace x Transport x Authentication.
Leading to 8 runs of the entire suite in each of the various configurations.