### PR TITLE
chore: move devcontainer image to be repo-scoped

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Build and run Dev Container task
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/flipt-io/flipt-devcontainer
+          imageName: ghcr.io/flipt-io/flipt/flipt-devcontainer
           runCmd: |
             mage bootstrap


### PR DESCRIPTION
trying to fix this error:

```
 The push refers to repository [ghcr.io/flipt-io/flipt-devcontainer]

  denied: installation not allowed to Create organization package
```

Moving to a repo scoped package which the action should have permissions to create