### PR TITLE
chore: add audit config keys to toplevel schema defs

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -9,6 +9,7 @@ import "strings"
 	// Flipt application.
 	@jsonschema(schema="http://json-schema.org/draft/2019-09/schema#")
 	version?:        "1.0" | *"1.0"
+	audit?:          #audit
 	authentication?: #authentication
 	cache?:          #cache
 	cors?:           #cors

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -11,6 +11,9 @@
       "enum": ["1.0"],
       "default": "1.0"
     },
+    "audit": {
+      "$ref": "#/definitions/audit"
+    },
     "authentication": {
       "$ref": "#/definitions/authentication"
     },


### PR DESCRIPTION
chore: add audit config keys to toplevel schema defs

looks like we forgot to add the new audit properties to the top level config objects