### PR TITLE
fix: protojson to use DiscardUnknown option for backwards compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,8 +36,8 @@ require (
 	github.com/testcontainers/testcontainers-go v0.19.0
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/xo/dburl v0.13.0
-	go.flipt.io/flipt/errors v1.19.2
-	go.flipt.io/flipt/rpc/flipt v1.19.2
+	go.flipt.io/flipt/errors v1.19.3
+	go.flipt.io/flipt/rpc/flipt v1.19.3
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0
 	go.opentelemetry.io/otel v1.14.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.14.0

--- a/internal/cmd/protoc-gen-go-flipt-sdk/http.go
+++ b/internal/cmd/protoc-gen-go-flipt-sdk/http.go
@@ -289,7 +289,7 @@ func generateHTTPMethod(g *protogen.GeneratedFile, m mappings, method *protogen.
 		return
 	}
 
-	g.P("if err := ", "(protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal", "(respData, &output); err != nil { return nil, err }")
+	g.P("if err := (", protojson("UnmarshalOptions"), "{DiscardUnknown: true}).Unmarshal", "(respData, &output); err != nil { return nil, err }")
 	g.P("return &output, nil")
 	g.P("}\n")
 }

--- a/internal/cmd/protoc-gen-go-flipt-sdk/http.go
+++ b/internal/cmd/protoc-gen-go-flipt-sdk/http.go
@@ -289,7 +289,7 @@ func generateHTTPMethod(g *protogen.GeneratedFile, m mappings, method *protogen.
 		return
 	}
 
-	g.P("if err := ", protojson("Unmarshal"), "(respData, &output); err != nil { return nil, err }")
+	g.P("if err := ", "(protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal", "(respData, &output); err != nil { return nil, err }")
 	g.P("return &output, nil")
 	g.P("}\n")
 }

