### PR TITLE
feat: add checks and tests for potential `namespace`d related failures

### DIFF
--- a/hack/build/integration/integration.go
+++ b/hack/build/integration/integration.go
@@ -326,6 +326,19 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 			assert.Equal(t, "everyone", ruleTwo.SegmentKey)
 			assert.Equal(t, int32(2), ruleTwo.Rank)
 
+			// ensure you can not link flags and segments from different namespaces.
+			if namespace != "" {
+				t.Log(`Ensure that rules can only link entities in the same namespace.`)
+				_, err = client.Flipt().CreateRule(ctx, &flipt.CreateRuleRequest{
+					FlagKey:    "test",
+					SegmentKey: "everyone",
+					Rank:       2,
+				})
+
+				msg := "rpc error: code = NotFound desc = flag \"default/test\" or segment \"default/everyone\" not found"
+				require.EqualError(t, err, msg)
+			}
+
 			t.Log(`List rules.`)
 
 			allRules, err := client.Flipt().ListRules(ctx, &flipt.ListRuleRequest{

--- a/hack/build/integration/integration.go
+++ b/hack/build/integration/integration.go
@@ -423,7 +423,7 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 					Rollout:   100,
 				})
 
-				msg := fmt.Sprintf("rpc error: code = NotFound desc = namespace does not match for variant %q, rule %q, flag %q/%q not found", defaultVariant.Id, ruleTwo.Id, namespace, "test")
+				msg := fmt.Sprintf("rpc error: code = NotFound desc = variant %q, rule %q, flag %q/%q in namespace not found", defaultVariant.Id, ruleTwo.Id, "default", "test")
 				require.EqualError(t, err, msg)
 
 				_, err = client.Flipt().UpdateDistribution(ctx, &flipt.UpdateDistributionRequest{
@@ -434,6 +434,8 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 					RuleId:       ruleTwo.Id,
 					Rollout:      50,
 				})
+
+				msg = fmt.Sprintf("rpc error: code = NotFound desc = variant %q, rule %q, flag %q/%q in namespace not found", defaultVariant.Id, ruleTwo.Id, namespace, "test")
 				require.EqualError(t, err, msg)
 
 				err = client.Flipt().DeleteFlag(ctx, &flipt.DeleteFlagRequest{

--- a/hack/build/integration/integration.go
+++ b/hack/build/integration/integration.go
@@ -423,7 +423,7 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 					Rollout:   100,
 				})
 
-				msg := fmt.Sprintf("rpc error: code = NotFound desc = variant %q, rule %q, flag %q/%q in namespace not found", defaultVariant.Id, ruleTwo.Id, "default", "test")
+				msg := fmt.Sprintf("rpc error: code = NotFound desc = variant %q, rule %q, flag %q in namespace %q not found", defaultVariant.Id, ruleTwo.Id, "test", "default")
 				require.EqualError(t, err, msg)
 
 				_, err = client.Flipt().UpdateDistribution(ctx, &flipt.UpdateDistributionRequest{
@@ -435,7 +435,7 @@ func Core(t *testing.T, fn func(t *testing.T) (sdk.SDK, string)) {
 					Rollout:      50,
 				})
 
-				msg = fmt.Sprintf("rpc error: code = NotFound desc = variant %q, rule %q, flag %q/%q in namespace not found", defaultVariant.Id, ruleTwo.Id, namespace, "test")
+				msg = fmt.Sprintf("rpc error: code = NotFound desc = variant %q, rule %q, flag %q in namespace %q not found", defaultVariant.Id, ruleTwo.Id, "test", namespace)
 				require.EqualError(t, err, msg)
 
 				err = client.Flipt().DeleteFlag(ctx, &flipt.DeleteFlagRequest{

--- a/internal/storage/sql/common/rule.go
+++ b/internal/storage/sql/common/rule.go
@@ -489,7 +489,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 	err := s.distributionValidationHelper(ctx, r.RuleId, r.VariantId, r.FlagKey, r.NamespaceKey)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q/%q in namespace", r.VariantId, r.RuleId, r.NamespaceKey, r.FlagKey)
+			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q in namespace %q", r.VariantId, r.RuleId, r.FlagKey, r.NamespaceKey)
 		}
 		return nil, err
 	}
@@ -520,7 +520,7 @@ func (s *Store) UpdateDistribution(ctx context.Context, r *flipt.UpdateDistribut
 	err := s.distributionValidationHelper(ctx, r.RuleId, r.VariantId, r.FlagKey, r.NamespaceKey)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q/%q in namespace", r.VariantId, r.RuleId, r.NamespaceKey, r.FlagKey)
+			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q in namespace %q", r.VariantId, r.RuleId, r.FlagKey, r.NamespaceKey)
 		}
 		return nil, err
 	}

