### PR TITLE
chore: validation logic for namespace requests

### DIFF
--- a/internal/ext/importer.go
+++ b/internal/ext/importer.go
@@ -57,7 +57,8 @@ func (i *Importer) Import(ctx context.Context, r io.Reader) error {
 		}
 
 		_, err = i.creator.CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
-			Key: i.namespace,
+			Key:  i.namespace,
+			Name: i.namespace,
 		})
 		if err != nil {
 			return err

--- a/rpc/flipt/validation.go
+++ b/rpc/flipt/validation.go
@@ -459,3 +459,32 @@ func (req *DeleteConstraintRequest) Validate() error {
 
 	return nil
 }
+
+// Namespaces
+func (req *CreateNamespaceRequest) Validate() error {
+	if req.Key == "" {
+		return errors.EmptyFieldError("key")
+	}
+
+	if !keyRegex.MatchString(req.Key) {
+		return errors.InvalidFieldError("key", "contains invalid characters")
+	}
+
+	if req.Name == "" {
+		return errors.EmptyFieldError("name")
+	}
+
+	return nil
+}
+
+func (req *UpdateNamespaceRequest) Validate() error {
+	if req.Key == "" {
+		return errors.EmptyFieldError("key")
+	}
+
+	if req.Name == "" {
+		return errors.EmptyFieldError("name")
+	}
+
+	return nil
+}

--- a/rpc/flipt/validation_test.go
+++ b/rpc/flipt/validation_test.go
@@ -1485,3 +1485,106 @@ func TestValidate_DeleteConstraintRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate_CreateNamespaceRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *CreateNamespaceRequest
+		wantErr error
+	}{
+		{
+			name: "emptyKey",
+			req: &CreateNamespaceRequest{
+				Key:         "",
+				Name:        "name",
+				Description: "desc",
+			},
+			wantErr: errors.EmptyFieldError("key"),
+		},
+		{
+			name: "invalidKey",
+			req: &CreateNamespaceRequest{
+				Key:         "foo:bar",
+				Name:        "name",
+				Description: "desc",
+			},
+			wantErr: errors.InvalidFieldError("key", "contains invalid characters"),
+		},
+		{
+			name: "emptyName",
+			req: &CreateNamespaceRequest{
+				Key:         "key",
+				Name:        "",
+				Description: "desc",
+			},
+			wantErr: errors.EmptyFieldError("name"),
+		},
+		{
+			name: "valid",
+			req: &CreateNamespaceRequest{
+				Key:         "key",
+				Name:        "name",
+				Description: "desc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		var (
+			req     = tt.req
+			wantErr = tt.wantErr
+		)
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := req.Validate()
+			assert.Equal(t, wantErr, err)
+		})
+	}
+}
+
+func TestValidate_UpdateNamespaceRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *UpdateNamespaceRequest
+		wantErr error
+	}{
+		{
+			name: "emptyKey",
+			req: &UpdateNamespaceRequest{
+				Key:         "",
+				Name:        "name",
+				Description: "desc",
+			},
+			wantErr: errors.EmptyFieldError("key"),
+		},
+		{
+			name: "emptyName",
+			req: &UpdateNamespaceRequest{
+				Key:         "key",
+				Name:        "",
+				Description: "desc",
+			},
+			wantErr: errors.EmptyFieldError("name"),
+		},
+		{
+			name: "valid",
+			req: &UpdateNamespaceRequest{
+				Key:         "key",
+				Name:        "name",
+				Description: "desc",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		var (
+			req     = tt.req
+			wantErr = tt.wantErr
+		)
+
+		t.Run(tt.name, func(t *testing.T) {
+			err := req.Validate()
+			assert.Equal(t, wantErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Writing validation logic for particular namespace requests. We want to disallow the creation of some namespaces based on inputs, mainly one could create a namespace, without this change, with backslashes. A namespace created with backslashes confuses the UI since it is included in the path of subsequent namespace requests.

Fixes FLI-300
Fixes FLI-299 