### PR TITLE
chore: fix stringer error

### DIFF
--- a/internal/server/middleware/grpc/support_test.go
+++ b/internal/server/middleware/grpc/support_test.go
@@ -252,6 +252,10 @@ func (a *auditSinkSpy) SendAudits(es []audit.Event) error {
 	return nil
 }
 
+func (a *auditSinkSpy) String() string {
+	return "auditSinkSpy"
+}
+
 func (a *auditSinkSpy) Close() error { return nil }
 
 type auditExporterSpy struct {


### PR DESCRIPTION
As test were ran in CI, the "mock" sink did not have a `String` method for zap to call. It resulted in a `panic` in the log output. This fixes the issue.