--- a/internal/storage/sql/evaluation_test.go
+++ b/internal/storage/sql/evaluation_test.go
@@ -345,10 +345,11 @@ func (s *DBTestSuite) TestGetEvaluationDistributionsNamespace() {
 
 	// 50/50 distribution
 	_, err = s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
-		FlagKey:   flag.Key,
-		RuleId:    rule.Id,
-		VariantId: variant1.Id,
-		Rollout:   50.00,
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		RuleId:       rule.Id,
+		VariantId:    variant1.Id,
+		Rollout:      50.00,
 	})
 
 	// required for MySQL since it only s.stores timestamps to the second and not millisecond granularity
@@ -357,10 +358,11 @@ func (s *DBTestSuite) TestGetEvaluationDistributionsNamespace() {
 	require.NoError(t, err)
 
 	_, err = s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
-		FlagKey:   flag.Key,
-		RuleId:    rule.Id,
-		VariantId: variant2.Id,
-		Rollout:   50.00,
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		RuleId:       rule.Id,
+		VariantId:    variant2.Id,
+		Rollout:      50.00,
 	})
 
 	require.NoError(t, err)

--- a/internal/storage/sql/mysql/mysql.go
+++ b/internal/storage/sql/mysql/mysql.go
@@ -172,7 +172,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var merr *mysql.MySQLError
 
 		if errors.As(err, &merr) && merr.Number == constraintForeignKeyErrCode {
-			return nil, errs.ErrNotFoundf("rule %q or variant %q", r.RuleId, r.VariantId)
+			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q/%q in namespace", r.VariantId, r.RuleId, r.NamespaceKey, r.FlagKey)
 		}
 
 		return nil, err

--- a/internal/storage/sql/mysql/mysql.go
+++ b/internal/storage/sql/mysql/mysql.go
@@ -172,7 +172,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var merr *mysql.MySQLError
 
 		if errors.As(err, &merr) && merr.Number == constraintForeignKeyErrCode {
-			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q/%q in namespace", r.VariantId, r.RuleId, r.NamespaceKey, r.FlagKey)
+			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q in namespace %q", r.VariantId, r.RuleId, r.FlagKey, r.NamespaceKey)
 		}
 
 		return nil, err

--- a/internal/storage/sql/mysql/mysql.go
+++ b/internal/storage/sql/mysql/mysql.go
@@ -172,7 +172,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var merr *mysql.MySQLError
 
 		if errors.As(err, &merr) && merr.Number == constraintForeignKeyErrCode {
-			return nil, errs.ErrNotFoundf("rule %q", r.RuleId)
+			return nil, errs.ErrNotFoundf("rule %q or variant %q", r.RuleId, r.VariantId)
 		}
 
 		return nil, err

--- a/internal/storage/sql/postgres/postgres.go
+++ b/internal/storage/sql/postgres/postgres.go
@@ -172,7 +172,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var perr *pq.Error
 
 		if errors.As(err, &perr) && perr.Code.Name() == constraintForeignKeyErr {
-			return nil, errs.ErrNotFoundf("rule %q", r.RuleId)
+			return nil, errs.ErrNotFoundf("rule %q or variant %q", r.RuleId, r.VariantId)
 		}
 
 		return nil, err

--- a/internal/storage/sql/postgres/postgres.go
+++ b/internal/storage/sql/postgres/postgres.go
@@ -172,7 +172,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var perr *pq.Error
 
 		if errors.As(err, &perr) && perr.Code.Name() == constraintForeignKeyErr {
-			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q/%q in namespace", r.VariantId, r.RuleId, r.NamespaceKey, r.FlagKey)
+			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q in namespace %q", r.VariantId, r.RuleId, r.FlagKey, r.NamespaceKey)
 		}
 
 		return nil, err

