### PR TITLE
chore: add missing namespaces metrics

### DIFF
--- a/internal/server/metrics/metrics.go
+++ b/internal/server/metrics/metrics.go
@@ -55,9 +55,10 @@ var (
 
 	// Attributes used in evaluation metrics
 	//nolint
-	AttributeMatch   = attribute.Key("match")
-	AttributeFlag    = attribute.Key("flag")
-	AttributeSegment = attribute.Key("segment")
-	AttributeReason  = attribute.Key("reason")
-	AttributeValue   = attribute.Key("value")
+	AttributeMatch     = attribute.Key("match")
+	AttributeFlag      = attribute.Key("flag")
+	AttributeSegment   = attribute.Key("segment")
+	AttributeReason    = attribute.Key("reason")
+	AttributeValue     = attribute.Key("value")
+	AttributeNamespace = attribute.Key("namespace")
 )


### PR DESCRIPTION
Fixes: FLI-292

Adds missing namespace metrics for prometheus, the spanAttrs were added in previous PRs