### PR TITLE
feat(telemetry): track storage type

### DIFF
--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -43,9 +43,10 @@ type authentication struct {
 }
 
 type flipt struct {
-	Version        string          `json:"version"`
-	Storage        *storage        `json:"storage,omitempty"`
-	Authentication *authentication `json:"authentication,omitempty"`
+	Version        string                    `json:"version"`
+	Storage        *storage                  `json:"storage,omitempty"`
+	Authentication *authentication           `json:"authentication,omitempty"`
+	Experimental   config.ExperimentalConfig `json:"experimental,omitempty"`
 }
 
 type state struct {
@@ -175,7 +176,8 @@ func (r *Reporter) ping(_ context.Context, f file) error {
 	var (
 		props = analytics.NewProperties()
 		flipt = flipt{
-			Version: info.Version,
+			Version:      info.Version,
+			Experimental: r.cfg.Experimental,
 		}
 	)
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -33,6 +33,7 @@ type ping struct {
 }
 
 type storage struct {
+	Type     string `json:"type,omitempty"`
 	Database string `json:"database,omitempty"`
 	Cache    string `json:"cache,omitempty"`
 }
@@ -191,6 +192,7 @@ func (r *Reporter) ping(_ context.Context, f file) error {
 	}
 
 	flipt.Storage = &storage{
+		Type:     string(r.cfg.Storage.Type),
 		Database: dbProtocol,
 	}
 


### PR DESCRIPTION
Fixes FLI-404

This adds two new properties to the existing telemetry data.
These include:

- The storage type if defined (currently one of [`""`, `database`, `local` or `git`]).
- The entire experimental feature flag section (whether or not an experimental feature was enabled).