--- a/internal/storage/sql/postgres/postgres.go
+++ b/internal/storage/sql/postgres/postgres.go
@@ -172,7 +172,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var perr *pq.Error
 
 		if errors.As(err, &perr) && perr.Code.Name() == constraintForeignKeyErr {
-			return nil, errs.ErrNotFoundf("rule %q or variant %q", r.RuleId, r.VariantId)
+			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q/%q in namespace", r.VariantId, r.RuleId, r.NamespaceKey, r.FlagKey)
 		}
 
 		return nil, err

--- a/internal/storage/sql/rule_test.go
+++ b/internal/storage/sql/rule_test.go
@@ -455,6 +455,7 @@ func (s *DBTestSuite) TestCreateRuleAndDistribution() {
 	assert.Equal(t, rule.CreatedAt.Seconds, rule.UpdatedAt.Seconds)
 
 	distribution, err := s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
+		FlagKey:   flag.Key,
 		RuleId:    rule.Id,
 		VariantId: variant.Id,
 		Rollout:   100,
@@ -523,9 +524,11 @@ func (s *DBTestSuite) TestCreateRuleAndDistributionNamespace() {
 	assert.Equal(t, rule.CreatedAt.Seconds, rule.UpdatedAt.Seconds)
 
 	distribution, err := s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
-		RuleId:    rule.Id,
-		VariantId: variant.Id,
-		Rollout:   100,
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		RuleId:       rule.Id,
+		VariantId:    variant.Id,
+		Rollout:      100,
 	})
 
 	require.NoError(t, err)
