### PR TITLE
fix(cmd/import): pass namespace key as name on create

### DIFF
--- a/hack/build/testing/integration/readonly/readonly_test.go
+++ b/hack/build/testing/integration/readonly/readonly_test.go
@@ -28,7 +28,7 @@ func TestReadOnly(t *testing.T) {
 		if namespace != "" && namespace != "default" {
 			expected = namespace
 		}
-		assert.Equal(t, expected, namespace)
+		assert.Equal(t, expected, ns.Name)
 
 		require.NoError(t, err)
 		flags, err := sdk.Flipt().ListFlags(ctx, &flipt.ListFlagRequest{

--- a/hack/build/testing/integration/readonly/readonly_test.go
+++ b/hack/build/testing/integration/readonly/readonly_test.go
@@ -17,6 +17,20 @@ import (
 func TestReadOnly(t *testing.T) {
 	integration.Harness(t, func(t *testing.T, sdk sdk.SDK, namespace string, _ bool) {
 		ctx := context.Background()
+		ns, err := sdk.Flipt().GetNamespace(ctx, &flipt.GetNamespaceRequest{
+			Key: namespace,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, namespace, ns.Key)
+
+		expected := "Default"
+		if namespace != "" && namespace != "default" {
+			expected = namespace
+		}
+		assert.Equal(t, expected, namespace)
+
+		require.NoError(t, err)
 		flags, err := sdk.Flipt().ListFlags(ctx, &flipt.ListFlagRequest{
 			NamespaceKey: namespace,
 		})

--- a/internal/ext/importer.go
+++ b/internal/ext/importer.go
@@ -57,7 +57,8 @@ func (i *Importer) Import(ctx context.Context, r io.Reader) error {
 		}
 
 		_, err = i.creator.CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
-			Key: i.namespace,
+			Key:  i.namespace,
+			Name: i.namespace,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Supports FLI-300

This ensures namespaces created via `import --create-namespace` use the provided namespace key as the name.
There is another issue that create namespace succeeds even with a blank name which will be fixed in another PR.
This is simply to enure import passes a name on namespace creation.