### PR TITLE
feat: add storage configuration to support multiple backend types

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -297,19 +297,7 @@ func run(ctx context.Context, logger *zap.Logger, cfg *config.Config) error {
 		})
 	}
 
-	migrator, err := sql.NewMigrator(*cfg, logger)
-	if err != nil {
-		return err
-	}
-
-	if err := migrator.Up(forceMigrate); err != nil {
-		migrator.Close()
-		return err
-	}
-
-	migrator.Close()
-
-	grpcServer, err := cmd.NewGRPCServer(ctx, logger, cfg, info)
+	grpcServer, err := cmd.NewGRPCServer(ctx, logger, cfg, info, forceMigrate)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Cors           CorsConfig           `json:"cors,omitempty" mapstructure:"cors"`
 	Cache          CacheConfig          `json:"cache,omitempty" mapstructure:"cache"`
 	Server         ServerConfig         `json:"server,omitempty" mapstructure:"server"`
+	Storage        StorageConfig        `json:"storage,omitempty" mapstrucutre:"storage"`
 	Tracing        TracingConfig        `json:"tracing,omitempty" mapstructure:"tracing"`
 	Database       DatabaseConfig       `json:"db,omitempty" mapstructure:"db"`
 	Meta           MetaConfig           `json:"meta,omitempty" mapstructure:"meta"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -245,6 +245,10 @@ func defaultConfig() *Config {
 			GRPCPort:  9000,
 		},
 
+		Storage: StorageConfig{
+			Type: StorageType("database"),
+		},
+
 		Tracing: TracingConfig{
 			Enabled:  false,
 			Exporter: TracingJaeger,

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+type StorageType string
+
+const (
+	DatabaseStorageType = StorageType("database")
+	LocalStorageType    = StorageType("local")
+	GitStorageType      = StorageType("git")
+)
+
+// StorageConfig contains fields which will configure the type of backend in which Flipt will serve
+// flag state.
+type StorageConfig struct {
+	Type  StorageType `json:"type,omitempty" mapstructure:"type"`
+	Local Local       `json:"local,omitempty" mapstructure:"local"`
+	Git   Git         `json:"git,omitempty" mapstructure:"git"`
+}
+
+func (c *StorageConfig) setDefaults(v *viper.Viper) {
+	v.SetDefault("storage", map[string]any{
+		"type": "database",
+		"local": map[string]any{
+			"path": "",
+		},
+		"git": map[string]any{
+			"repository": "",
+			"ref":        "",
+		},
+	})
+}
+
+type Local struct {
+	Path string `json:"path,omitempty" mapstructure:"path"`
+}
+
+type Git struct {
+	Repository string `json:"repository,omitempty" mapstructure:"repository"`
+	Ref        string `json:"ref,omitempty" mapstructure:"ref"`
+}


### PR DESCRIPTION
Basic storage configuration for the multiple backends we can support (future). Git, local, or regular database configuration.

Completes FLI-290