### PR TITLE
feat: make changes to audit event structure

### DIFF
--- a/internal/server/audit/audit.go
+++ b/internal/server/audit/audit.go
@@ -118,7 +118,7 @@ func (e *Event) AddToSpan(ctx context.Context) {
 }
 
 func (e *Event) Valid() bool {
-	return e.Version != "" && e.Action != "" && e.Type != "" && e.Payload != nil
+	return e.Version != "" && e.Action != "" && e.Type != "" && e.Timestamp != "" && e.Payload != nil
 }
 
 var errEventNotValid = errors.New("audit event not valid")

--- a/internal/server/audit/audit_test.go
+++ b/internal/server/audit/audit_test.go
@@ -39,19 +39,18 @@ func TestSinkSpanExporter(t *testing.T) {
 
 	_, span := tr.Start(context.Background(), "OnStart")
 
-	e := NewEvent(Metadata{
-		Type:   Flag,
-		Action: Create,
-		Actor: map[string]string{
-			"method": "token",
-			"ip":     "127.0.0.1",
-		},
-	}, &flipt.CreateFlagRequest{
-		Key:         "this-flag",
-		Name:        "this-flag",
-		Description: "this description",
-		Enabled:     false,
-	})
+	e := NewEvent(
+		Flag,
+		Create,
+		map[string]string{
+			"authentication": "token",
+			"ip":             "127.0.0.1",
+		}, &flipt.CreateFlagRequest{
+			Key:         "this-flag",
+			Name:        "this-flag",
+			Description: "this description",
+			Enabled:     false,
+		})
 
 	span.AddEvent("auditEvent", trace.WithAttributes(e.DecodeToAttributes()...))
 	span.End()

--- a/internal/server/auth/server.go
+++ b/internal/server/auth/server.go
@@ -25,8 +25,8 @@ type Actor map[string]string
 
 func ActorFromContext(ctx context.Context) Actor {
 	var (
-		actor  = Actor{}
-		method = "none"
+		actor          = Actor{}
+		authentication = "none"
 	)
 
 	md, _ := metadata.FromIncomingContext(ctx)
@@ -36,13 +36,13 @@ func ActorFromContext(ctx context.Context) Actor {
 
 	auth := GetAuthenticationFrom(ctx)
 	if auth != nil {
-		method = strings.ToLower(strings.TrimPrefix(auth.Method.String(), "METHOD_"))
+		authentication = strings.ToLower(strings.TrimPrefix(auth.Method.String(), "METHOD_"))
 		for k, v := range auth.Metadata {
 			actor[k] = v
 		}
 	}
 
-	actor["method"] = method
+	actor["authentication"] = authentication
 	return actor
 }
 
@@ -142,7 +142,7 @@ func (s *Server) DeleteAuthentication(ctx context.Context, req *auth.DeleteAuthe
 			return nil, err
 		}
 		if a.Method == auth.Method_METHOD_TOKEN {
-			event := audit.NewEvent(audit.Metadata{Type: audit.Token, Action: audit.Delete, Actor: actor}, a.Metadata)
+			event := audit.NewEvent(audit.Token, audit.Delete, actor, a.Metadata)
 			event.AddToSpan(ctx)
 		}
 	}

--- a/internal/server/auth/server_test.go
+++ b/internal/server/auth/server_test.go
@@ -28,8 +28,8 @@ import (
 
 func TestActorFromContext(t *testing.T) {
 	const (
-		ipAddress = "127.0.0.1"
-		method    = "token"
+		ipAddress      = "127.0.0.1"
+		authentication = "token"
 	)
 
 	ctx := metadata.NewIncomingContext(context.Background(), map[string][]string{"x-forwarded-for": {"127.0.0.1"}})
@@ -38,7 +38,7 @@ func TestActorFromContext(t *testing.T) {
 	actor := fauth.ActorFromContext(ctx)
 
 	require.Equal(t, actor["ip"], ipAddress)
-	require.Equal(t, actor["method"], method)
+	require.Equal(t, actor["authentication"], authentication)
 }
 
 func TestServer(t *testing.T) {

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -251,49 +251,49 @@ func AuditUnaryInterceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
 
 		switch r := req.(type) {
 		case *flipt.CreateFlagRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Flag, Action: audit.Create, Actor: actor}, r)
+			event = audit.NewEvent(audit.Flag, audit.Create, actor, r)
 		case *flipt.UpdateFlagRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Flag, Action: audit.Update, Actor: actor}, r)
+			event = audit.NewEvent(audit.Flag, audit.Update, actor, r)
 		case *flipt.DeleteFlagRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Flag, Action: audit.Delete, Actor: actor}, r)
