### PR TITLE
fix: panic if no import file name provided

### DIFF
--- a/cmd/flipt/import.go
+++ b/cmd/flipt/import.go
@@ -84,6 +84,10 @@ func (c *importCommand) run(cmd *cobra.Command, args []string) error {
 	)
 
 	if !c.importStdin {
+		if len(args) < 1 {
+			return errors.New("import filename required")
+		}
+
 		importFilename := args[0]
 		if importFilename == "" {
 			return errors.New("import filename required")


### PR DESCRIPTION
Fixes: FLI-378

`flipt import` panics if filename not provided correctly

## Before

```
workspace/flipt - [fix-import-filename-check] » ./bin/flipt import --config /tmp/flipt.yaml
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.(*importCommand).run(0x1400003d2c0, 0x140006a8f00, {0x1400046c0c0, 0x0, 0x0?})
        go.flipt.io/flipt/cmd/flipt/import.go:87 +0x8b0
github.com/spf13/cobra.(*Command).execute(0x140006a8f00, {0x1400046c080, 0x2, 0x2})
        github.com/spf13/cobra@v1.7.0/command.go:940 +0x5c8
github.com/spf13/cobra.(*Command).ExecuteC(0x140006a8600)
        github.com/spf13/cobra@v1.7.0/command.go:1068 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.7.0/command.go:992
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        github.com/spf13/cobra@v1.7.0/command.go:985
main.main()
        go.flipt.io/flipt/cmd/flipt/main.go:157 +0x6d0
```

## After

```
workspace/flipt - [main●] » ./bin/flipt import --config /tmp/flipt.yaml
Error: import filename required
Usage:
  flipt import [flags]

Flags:
  -a, --address string     address of remote Flipt instance to import into (defaults to direct DB import if not supplied)
      --create-namespace   create the namespace if it does not exist.
      --drop               drop database before import
  -h, --help               help for import
  -n, --namespace string   destination namespace for imported resources. (default "default")
      --stdin              import from STDIN
  -t, --token string       client token used to authenticate access to remote Flipt instance when importing.

Global Flags:
      --config string   path to config file (default "/etc/flipt/config/default.yml")
```

@GeorgeMac I'd like to figure how how we could create some better Fuzz tests or ITs to catch these kinds of errors going forward in CI, any thoughts?