### PR TITLE
chore: fix Dockerfile go mod download step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN git clone https://github.com/magefile/mage && \
 
 COPY go.mod .
 COPY go.sum .
+COPY ./errors ./errors
+COPY ./rpc/flipt ./rpc/flipt
+COPY ./sdk ./sdk
 
 RUN go mod download
 


### PR DESCRIPTION
Fixes error when building local Dockerfile:

```
 => CACHED [build 6/9] COPY go.sum .                                                                                                  0.0s
 => ERROR [build 7/9] RUN go mod download                                                                                            13.2s
------
 > [build 7/9] RUN go mod download:
#15 13.15 go: go.flipt.io/flipt/errors@v1.19.3 (replaced by ./errors/): reading errors/go.mod: open /home/flipt/errors/go.mod: no such file or directory
```