### PR TITLE
fix: cross namespaced constraints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -61,10 +61,11 @@ issues:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/pkg/errors
+    rules:
+      main:
+        deny:
+          - pkg: "github.com/pkg/errors"
+            desc: Should be replaced by standard lib errors package
   staticcheck:
     checks:
       - all
@@ -77,3 +78,5 @@ linters-settings:
     excludes: # exclude gosec messages about weak crypto
       - "G501"
       - "G401"
+  goconst:
+    ignore-tests: true

--- a/internal/storage/sql/common/segment.go
+++ b/internal/storage/sql/common/segment.go
@@ -57,7 +57,7 @@ func (s *Store) GetSegment(ctx context.Context, namespaceKey, key string) (*flip
 
 	query := s.builder.Select("id, namespace_key, segment_key, type, property, operator, value, description, created_at, updated_at").
 		From("constraints").
-		Where(sq.Eq{"segment_key": segment.Key}).
+		Where(sq.And{sq.Eq{"namespace_key": segment.NamespaceKey}, sq.Eq{"segment_key": segment.Key}}).
 		OrderBy("created_at ASC")
 
 	rows, err := query.QueryContext(ctx)

--- a/internal/storage/sql/segment_test.go
+++ b/internal/storage/sql/segment_test.go
@@ -860,6 +860,68 @@ func (s *DBTestSuite) TestCreateConstraintNamespace_SegmentNotFound() {
 	assert.EqualError(t, err, fmt.Sprintf("segment \"%s/foo\" not found", s.namespace))
 }
 
+// bug: two segments created with same key with same constraint keys in two different namespaces, we return both constraints when getting a single segment
+func (s *DBTestSuite) TestGetSegmentWithConstraintMultiNamespace() {
+	t := s.T()
+
+	for _, namespace := range []string{storage.DefaultNamespace, s.namespace} {
+		segment, err := s.store.CreateSegment(context.TODO(), &flipt.CreateSegmentRequest{
+			NamespaceKey: namespace,
+			Key:          t.Name(),
+			Name:         "foo",
+			Description:  "bar",
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, segment)
+
+		constraint, err := s.store.CreateConstraint(context.TODO(), &flipt.CreateConstraintRequest{
+			NamespaceKey: namespace,
+			SegmentKey:   segment.Key,
+			Type:         flipt.ComparisonType_STRING_COMPARISON_TYPE,
+			Property:     "foo",
+			Operator:     "EQ",
+			Value:        "bar",
+			Description:  "desc",
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, constraint)
+
+		assert.NotZero(t, constraint.Id)
+		assert.Equal(t, namespace, constraint.NamespaceKey)
+		assert.Equal(t, segment.Key, constraint.SegmentKey)
+		assert.Equal(t, flipt.ComparisonType_STRING_COMPARISON_TYPE, constraint.Type)
+		assert.Equal(t, "foo", constraint.Property)
+		assert.Equal(t, flipt.OpEQ, constraint.Operator)
+		assert.Equal(t, "bar", constraint.Value)
+		assert.NotZero(t, constraint.CreatedAt)
+		assert.Equal(t, constraint.CreatedAt.Seconds, constraint.UpdatedAt.Seconds)
+		assert.Equal(t, "desc", constraint.Description)
+	}
+
+	// get the default namespaced segment
+	segment, err := s.store.GetSegment(context.TODO(), storage.DefaultNamespace, t.Name())
+
+	require.NoError(t, err)
+	assert.NotNil(t, segment)
+
+	// ensure we aren't crossing namespaces
+	assert.Len(t, segment.Constraints, 1)
+
+	constraint := segment.Constraints[0]
+	assert.NotZero(t, constraint.Id)
+	assert.Equal(t, storage.DefaultNamespace, constraint.NamespaceKey)
+	assert.Equal(t, segment.Key, constraint.SegmentKey)
+	assert.Equal(t, flipt.ComparisonType_STRING_COMPARISON_TYPE, constraint.Type)
+	assert.Equal(t, "foo", constraint.Property)
+	assert.Equal(t, flipt.OpEQ, constraint.Operator)
+	assert.Equal(t, "bar", constraint.Value)
+	assert.NotZero(t, constraint.CreatedAt)
+	assert.Equal(t, constraint.CreatedAt.Seconds, constraint.UpdatedAt.Seconds)
+	assert.Equal(t, "desc", constraint.Description)
+}
+
 func (s *DBTestSuite) TestUpdateConstraint() {
 	t := s.T()
 

--- a/internal/storage/sql/segment_test.go
+++ b/internal/storage/sql/segment_test.go
@@ -860,7 +860,7 @@ func (s *DBTestSuite) TestCreateConstraintNamespace_SegmentNotFound() {
 	assert.EqualError(t, err, fmt.Sprintf("segment \"%s/foo\" not found", s.namespace))
 }
 
-// bug: two segments created with same key with same constraint keys in two different namespaces, we return both constraints when getting a single segment
+// see: https://github.com/flipt-io/flipt/pull/1721/
 func (s *DBTestSuite) TestGetSegmentWithConstraintMultiNamespace() {
 	t := s.T()
 


### PR DESCRIPTION
fixes bug where we werent using the `namespace_key` when looking up constraints for segments