### PR TITLE
feat(cmd): install fs local backend into flipt

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        test: ["api", "fs/git", "import/export"]
+        test: ["api", "fs/git", "fs/local", "import/export"]
     steps:
       - uses: actions/checkout@v3
 

--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -26,6 +26,7 @@ var (
 	AllCases = map[string]testCaseFn{
 		"api":           api,
 		"fs/git":        git,
+		"fs/local":      local,
 		"import/export": importExport,
 	}
 )
@@ -158,6 +159,19 @@ const (
 	testdataDir     = "build/testing/integration/readonly/testdata"
 	testdataPathFmt = testdataDir + "/%s.yaml"
 )
+
+func local(ctx context.Context, client *dagger.Client, base, flipt *dagger.Container, conf testConfig) func() error {
+	flipt = flipt.
+		WithDirectory("/tmp/testdata", base.Directory(testdataDir)).
+		WithEnvVariable("FLIPT_LOG_LEVEL", "DEBUG").
+		WithEnvVariable("FLIPT_EXPERIMENTAL_FILESYSTEM_STORAGE_ENABLED", "true").
+		WithEnvVariable("FLIPT_STORAGE_TYPE", "local").
+		WithEnvVariable("FLIPT_STORAGE_LOCAL_PATH", "/tmp/testdata").
+		WithEnvVariable("UNIQUE", uuid.New().String()).
+		WithExec(nil)
+
+	return suite(ctx, "readonly", base, flipt, conf)
+}
 
 func git(ctx context.Context, client *dagger.Client, base, flipt *dagger.Container, conf testConfig) func() error {
 	gitea := client.Container().

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"go.flipt.io/flipt/internal/storage/fs/git"
+	"go.flipt.io/flipt/internal/storage/fs/local"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
@@ -153,6 +154,16 @@ func NewGRPCServer(
 		}
 
 		source, err := git.NewSource(logger, cfg.Storage.Git.Repository, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		store, err = fs.NewStore(logger, source)
+		if err != nil {
+			return nil, err
+		}
+	case config.LocalStorageType:
+		source, err := local.NewSource(logger, cfg.Storage.Local.Path)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes FLI-399

This installs the new `local.Source` into the `flipt` binary.

It also installs a new set of ITs `fs/local` for ensuring this behaviour with the existing readonly suite.