### PR TITLE
fix(mage): install package-changed as dev dependency

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -71,6 +71,7 @@
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "jest": "^29.5.0",
+        "package-changed": "^3.0.0",
         "postcss": "^8.4.24",
         "prettier": "^2.8.8",
         "prettier-plugin-organize-imports": "^3.2.2",
@@ -10223,6 +10224,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-changed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/package-changed/-/package-changed-3.0.0.tgz",
+      "integrity": "sha512-HSRbrO+Ab5AuqqYGSevtKJ1Yt96jW1VKV7wrp8K4SKj5tyDp/7D96uPCQyCPiNtWTEH/7nA3hZ4z2slbc9yFxg==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^6.2.0"
+      },
+      "bin": {
+        "package-changed": "bin/package-changed.js"
+      }
+    },
+    "node_modules/package-changed/node_modules/commander": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -19544,6 +19566,23 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "package-changed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/package-changed/-/package-changed-3.0.0.tgz",
+      "integrity": "sha512-HSRbrO+Ab5AuqqYGSevtKJ1Yt96jW1VKV7wrp8K4SKj5tyDp/7D96uPCQyCPiNtWTEH/7nA3hZ4z2slbc9yFxg==",
+      "dev": true,
+      "requires": {
+        "commander": "^6.2.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+          "dev": true
+        }
+      }
     },
     "parent-module": {
       "version": "1.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -75,6 +75,7 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "jest": "^29.5.0",
+    "package-changed": "^3.0.0",
     "postcss": "^8.4.24",
     "prettier": "^2.8.8",
     "prettier-plugin-organize-imports": "^3.2.2",


### PR DESCRIPTION
Took me a hot minute to track this one down:
```
➜  mage
Preparing...
Cleaning...
Installing UI deps...
npm ERR! canceled

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/georgemac/.npm/_logs/2023-06-08T09_51_53_487Z-debug-0.log
```

That "complete log" is useless. Turns out `package-changed` was not installed.
There is a bug open regarding it on npm:
https://github.com/npm/cli/issues/6215

This installs `packaged-changed` as a dev dependency.