### PR TITLE
chore: Fix CORS in nextjs example

### DIFF
--- a/examples/nextjs/Caddyfile
+++ b/examples/nextjs/Caddyfile
@@ -1,5 +1,28 @@
+{
+
+}
+
+(cors) {
+  @cors_preflight method OPTIONS
+  @cors header Origin {args.0}
+
+  handle @cors_preflight {
+    header Access-Control-Allow-Origin "{args.0}"
+    header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE"
+    header Access-Control-Allow-Headers "Content-Type"
+    header Access-Control-Max-Age "3600"
+    respond "" 204
+  }
+
+  handle @cors {
+    header Access-Control-Allow-Origin "{args.0}"
+    header Access-Control-Expose-Headers "Link"
+  }
+}
+
 :8081 {
   log
+  import cors *
 
   # proxy only evaluate requests to port 8080
   reverse_proxy /api/v1/evaluate flipt:8080 {


### PR DESCRIPTION
Allow all origins so the nextjs example can make client side requests.