+			event = audit.NewEvent(audit.Flag, audit.Delete, actor, r)
 		case *flipt.CreateVariantRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Variant, Action: audit.Create, Actor: actor}, r)
+			event = audit.NewEvent(audit.Variant, audit.Create, actor, r)
 		case *flipt.UpdateVariantRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Variant, Action: audit.Update, Actor: actor}, r)
+			event = audit.NewEvent(audit.Variant, audit.Update, actor, r)
 		case *flipt.DeleteVariantRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Variant, Action: audit.Delete, Actor: actor}, r)
+			event = audit.NewEvent(audit.Variant, audit.Delete, actor, r)
 		case *flipt.CreateSegmentRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Segment, Action: audit.Create, Actor: actor}, r)
+			event = audit.NewEvent(audit.Segment, audit.Create, actor, r)
 		case *flipt.UpdateSegmentRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Segment, Action: audit.Update, Actor: actor}, r)
+			event = audit.NewEvent(audit.Segment, audit.Update, actor, r)
 		case *flipt.DeleteSegmentRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Segment, Action: audit.Delete, Actor: actor}, r)
+			event = audit.NewEvent(audit.Segment, audit.Delete, actor, r)
 		case *flipt.CreateConstraintRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Constraint, Action: audit.Create, Actor: actor}, r)
+			event = audit.NewEvent(audit.Constraint, audit.Create, actor, r)
 		case *flipt.UpdateConstraintRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Constraint, Action: audit.Update, Actor: actor}, r)
+			event = audit.NewEvent(audit.Constraint, audit.Update, actor, r)
 		case *flipt.DeleteConstraintRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Constraint, Action: audit.Delete, Actor: actor}, r)
+			event = audit.NewEvent(audit.Constraint, audit.Delete, actor, r)
 		case *flipt.CreateDistributionRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Distribution, Action: audit.Create}, r)
+			event = audit.NewEvent(audit.Distribution, audit.Create, actor, r)
 		case *flipt.UpdateDistributionRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Distribution, Action: audit.Update, Actor: actor}, r)
+			event = audit.NewEvent(audit.Distribution, audit.Update, actor, r)
 		case *flipt.DeleteDistributionRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Distribution, Action: audit.Delete, Actor: actor}, r)
+			event = audit.NewEvent(audit.Distribution, audit.Delete, actor, r)
 		case *flipt.CreateRuleRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Rule, Action: audit.Create, Actor: actor}, r)
+			event = audit.NewEvent(audit.Rule, audit.Create, actor, r)
 		case *flipt.UpdateRuleRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Rule, Action: audit.Update, Actor: actor}, r)
+			event = audit.NewEvent(audit.Rule, audit.Update, actor, r)
 		case *flipt.DeleteRuleRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Rule, Action: audit.Delete, Actor: actor}, r)
+			event = audit.NewEvent(audit.Rule, audit.Delete, actor, r)
 		case *flipt.CreateNamespaceRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Namespace, Action: audit.Create, Actor: actor}, r)
+			event = audit.NewEvent(audit.Namespace, audit.Create, actor, r)
 		case *flipt.UpdateNamespaceRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Namespace, Action: audit.Update, Actor: actor}, r)
+			event = audit.NewEvent(audit.Namespace, audit.Update, actor, r)
 		case *flipt.DeleteNamespaceRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Namespace, Action: audit.Delete, Actor: actor}, r)
+			event = audit.NewEvent(audit.Namespace, audit.Delete, actor, r)
 		case *authrpc.CreateTokenRequest:
-			event = audit.NewEvent(audit.Metadata{Type: audit.Token, Action: audit.Create, Actor: actor}, r)
+			event = audit.NewEvent(audit.Token, audit.Create, actor, r)
 		}
 
 		resp, err := handler(ctx, req)

--- a/internal/server/middleware/grpc/middleware_test.go
+++ b/internal/server/middleware/grpc/middleware_test.go
@@ -1654,7 +1654,7 @@ func TestAuthMetadataAuditUnaryInterceptor(t *testing.T) {
 
 	event := exporterSpy.GetEvents()[0]
 	assert.Equal(t, event.Metadata.Actor["email"], "example@flipt.com")
-	assert.Equal(t, event.Metadata.Actor["method"], "oidc")
+	assert.Equal(t, event.Metadata.Actor["authentication"], "oidc")
 }
 
 func TestAuditUnaryInterceptor_CreateToken(t *testing.T) {


### PR DESCRIPTION
Modify event structure to have `action` and `type` as top level fields. Also add timestamp to the event structure.