### PR TITLE
fix(github): install mage in release and prepend tag with v

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,12 @@ jobs:
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
 
+      - name: Install Mage
+        run:
+          git clone https://github.com/magefile/mage
+          cd mage
+          go run bootstrap.go
+
       - name: Tag and Push latest
         env:
           TAG: ${{ github.ref_name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,8 +64,8 @@ dockers:
     use: buildx
     goarch: amd64
     image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:v{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-amd64{{ end }}"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -78,8 +78,8 @@ dockers:
     use: buildx
     goarch: arm64
     image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:{{ .Tag }}-arm64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:v{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-arm64{{ end }}"
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -89,20 +89,20 @@ dockers:
       - config/default.yml
 
 docker_manifests:
-  - name_template: "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly{{ else }}flipt/flipt:{{ .Tag }}{{ end }}"
+  - name_template: "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly{{ else }}flipt/flipt:v{{ .Tag }}{{ end }}"
     image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:v{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:v{{ .Tag }}-arm64{{ end }}"
 
-  - name_template: "{{ if .IsNightly }}markphelps/flipt:{{ incpatch .Version }}-nightly{{ else }}markphelps/flipt:{{ .Tag }}{{ end }}" # TODO: deprecate
+  - name_template: "{{ if .IsNightly }}markphelps/flipt:{{ incpatch .Version }}-nightly{{ else }}markphelps/flipt:v{{ .Tag }}{{ end }}" # TODO: deprecate
     image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}flipt/flipt:v{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}flipt/flipt:v{{ .Tag }}-arm64{{ end }}"
 
-  - name_template: "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}{{ end }}"
+  - name_template: "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}{{ end }}"
     image_templates:
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-arm64{{ end }}"
 
 announce:
   discord:


### PR DESCRIPTION
1. Installs `mage` into the release workflow.
2. Prepends all images with `v` now that gorelease strips it.