### PR TITLE
test(integration): ensure public and auth self routes are reachable

### DIFF
--- a/build/testing/integration/api/api.go
+++ b/build/testing/integration/api/api.go
@@ -13,9 +13,7 @@ import (
 	sdk "go.flipt.io/flipt/sdk/go"
 )
 
-func API(t *testing.T, client sdk.SDK, namespace string) {
-	ctx := context.Background()
-
+func API(t *testing.T, ctx context.Context, client sdk.SDK, namespace string, authenticated bool) {
 	t.Run("Namespaces", func(t *testing.T) {
 		if !namespaceIsDefault(namespace) {
 			t.Log(`Create namespace.`)
@@ -622,6 +620,21 @@ func API(t *testing.T, client sdk.SDK, namespace string) {
 			assert.True(t, ok, "Missing %s.", name)
 			assert.NotEmpty(t, field)
 		}
+	})
+
+	t.Run("Auth", func(t *testing.T) {
+		t.Run("Self", func(t *testing.T) {
+			_, err := client.Auth().AuthenticationService().GetAuthenticationSelf(ctx)
+			if authenticated {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, "rpc error: code = Unauthenticated desc = request was not authenticated")
+			}
+		})
+		t.Run("Public", func(t *testing.T) {
+			_, err := client.Auth().PublicAuthenticationService().ListAuthenticationMethods(ctx)
+			require.NoError(t, err)
+		})
 	})
 }
 

--- a/build/testing/integration/api/api_test.go
+++ b/build/testing/integration/api/api_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	"go.flipt.io/flipt/build/testing/integration"
@@ -10,7 +11,9 @@ import (
 
 func TestAPI(t *testing.T) {
 	integration.Harness(t, func(t *testing.T, sdk sdk.SDK, namespace string, authentication bool) {
-		api.API(t, sdk, namespace)
+		ctx := context.Background()
+
+		api.API(t, ctx, sdk, namespace, authentication)
 
 		// run extra tests in authenticated context
 		if authentication {


### PR DESCRIPTION
Fixes FLI-402

This initial WIP defines the failing tests for this issue.
Currently, we're not mounting the authentication endpoints when auth is configured as not required in the filesystem backends work. This leads to both the public and self endpoints to not be reachable (404).

The frontend expects these endpoints to be present. Also, we have a (somewhat) feature, which is that you can still list authentication entries when all of the auth subsystem is disabled. Given there happen to have previously been authentication credentials entered into backing database.

In order to continue supporting this, we're going to connect to the database whenver the database backend is configured for flag storage. However, in order to support not attempting DB connections with the new git and local backends, we're going to remove this feature from that particular configuration setup. The endpoints will be reachable, however, they will always return an empty set. This is until you enable at-least a authentication method (e.g. token) or make authentication required.