@@ -561,6 +564,7 @@ func (s *DBTestSuite) TestCreateDistribution_NoRule() {
 	assert.NotNil(t, variant)
 
 	_, err = s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
+		FlagKey:   flag.Key,
 		RuleId:    "foo",
 		VariantId: variant.Id,
 		Rollout:   100,
@@ -689,6 +693,7 @@ func (s *DBTestSuite) TestUpdateRuleAndDistribution() {
 	assert.Equal(t, rule.CreatedAt.Seconds, rule.UpdatedAt.Seconds)
 
 	distribution, err := s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
+		FlagKey:   flag.Key,
 		RuleId:    rule.Id,
 		VariantId: variant.Id,
 		Rollout:   100,
@@ -728,6 +733,7 @@ func (s *DBTestSuite) TestUpdateRuleAndDistribution() {
 	assert.NotZero(t, rule.UpdatedAt)
 
 	updatedDistribution, err := s.store.UpdateDistribution(context.TODO(), &flipt.UpdateDistributionRequest{
+		FlagKey:   flag.Key,
 		Id:        distribution.Id,
 		RuleId:    rule.Id,
 		VariantId: variant.Id,
@@ -804,9 +810,11 @@ func (s *DBTestSuite) TestUpdateRuleAndDistributionNamespace() {
 	assert.Equal(t, rule.CreatedAt.Seconds, rule.UpdatedAt.Seconds)
 
 	distribution, err := s.store.CreateDistribution(context.TODO(), &flipt.CreateDistributionRequest{
-		RuleId:    rule.Id,
-		VariantId: variant.Id,
-		Rollout:   100,
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		RuleId:       rule.Id,
+		VariantId:    variant.Id,
+		Rollout:      100,
 	})
 
 	require.NoError(t, err)
@@ -846,10 +854,12 @@ func (s *DBTestSuite) TestUpdateRuleAndDistributionNamespace() {
 	assert.NotZero(t, rule.UpdatedAt)
 
 	updatedDistribution, err := s.store.UpdateDistribution(context.TODO(), &flipt.UpdateDistributionRequest{
-		Id:        distribution.Id,
-		RuleId:    rule.Id,
-		VariantId: variant.Id,
-		Rollout:   10,
+		NamespaceKey: s.namespace,
+		FlagKey:      flag.Key,
+		Id:           distribution.Id,
+		RuleId:       rule.Id,
+		VariantId:    variant.Id,
+		Rollout:      10,
 	})
 
 	require.NoError(t, err)

--- a/internal/storage/sql/rule_test.go
+++ b/internal/storage/sql/rule_test.go
@@ -570,7 +570,7 @@ func (s *DBTestSuite) TestCreateDistribution_NoRule() {
 		Rollout:   100,
 	})
 
-	assert.EqualError(t, err, "rule \"foo\" not found")
+	assert.EqualError(t, err, fmt.Sprintf("variant %q, rule %q, flag %q/%q in namespace not found", variant.Id, "foo", "default", flag.Key))
 }
 
 func (s *DBTestSuite) TestCreateRule_FlagNotFound() {

--- a/internal/storage/sql/rule_test.go
+++ b/internal/storage/sql/rule_test.go
@@ -570,7 +570,7 @@ func (s *DBTestSuite) TestCreateDistribution_NoRule() {
 		Rollout:   100,
 	})
 
-	assert.EqualError(t, err, fmt.Sprintf("variant %q, rule %q, flag %q/%q in namespace not found", variant.Id, "foo", "default", flag.Key))
+	assert.EqualError(t, err, fmt.Sprintf("variant %q, rule %q, flag %q in namespace %q not found", variant.Id, "foo", flag.Key, "default"))
 }
 
 func (s *DBTestSuite) TestCreateRule_FlagNotFound() {

--- a/internal/storage/sql/sqlite/sqlite.go
+++ b/internal/storage/sql/sqlite/sqlite.go
@@ -169,7 +169,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var serr sqlite3.Error
 
 		if errors.As(err, &serr) && serr.Code == sqlite3.ErrConstraint {
-			return nil, errs.ErrNotFoundf("rule %q or variant %q", r.RuleId, r.VariantId)
+			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q/%q in namespace", r.VariantId, r.RuleId, r.NamespaceKey, r.FlagKey)
 		}
 
 		return nil, err

--- a/internal/storage/sql/sqlite/sqlite.go
+++ b/internal/storage/sql/sqlite/sqlite.go
@@ -169,7 +169,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var serr sqlite3.Error
 
 		if errors.As(err, &serr) && serr.Code == sqlite3.ErrConstraint {
-			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q/%q in namespace", r.VariantId, r.RuleId, r.NamespaceKey, r.FlagKey)
+			return nil, errs.ErrNotFoundf("variant %q, rule %q, flag %q in namespace %q", r.VariantId, r.RuleId, r.FlagKey, r.NamespaceKey)
 		}
 
 		return nil, err

--- a/internal/storage/sql/sqlite/sqlite.go
+++ b/internal/storage/sql/sqlite/sqlite.go
@@ -169,7 +169,7 @@ func (s *Store) CreateDistribution(ctx context.Context, r *flipt.CreateDistribut
 		var serr sqlite3.Error
 
 		if errors.As(err, &serr) && serr.Code == sqlite3.ErrConstraint {
-			return nil, errs.ErrNotFoundf("rule %q", r.RuleId)
+			return nil, errs.ErrNotFoundf("rule %q or variant %q", r.RuleId, r.VariantId)
 		}
 
 		return nil, err

--- a/rpc/flipt/flipt.pb.gw.go
+++ b/rpc/flipt/flipt.pb.gw.go
@@ -2779,6 +2779,114 @@ func local_request_Flipt_CreateDistribution_0(ctx context.Context, marshaler run
 
 }
 
+func request_Flipt_CreateDistribution_1(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CreateDistributionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["namespace_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace_key")
+	}
+
+	protoReq.NamespaceKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "namespace_key", err)
+	}
+
+	val, ok = pathParams["flag_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "flag_key")
+	}
+
+	protoReq.FlagKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "flag_key", err)
+	}
+
+	val, ok = pathParams["rule_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rule_id")
+	}
+
+	protoReq.RuleId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rule_id", err)
+	}
+
+	msg, err := client.CreateDistribution(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Flipt_CreateDistribution_1(ctx context.Context, marshaler runtime.Marshaler, server FliptServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CreateDistributionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["namespace_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace_key")
+	}
+
+	protoReq.NamespaceKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "namespace_key", err)
+	}
+
+	val, ok = pathParams["flag_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "flag_key")
+	}
+
+	protoReq.FlagKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "flag_key", err)
+	}
+
+	val, ok = pathParams["rule_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rule_id")
+	}
+
+	protoReq.RuleId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rule_id", err)
+	}
+
+	msg, err := server.CreateDistribution(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_Flipt_UpdateDistribution_0(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq UpdateDistributionRequest
 	var metadata runtime.ServerMetadata
@@ -2851,6 +2959,134 @@ func local_request_Flipt_UpdateDistribution_0(ctx context.Context, marshaler run
 		err error
 		_   = err
 	)
+
+	val, ok = pathParams["flag_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "flag_key")
+	}
+
+	protoReq.FlagKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "flag_key", err)
+	}
+
+	val, ok = pathParams["rule_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rule_id")
+	}
+
+	protoReq.RuleId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rule_id", err)
+	}
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.UpdateDistribution(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+func request_Flipt_UpdateDistribution_1(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UpdateDistributionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["namespace_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace_key")
+	}
+
+	protoReq.NamespaceKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "namespace_key", err)
+	}
+
+	val, ok = pathParams["flag_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "flag_key")
+	}
+
+	protoReq.FlagKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "flag_key", err)
+	}
+
+	val, ok = pathParams["rule_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rule_id")
+	}
+
+	protoReq.RuleId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rule_id", err)
+	}
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := client.UpdateDistribution(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Flipt_UpdateDistribution_1(ctx context.Context, marshaler runtime.Marshaler, server FliptServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq UpdateDistributionRequest
+	var metadata runtime.ServerMetadata
+
+	newReader, berr := utilities.IOReaderFactory(req.Body)
+	if berr != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", berr)
+	}
+	if err := marshaler.NewDecoder(newReader()).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["namespace_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace_key")
+	}
+
+	protoReq.NamespaceKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "namespace_key", err)
+	}
 
 	val, ok = pathParams["flag_key"]
 	if !ok {
@@ -2989,6 +3225,136 @@ func local_request_Flipt_DeleteDistribution_0(ctx context.Context, marshaler run
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Flipt_DeleteDistribution_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := server.DeleteDistribution(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
+var (
+	filter_Flipt_DeleteDistribution_1 = &utilities.DoubleArray{Encoding: map[string]int{"namespace_key": 0, "namespaceKey": 1, "flag_key": 2, "flagKey": 3, "rule_id": 4, "ruleId": 5, "id": 6}, Base: []int{1, 1, 2, 3, 4, 5, 6, 8, 0, 0, 0, 0, 0, 0, 0, 0}, Check: []int{0, 1, 1, 1, 1, 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 8}}
+)
+
+func request_Flipt_DeleteDistribution_1(ctx context.Context, marshaler runtime.Marshaler, client FliptClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteDistributionRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["namespace_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace_key")
+	}
+
+	protoReq.NamespaceKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "namespace_key", err)
+	}
+
+	val, ok = pathParams["flag_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "flag_key")
+	}
+
+	protoReq.FlagKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "flag_key", err)
+	}
+
+	val, ok = pathParams["rule_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rule_id")
+	}
+
+	protoReq.RuleId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rule_id", err)
+	}
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Flipt_DeleteDistribution_1); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	msg, err := client.DeleteDistribution(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Flipt_DeleteDistribution_1(ctx context.Context, marshaler runtime.Marshaler, server FliptServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq DeleteDistributionRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["namespace_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace_key")
+	}
+
+	protoReq.NamespaceKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "namespace_key", err)
+	}
+
+	val, ok = pathParams["flag_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "flag_key")
+	}
+
+	protoReq.FlagKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "flag_key", err)
+	}
+
+	val, ok = pathParams["rule_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "rule_id")
+	}
+
+	protoReq.RuleId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "rule_id", err)
+	}
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_Flipt_DeleteDistribution_1); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
@@ -5135,6 +5501,31 @@ func RegisterFliptHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 
 	})
 
