### PR TITLE
chore: fix Dagger UI build as node-18 bumped to a different base image

### DIFF
--- a/build/internal/ui.go
+++ b/build/internal/ui.go
@@ -23,7 +23,7 @@ func UI(ctx context.Context, client *dagger.Client) (*dagger.Container, error) {
 
 	cache := client.CacheVolume(fmt.Sprintf("node-modules-%x", sha256.Sum256([]byte(contents))))
 
-	return client.Container().From("node:18").
+	return client.Container().From("node:18-bullseye").
 		WithMountedDirectory("/src", src).WithWorkdir("/src").
 		WithMountedCache("/src/node_modules", cache).
 		WithExec([]string{"npm", "install"}).


### PR DESCRIPTION
the `node:18` tag recently was bumped up to be based on debian `bookworm`, which apparently playwright doesn't like (see: https://github.com/flipt-io/flipt/actions/runs/5257503513/jobs/9500375823)

this pins us to the previous version that we were using `bullseye` for our UI ITs

https://hub.docker.com/layers/library/node/18/images/sha256-d0afe9aa33273de0aa336cc70844be7ba9f0c82deb6c06a07d4d8e01ec11f750?context=explore

We could consider looking into what it would take to get playwright to work with this newer version.. or just carry on with using bullseye for now

