### PR TITLE
fix(migrations/sqlite): reorder to ensure we copy all data before drop

### DIFF
--- a/config/migrations/sqlite3/7_namespaces_relationships.up.sql
+++ b/config/migrations/sqlite3/7_namespaces_relationships.up.sql
@@ -89,6 +89,25 @@ INSERT INTO rules_temp (id, flag_key, segment_key, rank, created_at, updated_at)
   SELECT id, flag_key, segment_key, rank, created_at, updated_at
   FROM rules;
 
+-- Copy data from distributions table to temporary distributions table
+CREATE TABLE distributions_temp (
+  id VARCHAR(255) PRIMARY KEY UNIQUE NOT NULL,
+  rule_id VARCHAR(255) NOT NULL REFERENCES rules_temp ON DELETE CASCADE,
+  variant_id VARCHAR(255) NOT NULL REFERENCES variants_temp ON DELETE CASCADE,
+  rollout float DEFAULT 0 NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+INSERT INTO distributions_temp (id, rule_id, variant_id, rollout, created_at, updated_at)
+  SELECT id, rule_id, variant_id, rollout, created_at, updated_at
+  FROM distributions;
+
+-- Drop old distributions table
+DROP TABLE distributions;
+-- Rename temporary distributions table to distributions
+ALTER TABLE distributions_temp RENAME TO distributions;
+
 -- Drop old rules table
 DROP TABLE rules;
 -- Rename temporary rules table to rules

--- a/config/migrations/sqlite3/7_namespaces_relationships.up.sql
+++ b/config/migrations/sqlite3/7_namespaces_relationships.up.sql
@@ -1,26 +1,3 @@
-PRAGMA foreign_keys=off;
-
--- Create temporary rules table
-CREATE TABLE IF NOT EXISTS rules_temp (
-  id VARCHAR(255) PRIMARY KEY UNIQUE NOT NULL,
-  flag_key VARCHAR(255) NOT NULL,
-  segment_key VARCHAR(255) NOT NULL,
-  rank INTEGER DEFAULT 1 NOT NULL,
-  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  namespace_key VARCHAR(255) NOT NULL DEFAULT 'default' REFERENCES namespaces ON DELETE CASCADE
-);
-
--- Copy data from rules table to temporary rules table
-INSERT INTO rules_temp (id, flag_key, segment_key, rank, created_at, updated_at)
-  SELECT id, flag_key, segment_key, rank, created_at, updated_at
-  FROM rules;
-
--- Drop old rules table
-DROP TABLE rules;
--- Rename temporary rules table to rules
-ALTER TABLE rules_temp RENAME TO rules;
-
 -- Create temporary flags table
 CREATE TABLE IF NOT EXISTS flags_temp (
   key VARCHAR(255) NOT NULL,
@@ -38,11 +15,6 @@ INSERT INTO flags_temp (key, name, description, enabled, created_at, updated_at)
   SELECT key, name, description, enabled, created_at, updated_at
   FROM flags;
 
--- Drop old flags table
-DROP TABLE flags;
--- Rename temporary flags table to flags
-ALTER TABLE flags_temp RENAME TO flags;
-
 -- Create temporary variants table
 CREATE TABLE IF NOT EXISTS variants_temp (
   id VARCHAR(255) PRIMARY KEY UNIQUE NOT NULL,
@@ -55,18 +27,13 @@ CREATE TABLE IF NOT EXISTS variants_temp (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
   namespace_key VARCHAR(255) NOT NULL DEFAULT 'default' REFERENCES namespaces ON DELETE CASCADE,
   UNIQUE (namespace_key, flag_key, key),
-  FOREIGN KEY (namespace_key, flag_key) REFERENCES flags (namespace_key, key) ON DELETE CASCADE
+  FOREIGN KEY (namespace_key, flag_key) REFERENCES flags_temp (namespace_key, key) ON DELETE CASCADE
 );
 
 -- Copy data from variants table to temporary variants table
 INSERT INTO variants_temp (id, flag_key, key, name, description, attachment, created_at, updated_at)
   SELECT id, flag_key, key, name, description, attachment, created_at, updated_at
   FROM variants;
-
--- Drop old variants table
-DROP TABLE variants;
--- Rename temporary variants table to variants
-ALTER TABLE variants_temp RENAME TO variants;
 
 -- Create temporary segments table
 CREATE TABLE IF NOT EXISTS segments_temp (
@@ -85,11 +52,6 @@ INSERT INTO segments_temp (key, name, description, match_type, created_at, updat
   SELECT key, name, description, match_type, created_at, updated_at
   FROM segments;
 
--- Drop old segments table
-DROP TABLE segments;
--- Rename temporary segments table to segments
-ALTER TABLE segments_temp RENAME TO segments;
-
 -- Create temporary constraints table
 CREATE TABLE IF NOT EXISTS constraints_temp (
   id VARCHAR(255) PRIMARY KEY UNIQUE NOT NULL,
@@ -101,18 +63,13 @@ CREATE TABLE IF NOT EXISTS constraints_temp (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
   namespace_key VARCHAR(255) NOT NULL DEFAULT 'default' REFERENCES namespaces ON DELETE CASCADE,
-  FOREIGN KEY (namespace_key, segment_key) REFERENCES segments (namespace_key, key) ON DELETE CASCADE
+  FOREIGN KEY (namespace_key, segment_key) REFERENCES segments_temp (namespace_key, key) ON DELETE CASCADE
 );
 
 -- Copy data from constraints table to temporary constraints table
 INSERT INTO constraints_temp (id, segment_key, type, property, operator, value, created_at, updated_at)
   SELECT id, segment_key, type, property, operator, value, created_at, updated_at
   FROM constraints;
-
--- Drop old constraints table
-DROP TABLE constraints;
--- Rename temporary constraints table to constraints
-ALTER TABLE constraints_temp RENAME TO constraints;
 
 -- Create temporary rules table
 CREATE TABLE IF NOT EXISTS rules_temp (
@@ -123,8 +80,8 @@ CREATE TABLE IF NOT EXISTS rules_temp (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
   namespace_key VARCHAR(255) NOT NULL DEFAULT 'default' REFERENCES namespaces ON DELETE CASCADE,
-  FOREIGN KEY (namespace_key, flag_key) REFERENCES flags (namespace_key, key) ON DELETE CASCADE,
-  FOREIGN KEY (namespace_key, segment_key) REFERENCES segments (namespace_key, key) ON DELETE CASCADE
+  FOREIGN KEY (namespace_key, flag_key) REFERENCES flags_temp (namespace_key, key) ON DELETE CASCADE,
+  FOREIGN KEY (namespace_key, segment_key) REFERENCES segments_temp (namespace_key, key) ON DELETE CASCADE
 );
 
 -- Copy data from rules table to temporary rules table
@@ -137,4 +94,22 @@ DROP TABLE rules;
 -- Rename temporary rules table to rules
 ALTER TABLE rules_temp RENAME TO rules;
 
-PRAGMA foreign_keys=on;
+-- Drop old flags table
+DROP TABLE flags;
+-- Rename temporary flags table to flags
+ALTER TABLE flags_temp RENAME TO flags;
+
+-- Drop old variants table
+DROP TABLE variants;
+-- Rename temporary variants table to variants
+ALTER TABLE variants_temp RENAME TO variants;
+
+-- Drop old segments table
+DROP TABLE segments;
+-- Rename temporary segments table to segments
+ALTER TABLE segments_temp RENAME TO segments;
+
+-- Drop old constraints table
+DROP TABLE constraints;
+-- Rename temporary constraints table to constraints
+ALTER TABLE constraints_temp RENAME TO constraints;


### PR DESCRIPTION
While poking around in the namespaces branch I noticed that a migration (over `sqlite`) with state led to `variants`, `rules` and `distributions` getting dropped during migration.

This appears to be due to the fact that we're performing a copy and then drop table by table.
When we drop parent tables their cascading deletes are taking effect and whiping these referencing tables before we even get to migrating them.

This change makes it so that we create and copy all tables into temp tables first, before we drop and rename at the end of the migration. When we define the temporary table, any references also reference the other temporary tables. SQLite appears to correctly rename these references when the tables are renamed. This protects each table from the original table getting dropped.

## Other changes of note

1. I can't remember again why we have (had?) to copy the rule tables twice. It seems to work for me as expected when I just do it at the end now.
2. I removed the foreign key pragma disabling. I read somewher this can have no effect in a multi-statement transaction. It seems to have little to no effect when I remove these from the migration altogether.
3. I added copying of `distributions` into a temporary table as its contents was getting dropped on variants / rules drop.