### PR TITLE
chore(sdk/go): update docs examples to reference namespaces

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -20,7 +20,7 @@ The [Flipt SDK Generator](../../internal/cmd/protoc-gen-go-flipt-sdk/) can be fo
 | 0.1.\*              |          ✓ |       ✓\* |
 | >= 0.2.\*           |          ✗ |         ✓ |
 
-\* Backwards compatible, but does can only access the `"default"` namespace.
+\* Backwards compatible, but can only access the `"default"` namespace.
 
 ## Get the SDK
 

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -13,6 +13,15 @@ The [Flipt SDK Generator](../../internal/cmd/protoc-gen-go-flipt-sdk/) can be fo
 
 - Go `>= v1.20`
 
+## Client / Server Version Compatibility
+
+| client ⌄ / server › | <= 1.19.\* | >= 1.20.0 |
+| ------------------- | ---------- | --------- |
+| 0.1.\*              |          ✓ |       ✓\* |
+| >= 0.2.\*           |          ✗ |         ✓ |
+
+\* Backwards compatible, but does can only access the `"default"` namespace.
+
 ## Get the SDK
 
 ```sh

--- a/sdk/go/defaults.go
+++ b/sdk/go/defaults.go
@@ -1,0 +1,6 @@
+package sdk
+
+// DefaultNamespace is the default namespace created in Flipt.
+// This namespace is protected and will always be present.
+// Omitting a namespace key leads to this namespace being referenced.
+const DefaultNamespace = "default"

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -15,7 +15,7 @@
 //	func main() {
 //	    conn := grpc.Dial("localhost:9090")
 //	    transport := grpc.NewTransport(conn)
-//	    sdk := sdk.New(transport)
+//	    client := sdk.New(transport)
 //	}
 //
 // # HTTP Transport
@@ -24,7 +24,7 @@
 //
 //	func main() {
 //	    transport := http.NewTransport("http://localhost:8080")
-//	    sdk := sdk.New(transport)
+//	    client := sdk.New(transport)
 //	}
 
 // # Authenticating the SDK
@@ -36,7 +36,7 @@
 //
 //	func main() {
 //	    provider := sdk.StaticClientTokenProvider("some-flipt-token")
-//	    sdk.New(transport, sdk.WithClientTokenProvider(provider))
+//	    client := sdk.New(transport, sdk.WithClientTokenProvider(provider))
 //	}
 //
 // # SDK Services
@@ -56,6 +56,7 @@
 //
 //	result, err := client.Evaluate(ctx, &flipt.EvaluationRequest{
 //	    RequestId: uuid.NewV4().String(),
+//	    NamespaceKey: sdk.DefaultNamespace,
 //	    FlagKey: "my_flag_key",
 //	    EntityId: userID,
 //	    Context: map[string]string{
@@ -65,7 +66,10 @@
 //
 // Additionally, Flipt resources can be accessed and managed directly.
 //
-//	flag, err := client.GetFlag(ctx, &flipt.GetFlagRequest{Key: "my_flag_key"})
+//	flag, err := client.GetFlag(ctx, &flipt.GetFlagRequest{
+//	    NamespaceKey: "my_namespace",
+//	    Key: "my_flag_key",
+//	})
 //	if err != nil {
 //	    panic(err)
 //	}

--- a/sdk/go/example_test.go
+++ b/sdk/go/example_test.go
@@ -14,5 +14,8 @@ func ExampleNew() {
 
 	client := New(transport)
 
-	client.Flipt().GetFlag(context.Background(), &flipt.GetFlagRequest{Key: "my_flag"})
+	client.Flipt().GetFlag(context.Background(), &flipt.GetFlagRequest{
+		NamespaceKey: "my_namespace",
+		Key:          "my_flag",
+	})
 }


### PR DESCRIPTION
- Adds a constant `DefaultNamespace`.
- Updates `doc.go` examples to demonstrate passes `NamespaceKey`.
- Adds a client <-> server compatability documentation section to README.md.

Fixes: FLI-314