### PR TITLE
chore: fix telemetry typo; add build to codecov ignore

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,4 @@ ignore:
   - "ui"
   - "_tools"
   - "hack"
+  - "build"

--- a/examples/audit/docker-compose.yml
+++ b/examples/audit/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - FLIPT_LOG_LEVEL=debug
       - FLIPT_AUDIT_SINKS_LOG_ENABLED=true
       - FLIPT_AUDIT_SINKS_LOG_FILE=/var/log/flipt/audit.log
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     networks:
       - flipt_network
 

--- a/examples/authentication/dex/docker-compose.yml
+++ b/examples/authentication/dex/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - ./config.yaml:/etc/flipt/config/default.yml
     environment:
       - FLIPT_LOG_LEVEL=debug
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     networks:
       - flipt_network
 

--- a/examples/authentication/proxy/docker-compose.yml
+++ b/examples/authentication/proxy/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - caddy
     environment:
       - FLIPT_LOG_LEVEL=debug
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     networks:
       - flipt_network
 

--- a/examples/basic/docker-compose.yml
+++ b/examples/basic/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - flipt_network
     environment:
       - FLIPT_LOG_LEVEL=debug
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     volumes:
       - "./flipt.db:/var/opt/flipt/flipt.db"
 

--- a/examples/database/cockroachdb/docker-compose.yml
+++ b/examples/database/cockroachdb/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       - FLIPT_DB_URL=cockroach://root@crdb:26257/defaultdb?sslmode=disable
       - FLIPT_LOG_LEVEL=debug
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     command: ["./tmp/wait-for-it.sh", "crdb:26257", "--", "./flipt", "--force-migrate"]
 
 networks:

--- a/examples/database/mysql/docker-compose.yml
+++ b/examples/database/mysql/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       - FLIPT_DB_URL=mysql://mysql:password@mysql:3306/flipt
       - FLIPT_LOG_LEVEL=debug
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     command: ["./tmp/wait-for-it.sh", "mysql:3306", "--", "./flipt", "--force-migrate"]
 
 networks:

--- a/examples/database/postgres/docker-compose.yml
+++ b/examples/database/postgres/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - FLIPT_DB_URL=postgres://postgres:password@postgres:5432/flipt?sslmode=disable
       - FLIPT_LOG_LEVEL=debug
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     command: ["./tmp/wait-for-it.sh", "postgres:5432", "--", "./flipt", "--force-migrate"]
 
 networks:

--- a/examples/metrics/docker-compose.yml
+++ b/examples/metrics/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - FLIPT_CACHE_ENABLED=true
       - FLIPT_CACHE_BACKEND=memory
       - FLIPT_CACHE_TTL=1m
+      - FLIPT_META_TELEMETRY_ENABLED=false
       
   grafana:
     environment:

--- a/examples/nextjs/docker-compose.yml
+++ b/examples/nextjs/docker-compose.yml
@@ -31,8 +31,7 @@ services:
       - "8080:8080"
     environment:
       - FLIPT_LOG_LEVEL=debug
-      - FLIPT_TELMETRY_ENABLED=false
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     volumes:
       - type: bind
         source: ./flipt.db

--- a/examples/openfeature/docker-compose.yml
+++ b/examples/openfeature/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - FLIPT_TRACING_ENABLED=true
       - FLIPT_TRACING_EXPORTER=jaeger
       - FLIPT_TRACING_JAEGER_HOST=jaeger
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     volumes:
       - "./flipt.db:/var/opt/flipt/flipt.db"
 

--- a/examples/redis/docker-compose.yml
+++ b/examples/redis/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - FLIPT_CACHE_REDIS_HOST=redis
       - FLIPT_CACHE_REDIS_PORT=6379
       - FLIPT_LOG_LEVEL=debug
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
     command: ["./tmp/wait-for-it.sh", "redis:6379", "--", "./flipt", "--force-migrate"]
 
 networks:

--- a/examples/tracing/jaeger/docker-compose.yml
+++ b/examples/tracing/jaeger/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - FLIPT_TRACING_ENABLED=true
       - FLIPT_TRACING_EXPORTER=jaeger
       - FLIPT_TRACING_JAEGER_HOST=jaeger
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
 
 networks:
   flipt_network:

--- a/examples/tracing/otlp/docker-compose.yml
+++ b/examples/tracing/otlp/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - FLIPT_TRACING_ENABLED=true
       - FLIPT_TRACING_EXPORTER=otlp
       - FLIPT_TRACING_OTLP_ENDPOINT=otel:4317
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
 
 networks:
   flipt_network:

--- a/examples/tracing/zipkin/docker-compose.yml
+++ b/examples/tracing/zipkin/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - FLIPT_TRACING_ENABLED=true
       - FLIPT_TRACING_EXPORTER=zipkin
       - FLIPT_TRACING_ZIPKIN_ENDPOINT=http://zipkin:9411/api/v2/spans
-      - FLIPT_META_TELMETRY_ENABLED=false
+      - FLIPT_META_TELEMETRY_ENABLED=false
 
 networks:
   flipt_network:


### PR DESCRIPTION
s/`FLIPT_META_TELMETRY_ENABLED`/`FLIPT_META_TELEMETRY_ENABLED`/g