### PR TITLE
fix: catch errs on call to namespaces API in namespace form

### DIFF
--- a/ui/src/components/namespaces/NamespaceForm.tsx
+++ b/ui/src/components/namespaces/NamespaceForm.tsx
@@ -38,12 +38,12 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
 
   const handleSubmit = async (values: INamespaceBase) => {
     if (isNew) {
-      return dispatch(createNamespaceAsync(values));
+      return dispatch(createNamespaceAsync(values)).unwrap();
     }
 
     return dispatch(
       updateNamespaceAsync({ key: namespace.key, namespace: values })
-    );
+    ).unwrap();
   };
 
   return (


### PR DESCRIPTION
catches errors on namespaces form if namespaces API returns err

more: https://redux-toolkit.js.org/api/createAsyncThunk#unwrapping-result-actions

## Before

1. shutdown backend server (API)
2. try to create namespace
3. see the success msg even though nothing was created

![Kapture 2023-06-01 at 10 48 01](https://github.com/flipt-io/flipt/assets/209477/4d704868-7cc5-4bed-befd-d66e616008e6)

## After

1. shutdown backend server (API)
2. try to create namespace
3. proper err message

![CleanShot 2023-06-01 at 10 39 59](https://github.com/flipt-io/flipt/assets/209477/bc5a5548-d088-480b-be4c-4ecb1d77b9a4)