+	mux.Handle("POST", pattern_Flipt_CreateDistribution_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.Flipt/CreateDistribution", runtime.WithHTTPPathPattern("/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Flipt_CreateDistribution_1(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_CreateDistribution_1(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("PUT", pattern_Flipt_UpdateDistribution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -5160,6 +5551,31 @@ func RegisterFliptHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 
 	})
 
+	mux.Handle("PUT", pattern_Flipt_UpdateDistribution_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.Flipt/UpdateDistribution", runtime.WithHTTPPathPattern("/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Flipt_UpdateDistribution_1(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_UpdateDistribution_1(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("DELETE", pattern_Flipt_DeleteDistribution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -5182,6 +5598,31 @@ func RegisterFliptHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Flipt_DeleteDistribution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("DELETE", pattern_Flipt_DeleteDistribution_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.Flipt/DeleteDistribution", runtime.WithHTTPPathPattern("/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Flipt_DeleteDistribution_1(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_DeleteDistribution_1(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -6462,6 +6903,28 @@ func RegisterFliptHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("POST", pattern_Flipt_CreateDistribution_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/flipt.Flipt/CreateDistribution", runtime.WithHTTPPathPattern("/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Flipt_CreateDistribution_1(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_CreateDistribution_1(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("PUT", pattern_Flipt_UpdateDistribution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -6484,6 +6947,28 @@ func RegisterFliptHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("PUT", pattern_Flipt_UpdateDistribution_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/flipt.Flipt/UpdateDistribution", runtime.WithHTTPPathPattern("/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Flipt_UpdateDistribution_1(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_UpdateDistribution_1(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("DELETE", pattern_Flipt_DeleteDistribution_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -6503,6 +6988,28 @@ func RegisterFliptHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 		}
 
 		forward_Flipt_DeleteDistribution_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("DELETE", pattern_Flipt_DeleteDistribution_1, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/flipt.Flipt/DeleteDistribution", runtime.WithHTTPPathPattern("/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions/{id}"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Flipt_DeleteDistribution_1(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Flipt_DeleteDistribution_1(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -6938,9 +7445,15 @@ var (
 
 	pattern_Flipt_CreateDistribution_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 6}, []string{"api", "v1", "flags", "flag_key", "rules", "rule_id", "distributions"}, ""))
 
+	pattern_Flipt_CreateDistribution_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 6, 1, 0, 4, 1, 5, 7, 2, 8}, []string{"api", "v1", "namespaces", "namespace_key", "flags", "flag_key", "rules", "rule_id", "distributions"}, ""))
+
 	pattern_Flipt_UpdateDistribution_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 6, 1, 0, 4, 1, 5, 7}, []string{"api", "v1", "flags", "flag_key", "rules", "rule_id", "distributions", "id"}, ""))
 
+	pattern_Flipt_UpdateDistribution_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 6, 1, 0, 4, 1, 5, 7, 2, 8, 1, 0, 4, 1, 5, 9}, []string{"api", "v1", "namespaces", "namespace_key", "flags", "flag_key", "rules", "rule_id", "distributions", "id"}, ""))
+
 	pattern_Flipt_DeleteDistribution_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 6, 1, 0, 4, 1, 5, 7}, []string{"api", "v1", "flags", "flag_key", "rules", "rule_id", "distributions", "id"}, ""))
+
+	pattern_Flipt_DeleteDistribution_1 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 6, 1, 0, 4, 1, 5, 7, 2, 8, 1, 0, 4, 1, 5, 9}, []string{"api", "v1", "namespaces", "namespace_key", "flags", "flag_key", "rules", "rule_id", "distributions", "id"}, ""))
 
 	pattern_Flipt_GetSegment_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "segments", "key"}, ""))
 
