### PR TITLE
feat(config): add support for experimental configuration and features

### DIFF
--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -176,6 +176,7 @@ func git(ctx context.Context, client *dagger.Client, base, flipt *dagger.Contain
 	flipt = flipt.
 		WithServiceBinding("gitea", gitea).
 		WithEnvVariable("FLIPT_LOG_LEVEL", "DEBUG").
+		WithEnvVariable("FLIPT_EXPERIMENTAL_FILESYSTEM_STORAGE_ENABLED", "true").
 		WithEnvVariable("FLIPT_STORAGE_TYPE", "git").
 		WithEnvVariable("FLIPT_STORAGE_GIT_REPOSITORY", "http://gitea:3000/root/features.git").
 		WithEnvVariable("UNIQUE", uuid.New().String()).

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -114,7 +114,7 @@ func NewGRPCServer(
 	var store storage.Store
 
 	switch cfg.Storage.Type {
-	case config.DatabaseStorageType:
+	case "", config.DatabaseStorageType:
 		db, driver, shutdown, err := getDB(ctx, logger, cfg, forceMigrate)
 		if err != nil {
 			return nil, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
-var decodeHooks = mapstructure.ComposeDecodeHookFunc(
+var decodeHooks = []mapstructure.DecodeHookFunc{
 	mapstructure.StringToTimeDurationHookFunc(),
 	stringToSliceHookFunc(),
 	stringToEnumHookFunc(stringToLogEncoding),
@@ -22,7 +22,7 @@ var decodeHooks = mapstructure.ComposeDecodeHookFunc(
 	stringToEnumHookFunc(stringToScheme),
 	stringToEnumHookFunc(stringToDatabaseProtocol),
 	stringToEnumHookFunc(stringToAuthMethod),
-)
+}
 
 // Config contains all of Flipts configuration needs.
 //
@@ -38,12 +38,13 @@ var decodeHooks = mapstructure.ComposeDecodeHookFunc(
 // any errors derived from the resulting state of the configuration.
 type Config struct {
 	Version        string               `json:"version,omitempty"`
+	Experimental   ExperimentalConfig   `json:"experimental,omitempty" mapstructure:"experimental"`
 	Log            LogConfig            `json:"log,omitempty" mapstructure:"log"`
 	UI             UIConfig             `json:"ui,omitempty" mapstructure:"ui"`
 	Cors           CorsConfig           `json:"cors,omitempty" mapstructure:"cors"`
 	Cache          CacheConfig          `json:"cache,omitempty" mapstructure:"cache"`
 	Server         ServerConfig         `json:"server,omitempty" mapstructure:"server"`
-	Storage        StorageConfig        `json:"storage,omitempty" mapstructure:"storage"`
+	Storage        StorageConfig        `json:"storage,omitempty" mapstructure:"storage" experiment:"filesystem_storage"`
 	Tracing        TracingConfig        `json:"tracing,omitempty" mapstructure:"tracing"`
 	Database       DatabaseConfig       `json:"db,omitempty" mapstructure:"db"`
 	Meta           MetaConfig           `json:"meta,omitempty" mapstructure:"meta"`
@@ -102,16 +103,25 @@ func Load(path string) (*Result, error) {
 	root := reflect.ValueOf(cfg).Interface()
 	f(root)
 
+	// these are reflected config top-level types for fields where
+	// they have been marked as experimental and their associated
+	// flag has enabled set to false.
+	var skippedTypes []reflect.Type
+
 	val := reflect.ValueOf(cfg).Elem()
 	for i := 0; i < val.NumField(); i++ {
 		// search for all expected env vars since Viper cannot
 		// infer when doing Unmarshal + AutomaticEnv.
 		// see: https://github.com/spf13/viper/issues/761
-		var (
-			structField = val.Type().Field(i)
-			key         = fieldKey(structField)
-		)
+		structField := val.Type().Field(i)
+		if exp := structField.Tag.Get("experiment"); exp != "" {
+			// TODO(georgemac): register target for skipping
+			if !v.GetBool(fmt.Sprintf("experimental.%s.enabled", exp)) {
+				skippedTypes = append(skippedTypes, structField.Type)
+			}
+		}
 
+		key := fieldKey(structField)
 		bindEnvVars(v, getFliptEnvs(), []string{key}, structField.Type)
 
 		field := val.Field(i).Addr().Interface()
@@ -131,7 +141,11 @@ func Load(path string) (*Result, error) {
 		defaulter.setDefaults(v)
 	}
 
-	if err := v.Unmarshal(cfg, viper.DecodeHook(decodeHooks)); err != nil {
+	if err := v.Unmarshal(cfg, viper.DecodeHook(
+		mapstructure.ComposeDecodeHookFunc(
+			append(decodeHooks, experimentalFieldSkipHookFunc(skippedTypes...))...,
+		),
+	)); err != nil {
 		return nil, err
 	}
 
@@ -346,6 +360,30 @@ func stringToEnumHookFunc[T constraints.Integer](mappings map[string]T) mapstruc
 		enum := mappings[data.(string)]
 
 		return enum, nil
+	}
+}
+
+func experimentalFieldSkipHookFunc(types ...reflect.Type) mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if len(types) == 0 {
+			return data, nil
+		}
+
+		if t.Kind() != reflect.Struct {
+			return data, nil
+		}
+
+		// skip any types that match a type in the provided set
+		for _, typ := range types {
+			if t == typ {
+				return reflect.New(typ).Interface(), nil
+			}
+		}
+
+		return data, nil
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -245,10 +245,6 @@ func defaultConfig() *Config {
 			GRPCPort:  9000,
 		},
 
-		Storage: StorageConfig{
-			Type: StorageType("database"),
-		},
-
 		Tracing: TracingConfig{
 			Enabled:  false,
 			Exporter: TracingJaeger,
@@ -544,6 +540,9 @@ func TestLoad(t *testing.T) {
 			path: "./testdata/advanced.yml",
 			expected: func() *Config {
 				cfg := defaultConfig()
+
+				cfg.Experimental.FilesystemStorage.Enabled = true
+
 				cfg.Log = LogConfig{
 					Level:     "WARN",
 					File:      "testLogFile.txt",
@@ -587,6 +586,9 @@ func TestLoad(t *testing.T) {
 					OTLP: OTLPTracingConfig{
 						Endpoint: "localhost:4317",
 					},
+				}
+				cfg.Storage = StorageConfig{
+					Type: StorageType("database"),
 				}
 				cfg.Database = DatabaseConfig{
 					URL:             "postgres://postgres@localhost:5432/flipt?sslmode=disable",
@@ -680,6 +682,7 @@ func TestLoad(t *testing.T) {
 			path: "./testdata/storage/local_provided.yml",
 			expected: func() *Config {
 				cfg := defaultConfig()
+				cfg.Experimental.FilesystemStorage.Enabled = true
 				cfg.Storage = StorageConfig{
 					Type: LocalStorageType,
 					Local: Local{
@@ -694,6 +697,7 @@ func TestLoad(t *testing.T) {
 			path: "./testdata/storage/git_provided.yml",
 			expected: func() *Config {
 				cfg := defaultConfig()
+				cfg.Experimental.FilesystemStorage.Enabled = true
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: Git{

--- a/internal/config/experimental.go
+++ b/internal/config/experimental.go
@@ -1,0 +1,13 @@
+package config
+
+// ExperimentalConfig allows for experimental features to be enabled
+// and disabled.
+type ExperimentalConfig struct {
+	FilesystemStorage ExperimentalFlag `json:"filesystem_storage,omitempty" mapstructure:"filesystem_storage"`
+}
+
+// ExperimentalFlag is a structure which has properties to configure
+// experimental feature enablement.
+type ExperimentalFlag struct {
+	Enabled bool `json:"enabled,omitempty" mapstructure:"enabled"`
+}

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -1,3 +1,7 @@
+experimental:
+  filesystem_storage:
+    enabled: true
+
 log:
   level: WARN
   file: "testLogFile.txt"

--- a/internal/config/testdata/storage/git_basic_auth_invalid.yml
+++ b/internal/config/testdata/storage/git_basic_auth_invalid.yml
@@ -1,3 +1,6 @@
+experimental:
+  filesystem_storage:
+    enabled: true
 storage:
   type: git
   git:

--- a/internal/config/testdata/storage/git_provided.yml
+++ b/internal/config/testdata/storage/git_provided.yml
@@ -1,3 +1,6 @@
+experimental:
+  filesystem_storage:
+    enabled: true
 storage:
   type: git
   git:

--- a/internal/config/testdata/storage/invalid_git_repo_not_specified.yml
+++ b/internal/config/testdata/storage/invalid_git_repo_not_specified.yml
@@ -1,2 +1,5 @@
+experimental:
+  filesystem_storage:
+    enabled: true
 storage:
   type: git

--- a/internal/config/testdata/storage/local_provided.yml
+++ b/internal/config/testdata/storage/local_provided.yml
@@ -1,2 +1,5 @@
+experimental:
+  filesystem_storage:
+    enabled: true
 storage:
   type: local


### PR DESCRIPTION
Fixes FLI-396

This gives us the ability to create conditionally enabled and disabled configuration sections.
Giving us the ability to feature toggle entire sections within flipt via the `experimental` section of the config file.

Making a section experimental is done by adding a struct tag `experiment:"<key>"` where `key` is the `mapstructure` key for the `ExperimentalFlag` defined within the `ExperimentalConfig`. By connecting these dots the config parser will lookup whether or not a flag is in an enabled state and if not, set the config target to it's zero value.

This PR also adds a experimental guard around the new `storage` section.

https://github.com/flipt-io/flipt/blob/eb1ee40e9047ea3805829a52cdefc40d5885603e/internal/config/experimental.go#L6

Note that there is one flag currently called `FilesystemStorage` with a `mapstructure` tag `filesystem_storage`.

https://github.com/flipt-io/flipt/blob/eb1ee40e9047ea3805829a52cdefc40d5885603e/internal/config/config.go#L47

Then the new `Storage` field is tagged with `experment:"filesystem_storage"`.

This is all that is needed to conditionally parse a section altgother.