### PR TITLE
chore(sdk/go): upgrade rpc/flipt to v1.20.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/uber/jaeger-client-go v2.30.0+incompatible
 	github.com/xo/dburl v0.13.1
 	go.flipt.io/flipt/errors v1.19.3
-	go.flipt.io/flipt/rpc/flipt v1.20.0-rc1
+	go.flipt.io/flipt/rpc/flipt v1.20.0
 	go.flipt.io/flipt/sdk/go v0.1.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0
 	go.opentelemetry.io/otel v1.14.0

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -3,7 +3,8 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v0.2.0-rc1](https://github.com/flipt-io/flipt/releases/tag/sdk/go/v0.2.0-rc1) - 2023-04-06
+
+## [v0.2.0](https://github.com/flipt-io/flipt/releases/tag/sdk/go/v0.2.0) - 2023-04-11
 
 ### Added
 

--- a/sdk/go/CHANGELOG.md
+++ b/sdk/go/CHANGELOG.md
@@ -3,7 +3,6 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [v0.2.0](https://github.com/flipt-io/flipt/releases/tag/sdk/go/v0.2.0) - 2023-04-11
 
 ### Added

--- a/sdk/go/go.mod
+++ b/sdk/go/go.mod
@@ -3,7 +3,7 @@ module go.flipt.io/flipt/sdk/go
 go 1.20
 
 require (
-	go.flipt.io/flipt/rpc/flipt v1.20.0-rc1
+	go.flipt.io/flipt/rpc/flipt v1.20.0
 	google.golang.org/genproto v0.0.0-20230320184635-7606e756e683
 	google.golang.org/grpc v1.54.0
 	google.golang.org/protobuf v1.30.0


### PR DESCRIPTION
Preparing release of `sdk/go` v0.2.0.