@@ -7052,9 +7565,15 @@ var (
 
 	forward_Flipt_CreateDistribution_0 = runtime.ForwardResponseMessage
 
+	forward_Flipt_CreateDistribution_1 = runtime.ForwardResponseMessage
+
 	forward_Flipt_UpdateDistribution_0 = runtime.ForwardResponseMessage
 
+	forward_Flipt_UpdateDistribution_1 = runtime.ForwardResponseMessage
+
 	forward_Flipt_DeleteDistribution_0 = runtime.ForwardResponseMessage
+
+	forward_Flipt_DeleteDistribution_1 = runtime.ForwardResponseMessage
 
 	forward_Flipt_GetSegment_0 = runtime.ForwardResponseMessage
 

--- a/rpc/flipt/flipt.yaml
+++ b/rpc/flipt/flipt.yaml
@@ -151,12 +151,23 @@ http:
     post: "/api/v1/flags/{flag_key}/rules/{rule_id}/distributions"
     body: "*"
 
+  - selector: flipt.Flipt.CreateDistribution
+    post: "/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions"
+    body: "*"
+
   - selector: flipt.Flipt.UpdateDistribution
     put: "/api/v1/flags/{flag_key}/rules/{rule_id}/distributions/{id}"
     body: "*"
 
+  - selector: flipt.Flipt.UpdateDistribution
+    put: "/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions/{id}"
+    body: "*"
+
   - selector: flipt.Flipt.DeleteDistribution
     delete: "/api/v1/flags/{flag_key}/rules/{rule_id}/distributions/{id}"
+
+  - selector: flipt.Flipt.DeleteDistribution
+    delete: "/api/v1/namespaces/{namespace_key}/flags/{flag_key}/rules/{rule_id}/distributions/{id}"
 
   # segments
   #

--- a/sdk/go/http/flipt.sdk.gen.go
+++ b/sdk/go/http/flipt.sdk.gen.go
@@ -659,7 +659,7 @@ func (x *FliptClient) CreateDistribution(ctx context.Context, v *flipt.CreateDis
 		return nil, err
 	}
 	body = bytes.NewReader(reqData)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, x.addr+fmt.Sprintf("/api/v1/flags/%v/rules/%v/distributions", v.FlagKey, v.RuleId), body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, x.addr+fmt.Sprintf("/api/v1/namespaces/%v/flags/%v/rules/%v/distributions", v.NamespaceKey, v.FlagKey, v.RuleId), body)
 	if err != nil {
 		return nil, err
 	}
