### PR TITLE
test(cli): ensure user configuration path supported

### DIFF
--- a/build/testing/cli.go
+++ b/build/testing/cli.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"dagger.io/dagger"
 )
@@ -50,6 +49,48 @@ Run 'flipt --help' for usage.`))); err != nil {
 		if _, err := assertExec(ctx, container, flipt("--config", "/tmp"),
 			fails,
 			stdout(contains(`loading configuration: Unsupported Config Type`)),
+		); err != nil {
+			return err
+		}
+	}
+
+	{
+		container := container.Pipeline("flipt (no config)")
+		if _, err := assertExec(ctx, container.WithExec([]string{"rm", "/etc/flipt/config/default.yml"}), flipt(),
+			fails,
+			stdout(contains(`loading configuration	{"error": "loading configuration: open /etc/flipt/config/default.yml: no such file or directory", "config_path": "/etc/flipt/config/default.yml"}`)),
+		); err != nil {
+			return err
+		}
+	}
+
+	{
+		container := container.Pipeline("flipt (user config directory)")
+		container = container.
+			WithExec([]string{"mkdir", "-p", "/home/flipt/.config/flipt"}).
+			WithFile("/home/flipt/.config/flipt/config.yml", client.Host().Directory("build/testing/testdata").File("default.yml")).
+			// in order to stop a blocking process via SIGTERM and capture a successful exit code
+			// we use a shell script to start flipt in the background, sleep for two seconds,
+			// send the SIGTERM signal, wait for process to exit and then propagate Flipts exit code
+			WithNewFile("/test.sh", dagger.ContainerWithNewFileOpts{
+				Contents: `#!/bin/sh
+
+/flipt &
+
+sleep 2
+
+kill -s TERM $!
+
+wait $!
+
+exit $?`,
+				Owner:       "flipt",
+				Permissions: 0777,
+			}).
+			WithEnvVariable("FLIPT_LOG_LEVEL", "debug")
+
+		if _, err := assertExec(ctx, container, []string{"/test.sh"},
+			stdout(contains("configuration source\t{\"path\": \"/home/flipt/.config/flipt/config.yml\"}")),
 		); err != nil {
 			return err
 		}
@@ -115,34 +156,6 @@ Run 'flipt --help' for usage.`))); err != nil {
 	{
 		container := container.Pipeline("flipt migrate")
 		if _, err := assertExec(ctx, container, flipt("migrate")); err != nil {
-			return err
-		}
-	}
-
-	{
-		container := container.Pipeline("flipt")
-		if _, err := assertExec(ctx, container.WithExec([]string{"rm", "/etc/flipt/config/default.yml"}), flipt(),
-			fails,
-			stdout(contains(`loading configuration	{"error": "loading configuration: open /etc/flipt/config/default.yml: no such file or directory", "config_path": "/etc/flipt/config/default.yml"}`)),
-		); err != nil {
-			return err
-		}
-	}
-
-	{
-		container := container.Pipeline("flipt")
-		ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
-		defer cancel()
-
-		container = container.
-			WithExec([]string{"mkdir", "-p", "/home/flipt/.config/flipt"}).
-			WithFile("/home/flipt/.config/flipt/config.yml", client.Host().Directory("build/testing/testdata").File("default.yml")).
-			WithEnvVariable("FLIPT_LOG_LEVEL", "debug")
-
-		if _, err := assertExec(ctx, container, flipt(),
-			fails,
-			stdout(contains(`configuration source    {"path": "/home/flipt/.config/flipt/config.yml"}`)),
-		); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This ensures that the user default configuration directory is supported.
It does so by starting Flipt process in a background process, sleeping for 2 seconds, sending a SIGTERM to start a graceful shutdown and then propagating the background processes exit code from the script.