### PR TITLE
chore: Update .goreleaser.nightly.yml

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -10,15 +10,15 @@ changelog:
 docker_manifests:
   - name_template: "flipt/flipt:nightly"
     image_templates:
-      - "flipt/flipt:{{ incpatch .Version }}-nightly-amd64"
-      - "flipt/flipt:{{ incpatch .Version }}-nightly-arm64"
+      - "flipt/flipt:v{{ incpatch .Version }}-nightly-amd64"
+      - "flipt/flipt:v{{ incpatch .Version }}-nightly-arm64"
 
   - name_template: "markphelps/flipt:nightly"
     image_templates:
-      - "flipt/flipt:{{ incpatch .Version }}-nightly-amd64"
-      - "flipt/flipt:{{ incpatch .Version }}-nightly-arm64"
+      - "flipt/flipt:v{{ incpatch .Version }}-nightly-amd64"
+      - "flipt/flipt:v{{ incpatch .Version }}-nightly-arm64"
 
   - name_template: "ghcr.io/flipt-io/flipt:nightly"
     image_templates:
-      - "ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-amd64"
-      - "ghcr.io/flipt-io/flipt:{{ incpatch .Version }}-nightly-arm64"
+      - "ghcr.io/flipt-io/flipt:v{{ incpatch .Version }}-nightly-amd64"
+      - "ghcr.io/flipt-io/flipt:v{{ incpatch .Version }}-nightly-arm64"


### PR DESCRIPTION
Add those `v` prefixes back for the nightly images