### PR TITLE
fix(github): use event name workflow_run and conclusion

### DIFF
--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -31,7 +31,7 @@ jobs:
           gh workflow run proto-upgrade.yml -R flipt-io/flipt-grpc-ruby -f tag="${{ inputs.tag }}"
 
       - name: Trigger Workflow (Release)
-        if: ${{ github.event_name == 'release' }}
+        if: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |


### PR DESCRIPTION
Following along with this guide here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow

This changes the trigger to look for `event_name == workflow_run` and it only triggers when the conclusion of the previous run was successful.