### PR TITLE
feat: add text and json format option for output on `flipt validate` command

### DIFF
--- a/cmd/flipt/validate.go
+++ b/cmd/flipt/validate.go
@@ -30,7 +30,7 @@ func newValidateCommand() *cobra.Command {
 		&v.format,
 		"format", "F",
 		"text",
-		"format of the output once the validate command is issued.",
+		"output format.",
 	)
 
 	return cmd

--- a/cmd/flipt/validate.go
+++ b/cmd/flipt/validate.go
@@ -10,6 +10,7 @@ import (
 
 type validateCommand struct {
 	issueExitCode int
+	format        string
 }
 
 func newValidateCommand() *cobra.Command {
@@ -25,11 +26,18 @@ func newValidateCommand() *cobra.Command {
 
 	cmd.Flags().IntVar(&v.issueExitCode, "issue-exit-code", 1, "Exit code to use when issues are found")
 
+	cmd.Flags().StringVarP(
+		&v.format,
+		"format", "F",
+		"text",
+		"format of the output once the validate command is issued.",
+	)
+
 	return cmd
 }
 
 func (v *validateCommand) run(cmd *cobra.Command, args []string) {
-	if err := cue.ValidateFiles(os.Stdout, args); err != nil {
+	if err := cue.ValidateFiles(os.Stdout, args, v.format); err != nil {
 		if errors.Is(err, cue.ErrValidationFailed) && v.issueExitCode != 1 {
 			os.Exit(v.issueExitCode)
 		}

--- a/internal/cue/validate.go
+++ b/internal/cue/validate.go
@@ -152,7 +152,7 @@ func ValidateFiles(dst io.Writer, files []string, format string) error {
 
 			fmt.Fprintln(dst, buffer.String())
 
-			return err
+			return ErrValidationFailed
 		}
 		err = validate(b, cctx)
 		if err != nil {
@@ -183,7 +183,7 @@ func ValidateFiles(dst io.Writer, files []string, format string) error {
 			return err
 		}
 
-		return errors.New("validation error")
+		return ErrValidationFailed
 	} else {
 		if err := writeSuccessDetails(format, dst); err != nil {
 			return err

--- a/internal/cue/validate.go
+++ b/internal/cue/validate.go
@@ -79,10 +79,6 @@ func writeErrorDetails(format string, cerrs []Error, w io.Writer) error {
   Column : %d
 `, cerrs[i].Message, cerrs[i].Location.File, cerrs[i].Location.Line, cerrs[i].Location.Column)
 
-			if i < len(cerrs)-1 {
-				errString += "\n"
-			}
-
 			sb.WriteString(errString)
 		}
 	}
@@ -108,7 +104,7 @@ func writeErrorDetails(format string, cerrs []Error, w io.Writer) error {
 		buildErrorMessage()
 	}
 
-	fmt.Fprintln(w, sb.String())
+	fmt.Fprint(w, sb.String())
 
 	return nil
 }
@@ -125,12 +121,8 @@ func ValidateFiles(dst io.Writer, files []string, format string) error {
 		// Quit execution of the cue validating against the yaml
 		// files upon failure to read file.
 		if err != nil {
-			var sb strings.Builder
-
-			sb.WriteString("❌ Validation failure!\n\n")
-			sb.WriteString(fmt.Sprintf("Failed to read file %s", f))
-
-			fmt.Fprintln(dst, sb.String())
+			fmt.Print("❌ Validation failure!\n\n")
+			fmt.Printf("Failed to read file %s", f)
 
 			return ErrValidationFailed
 		}
@@ -170,15 +162,11 @@ func ValidateFiles(dst io.Writer, files []string, format string) error {
 			return nil
 		}
 
-		var sb strings.Builder
-
 		if format != textFormat {
-			sb.WriteString("Invalid format chosen, defaulting to \"text\" format...\n")
+			fmt.Print("Invalid format chosen, defaulting to \"text\" format...\n")
 		}
 
-		sb.WriteString("✅ Validation success!")
-
-		fmt.Fprintln(dst, sb.String())
+		fmt.Println("✅ Validation success!")
 	}
 
 	return nil


### PR DESCRIPTION
Introduce `format` flag for the `flipt validate` command.

Text format (failure):
```
$ ./bin/flipt validate features.yml
❌ Validation failure!


- Message: invalid value "flag1..." (out of bound =~"^[-_,A-Za-z0-9]+$")
  File   : features.yml
  Line   : 2
  Column : 11


- Message: invalid value 110 (out of bound <=100)
  File   : features.yml
  Line   : 27
  Column : 23
```

JSON format (failure piped through `jq`):
```
$ ./bin/flipt validate features.yml --format=json | jq
{
  "errors": [
    {
      "message": "invalid value \"flag1...\" (out of bound =~\"^[-_,A-Za-z0-9]+$\")",
      "location": {
        "file": "features.yml",
        "line": 2,
        "column": 11
      }
    },
    {
      "message": "invalid value 110 (out of bound <=100)",
      "location": {
        "file": "features.yml",
        "line": 27,
        "column": 23
      }
    }
  ]
}
```

Text format (success):

```
$ ./bin/flipt validate features.yml
✅ Validation success!
```

JSON format (success piped through `jq`):

```
$ ./bin/flipt validate features.yml --format=json | jq
{
  "validate": "success"
}
```

Completes FLI-345