### PR TITLE
fix: input bg / text in darkmode

### DIFF
--- a/ui/src/components/forms/Input.tsx
+++ b/ui/src/components/forms/Input.tsx
@@ -31,7 +31,7 @@ export default function Input(props: InputProps) {
         ref={forwardRef}
         className={classNames(
           hasError ? 'border-red-400' : 'border-gray-300',
-          `${className} block w-full rounded-md shadow-sm focus:ring-violet-300 focus:border-violet-300 disabled:cursor-not-allowed disabled:text-gray-500 disabled:bg-gray-50 disabled:border-gray-200 sm:text-sm`
+          `${className} block w-full rounded-md shadow-sm text-gray-900 bg-gray-50 focus:ring-violet-300 focus:border-violet-300 disabled:cursor-not-allowed disabled:text-gray-500 disabled:bg-gray-100 disabled:border-gray-200 sm:text-sm`
         )}
         id={id}
         type={type}

--- a/ui/src/components/forms/Select.tsx
+++ b/ui/src/components/forms/Select.tsx
@@ -22,7 +22,7 @@ export default function Select(props: SelectProps) {
     <select
       {...field}
       id={id}
-      className={`${className} block rounded-md py-2 pl-3 pr-10 text-base border-gray-300 bg-gray-50 text-gray-900 focus:outline-none focus:ring-violet-300 focus:border-violet-300 sm:text-sm`}
+      className={`${className} block rounded-md py-2 pl-3 pr-10 text-base text-gray-900 bg-gray-50 border-gray-300 focus:outline-none focus:ring-violet-300 focus:border-violet-300 sm:text-sm`}
       value={value}
       onChange={onChange || field.onChange}
     >

--- a/ui/src/components/forms/TextArea.tsx
+++ b/ui/src/components/forms/TextArea.tsx
@@ -22,7 +22,7 @@ export default function TextArea(props: TextAreaProps) {
         rows={rows}
         className={classNames(
           hasError ? 'border-red-400' : 'border-gray-300',
-          `${className} block w-full rounded-md shadow-sm focus:ring-violet-500 focus:border-violet-500 sm:text-sm`
+          `${className} block w-full rounded-md shadow-sm text-gray-900 bg-gray-50 focus:ring-violet-500 focus:border-violet-500 sm:text-sm`
         )}
         placeholder={placeholder}
         autoComplete={autocomplete ? 'on' : 'off'}


### PR DESCRIPTION
like #1747 but for text inputs

## Before
![localhost_8080_(Desktop) (8)](https://github.com/flipt-io/flipt/assets/209477/83f11314-9283-4f5c-a273-568770b86a03)

## After
![localhost_8080_(Desktop) (13)](https://github.com/flipt-io/flipt/assets/209477/e1d6f15e-a668-4185-acc0-10125421ebde)