@@ -691,7 +691,7 @@ func (x *FliptClient) UpdateDistribution(ctx context.Context, v *flipt.UpdateDis
 		return nil, err
 	}
 	body = bytes.NewReader(reqData)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, x.addr+fmt.Sprintf("/api/v1/flags/%v/rules/%v/distributions/%v", v.FlagKey, v.RuleId, v.Id), body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, x.addr+fmt.Sprintf("/api/v1/namespaces/%v/flags/%v/rules/%v/distributions/%v", v.NamespaceKey, v.FlagKey, v.RuleId, v.Id), body)
 	if err != nil {
 		return nil, err
 	}
@@ -719,8 +719,7 @@ func (x *FliptClient) DeleteDistribution(ctx context.Context, v *flipt.DeleteDis
 	var body io.Reader
 	values := url.Values{}
 	values.Set("variantId", v.VariantId)
-	values.Set("namespaceKey", v.NamespaceKey)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, x.addr+fmt.Sprintf("/api/v1/flags/%v/rules/%v/distributions/%v", v.FlagKey, v.RuleId, v.Id), body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, x.addr+fmt.Sprintf("/api/v1/namespaces/%v/flags/%v/rules/%v/distributions/%v", v.NamespaceKey, v.FlagKey, v.RuleId, v.Id), body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Since the addition of `namespace`s, we want to disallow users or remove our system of namespaced related errors. One scenario we would like to prevent all together is the ability for someone to link two entities of different namespaces.

Due to the introduction of the `NamespaceKey` in most entity models within our protobuf definition, we can only check things or create things in the namespace provided within the request. This will disallow users from mixing namespaces for creating a rule.

Nonetheless, in this PR I check to see that, you can not create a rule for entities that do not exist in a namespace.

For `distribution`s, in the db layer, the `rule_id` and `variant_id` are uniquely identified via a UUID (Primary Key). It would not make too much sense to uniquely identify it with the UUID and namespace key, so the namespace check for distributions has to be logically done in code.

I added some logic in what wraps the db layer to check if the `rule` or `variant` exists for a specific namespace, and return a specific error if it does not. Also, added some integration tests to validate that logic.

This PR also introduces namespace scoped routes for distributions, to make the namespace aware.

Completes FLI-228