### PR TITLE
 fix(storage/sql): handle null description on constraint during GetSegment

### DIFF
--- a/internal/storage/sql/common/segment.go
+++ b/internal/storage/sql/common/segment.go
@@ -74,6 +74,7 @@ func (s *Store) GetSegment(ctx context.Context, namespaceKey, key string) (*flip
 	for rows.Next() {
 		var (
 			constraint           flipt.Constraint
+			description          sql.NullString
 			createdAt, updatedAt fliptsql.Timestamp
 		)
 
@@ -85,7 +86,7 @@ func (s *Store) GetSegment(ctx context.Context, namespaceKey, key string) (*flip
 			&constraint.Property,
 			&constraint.Operator,
 			&constraint.Value,
-			&constraint.Description,
+			&description,
 			&createdAt,
 			&updatedAt); err != nil {
 			return segment, err
@@ -93,6 +94,7 @@ func (s *Store) GetSegment(ctx context.Context, namespaceKey, key string) (*flip
 
 		constraint.CreatedAt = createdAt.Timestamp
 		constraint.UpdatedAt = updatedAt.Timestamp
+		constraint.Description = description.String
 		segment.Constraints = append(segment.Constraints, &constraint)
 	}
 

--- a/internal/storage/sql/segment_test.go
+++ b/internal/storage/sql/segment_test.go
@@ -86,6 +86,41 @@ func (s *DBTestSuite) TestGetSegmentNamespace_NotFound() {
 	assert.EqualError(t, err, fmt.Sprintf("segment \"%s/foo\" not found", s.namespace))
 }
 
+func (s *DBTestSuite) TestGetSegment_WithConstraint() {
+	t := s.T()
+
+	segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+		Key:         t.Name(),
+		Name:        "foo",
+		Description: "bar",
+		MatchType:   flipt.MatchType_ALL_MATCH_TYPE,
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, segment)
+
+	_, err = s.db.DB.Exec(fmt.Sprintf(`INSERT INTO constraints (id, segment_key, type, property, operator, value) VALUES ('%s', '%s', 1, 'foo', 'eq', 'bar');`,
+		uuid.Must(uuid.NewV4()).String(),
+		segment.Key))
+
+	require.NoError(t, err)
+
+	got, err := s.store.GetSegment(context.TODO(), storage.DefaultNamespace, segment.Key)
+
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+
+	assert.Equal(t, storage.DefaultNamespace, got.NamespaceKey)
+	assert.Equal(t, segment.Key, got.Key)
+	assert.Equal(t, segment.Name, got.Name)
+	assert.Equal(t, segment.Description, got.Description)
+	assert.NotZero(t, segment.CreatedAt)
+	assert.NotZero(t, segment.UpdatedAt)
+	assert.Equal(t, segment.MatchType, got.MatchType)
+
+	require.Len(t, segment.Constraints, 1)
+}
+
 func (s *DBTestSuite) TestListSegments() {
 	t := s.T()
 

--- a/internal/storage/sql/segment_test.go
+++ b/internal/storage/sql/segment_test.go
@@ -39,8 +39,8 @@ func (s *DBTestSuite) TestGetSegment() {
 	assert.Equal(t, segment.Key, got.Key)
 	assert.Equal(t, segment.Name, got.Name)
 	assert.Equal(t, segment.Description, got.Description)
-	assert.NotZero(t, segment.CreatedAt)
-	assert.NotZero(t, segment.UpdatedAt)
+	assert.NotZero(t, got.CreatedAt)
+	assert.NotZero(t, got.UpdatedAt)
 	assert.Equal(t, segment.MatchType, got.MatchType)
 }
 
@@ -67,8 +67,8 @@ func (s *DBTestSuite) TestGetSegmentNamespace() {
 	assert.Equal(t, segment.Key, got.Key)
 	assert.Equal(t, segment.Name, got.Name)
 	assert.Equal(t, segment.Description, got.Description)
-	assert.NotZero(t, segment.CreatedAt)
-	assert.NotZero(t, segment.UpdatedAt)
+	assert.NotZero(t, got.CreatedAt)
+	assert.NotZero(t, got.UpdatedAt)
 	assert.Equal(t, segment.MatchType, got.MatchType)
 }
 
@@ -99,6 +99,7 @@ func (s *DBTestSuite) TestGetSegment_WithConstraint() {
 	require.NoError(t, err)
 	assert.NotNil(t, segment)
 
+	// ensure we support older versions of Flipt where constraints have NULL descriptions.
 	_, err = s.db.DB.Exec(fmt.Sprintf(`INSERT INTO constraints (id, segment_key, type, property, operator, value) VALUES ('%s', '%s', 1, 'foo', 'eq', 'bar');`,
 		uuid.Must(uuid.NewV4()).String(),
 		segment.Key))
@@ -114,11 +115,11 @@ func (s *DBTestSuite) TestGetSegment_WithConstraint() {
 	assert.Equal(t, segment.Key, got.Key)
 	assert.Equal(t, segment.Name, got.Name)
 	assert.Equal(t, segment.Description, got.Description)
-	assert.NotZero(t, segment.CreatedAt)
-	assert.NotZero(t, segment.UpdatedAt)
+	assert.NotZero(t, got.CreatedAt)
+	assert.NotZero(t, got.UpdatedAt)
 	assert.Equal(t, segment.MatchType, got.MatchType)
 
-	require.Len(t, segment.Constraints, 1)
+	require.Len(t, got.Constraints, 1)
 }
 
 func (s *DBTestSuite) TestListSegments() {


### PR DESCRIPTION
Fixes #1653 

This fixes a bug where a segments with constraints existing before version 1.22 are now failing due to their constraint descriptions returning a `NULL`. We were attemping to parse the `NULL` into a string field.
This updates the scan to use a `sql.NullString` for constraint desciption on `GetSegment`.