### PR TITLE
Fixed the dark mode in select component.

### DIFF
--- a/ui/src/components/forms/Select.tsx
+++ b/ui/src/components/forms/Select.tsx
@@ -22,7 +22,7 @@ export default function Select(props: SelectProps) {
     <select
       {...field}
       id={id}
-      className={`${className} block rounded-md py-2 pl-3 pr-10 text-base border-gray-300 focus:outline-none focus:ring-violet-300 focus:border-violet-300 sm:text-sm`}
+      className={`${className} block rounded-md py-2 pl-3 pr-10 text-base border-gray-300 bg-gray-50 text-gray-900 focus:outline-none focus:ring-violet-300 focus:border-violet-300 sm:text-sm`}
       value={value}
       onChange={onChange || field.onChange}
     >


### PR DESCRIPTION
Hi, the Select component (that is used in the settings section) was not compatible with dark mode. I fixed this by adding the desired classes to the element. 