### PR TITLE
chore: rework how index.html is served, no generation

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"time"
 
@@ -156,12 +155,12 @@ func NewHTTPServer(
 
 	// TODO: remove (deprecated as of 1.17)
 	if cfg.UI.Enabled {
-		u, err := fs.Sub(ui.UI, ui.Mount)
+		fs, err := ui.FS()
 		if err != nil {
-			return nil, fmt.Errorf("mounting UI: %w", err)
+			return nil, fmt.Errorf("mounting ui: %w", err)
 		}
 
-		r.Mount("/", http.FileServer(http.FS(u)))
+		r.Mount("/", http.FileServer(http.FS(fs)))
 	}
 
 	server.Server = &http.Server{

--- a/magefile.go
+++ b/magefile.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"html/template"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -115,30 +114,6 @@ const (
 )
 
 func ui(mode buildMode) error {
-	// use template to determine if we should inject dev scripts
-	// required to proxy to vite dev server
-	// see: https://vitejs.dev/guide/backend-integration.html
-	tmplt := template.Must(template.ParseFiles("ui/index.html.tmpl"))
-
-	v := struct {
-		IsDev bool
-	}{
-		IsDev: mode == buildModeDev,
-	}
-
-	f, err := os.Create(filepath.Join("ui", "index.html"))
-	if err != nil {
-		return fmt.Errorf("creating file: %w", err)
-	}
-
-	if err := tmplt.Execute(f, v); err != nil {
-		return fmt.Errorf("executing template: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("closing file: %w", err)
-	}
-
 	if mode == buildModeDev {
 		return nil
 	}

--- a/ui/dev.go
+++ b/ui/dev.go
@@ -3,10 +3,21 @@
 
 package ui
 
-import "embed"
-
-var (
-	//go:embed index.html
-	UI    embed.FS
-	Mount = "."
+import (
+	_ "embed"
+	"io/fs"
+	"testing/fstest"
 )
+
+//go:embed index.dev.html
+var ui []byte
+
+func FS() (fs.FS, error) {
+	// this allows us to serve 'index.dev.html' as 'index.html' so that it
+	// is served correctly by http.FileServer
+	return fstest.MapFS{
+		"index.html": &fstest.MapFile{
+			Data: ui,
+		},
+	}, nil
+}

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -3,10 +3,20 @@
 
 package ui
 
-import "embed"
-
-var (
-	//go:embed dist/*
-	UI    embed.FS
-	Mount = "dist"
+import (
+	"embed"
+	"fmt"
+	"io/fs"
 )
+
+//go:embed dist/*
+var ui embed.FS
+
+func FS() (fs.FS, error) {
+	u, err := fs.Sub(ui, "dist")
+	if err != nil {
+		return nil, fmt.Errorf("embedding file: %w", err)
+	}
+
+	return u, nil
+}

--- a/ui/index.dev.html
+++ b/ui/index.dev.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full w-auto bg-white">
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" href="/favicon.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Flipt</title>
+  
+  <script type="module">
+    import RefreshRuntime from 'http://localhost:5173/@react-refresh';
+    RefreshRuntime.injectIntoGlobalHook(window);
+    window.$RefreshReg$ = () => { };
+    window.$RefreshSig$ = () => (type) => type;
+    window.__vite_plugin_react_preamble_installed__ = true;
+  </script>
+  <script type="module" src="http://localhost:5173/@vite/client"></script>
+  
+</head>
+
+<body class="h-full antialiased">
+  <div id="root"></div>
+  
+  <script type="module" src="http://localhost:5173/src/main.tsx"></script>
+  
+</body>
+
+</html>


### PR DESCRIPTION
This is a slight rework of #1478 as the generating of 'index.html' each time from a template was causing issues when running unit tests/benchmarks outside of `mage` like in our GitHub Actions workflows

This PR changes the flow to:

1. both `index.html` and `index.dev.html` are long-lived and committed to Git, no generation
2. when building with the `-assets` build tag, we serve the embedded `dist` folder which would have been build via vite, as normal
3. when building/running without `-assets` build tag, we now return a 'fake' FS using [fstest.MapFS](https://pkg.go.dev/testing/fstest#MapFS) which simply returns the embedded contents of `index.dev.html` whenever `index.html` is requested, essentially swapping out `index.html` for `index.dev.html` at runtime