--- a/sdk/go/http/auth.sdk.gen.go
+++ b/sdk/go/http/auth.sdk.gen.go
@@ -52,7 +52,7 @@ func (x *publicAuthenticationServiceClient) ListAuthenticationMethods(ctx contex
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -88,7 +88,7 @@ func (x *authenticationServiceClient) GetAuthenticationSelf(ctx context.Context,
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -115,7 +115,7 @@ func (x *authenticationServiceClient) GetAuthentication(ctx context.Context, v *
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -145,7 +145,7 @@ func (x *authenticationServiceClient) ListAuthentications(ctx context.Context, v
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -172,7 +172,7 @@ func (x *authenticationServiceClient) DeleteAuthentication(ctx context.Context, 
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -214,7 +214,7 @@ func (x *authenticationServiceClient) ExpireAuthenticationSelf(ctx context.Conte
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -255,7 +255,7 @@ func (x *authenticationMethodTokenServiceClient) CreateToken(ctx context.Context
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -292,7 +292,7 @@ func (x *authenticationMethodOIDCServiceClient) AuthorizeURL(ctx context.Context
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -321,7 +321,7 @@ func (x *authenticationMethodOIDCServiceClient) Callback(ctx context.Context, v 
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -362,7 +362,7 @@ func (x *authenticationMethodKubernetesServiceClient) VerifyServiceAccount(ctx c
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil

--- a/sdk/go/http/flipt.sdk.gen.go
+++ b/sdk/go/http/flipt.sdk.gen.go
@@ -46,7 +46,7 @@ func (x *FliptClient) Evaluate(ctx context.Context, v *flipt.EvaluationRequest, 
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -78,7 +78,7 @@ func (x *FliptClient) BatchEvaluate(ctx context.Context, v *flipt.BatchEvaluatio
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -105,7 +105,7 @@ func (x *FliptClient) GetFlag(ctx context.Context, v *flipt.GetFlagRequest, _ ..
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -135,7 +135,7 @@ func (x *FliptClient) ListFlags(ctx context.Context, v *flipt.ListFlagRequest, _
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -167,7 +167,7 @@ func (x *FliptClient) CreateFlag(ctx context.Context, v *flipt.CreateFlagRequest
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -199,7 +199,7 @@ func (x *FliptClient) UpdateFlag(ctx context.Context, v *flipt.UpdateFlagRequest
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -226,7 +226,7 @@ func (x *FliptClient) DeleteFlag(ctx context.Context, v *flipt.DeleteFlagRequest
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -258,7 +258,7 @@ func (x *FliptClient) CreateVariant(ctx context.Context, v *flipt.CreateVariantR
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -290,7 +290,7 @@ func (x *FliptClient) UpdateVariant(ctx context.Context, v *flipt.UpdateVariantR
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -317,7 +317,7 @@ func (x *FliptClient) DeleteVariant(ctx context.Context, v *flipt.DeleteVariantR
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -344,7 +344,7 @@ func (x *FliptClient) GetRule(ctx context.Context, v *flipt.GetRuleRequest, _ ..
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -374,7 +374,7 @@ func (x *FliptClient) ListRules(ctx context.Context, v *flipt.ListRuleRequest, _
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -406,7 +406,7 @@ func (x *FliptClient) CreateRule(ctx context.Context, v *flipt.CreateRuleRequest
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -438,7 +438,7 @@ func (x *FliptClient) UpdateRule(ctx context.Context, v *flipt.UpdateRuleRequest
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -470,7 +470,7 @@ func (x *FliptClient) OrderRules(ctx context.Context, v *flipt.OrderRulesRequest
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -497,7 +497,7 @@ func (x *FliptClient) DeleteRule(ctx context.Context, v *flipt.DeleteRuleRequest
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -529,7 +529,7 @@ func (x *FliptClient) CreateDistribution(ctx context.Context, v *flipt.CreateDis
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -561,7 +561,7 @@ func (x *FliptClient) UpdateDistribution(ctx context.Context, v *flipt.UpdateDis
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -589,7 +589,7 @@ func (x *FliptClient) DeleteDistribution(ctx context.Context, v *flipt.DeleteDis
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -616,7 +616,7 @@ func (x *FliptClient) GetSegment(ctx context.Context, v *flipt.GetSegmentRequest
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -646,7 +646,7 @@ func (x *FliptClient) ListSegments(ctx context.Context, v *flipt.ListSegmentRequ
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -678,7 +678,7 @@ func (x *FliptClient) CreateSegment(ctx context.Context, v *flipt.CreateSegmentR
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -710,7 +710,7 @@ func (x *FliptClient) UpdateSegment(ctx context.Context, v *flipt.UpdateSegmentR
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -737,7 +737,7 @@ func (x *FliptClient) DeleteSegment(ctx context.Context, v *flipt.DeleteSegmentR
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -769,7 +769,7 @@ func (x *FliptClient) CreateConstraint(ctx context.Context, v *flipt.CreateConst
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -801,7 +801,7 @@ func (x *FliptClient) UpdateConstraint(ctx context.Context, v *flipt.UpdateConst
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil
@@ -828,7 +828,7 @@ func (x *FliptClient) DeleteConstraint(ctx context.Context, v *flipt.DeleteConst
 	if err := checkResponse(resp, respData); err != nil {
 		return nil, err
 	}
-	if err := protojson.Unmarshal(respData, &output); err != nil {
+	if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(respData, &output); err != nil {
 		return nil, err
 	}
 	return &output, nil


### PR DESCRIPTION
The current http sdk client fails with requests against Flipt instances that are namespace aware (according to the proto definitions). We start to see errors like the following:

```
$ go run main.go
This is the error:  proto: (line 1:167): unknown field "namespaceKey"
```

This is because the http client does not know what to do with unknown fields when it goes to decode the output back out to the user. This change introduces a `DiscardUnknown` Unmarshal option, so the client can know what to do with unknown fields relative to the protobuf definition.
