### PR TITLE
fix: prevent overwriting URL struct

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -241,12 +240,7 @@ func (h *HTTPServer) Shutdown(ctx context.Context) error {
 
 func removeTrailingSlash(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		u, err := url.Parse(strings.TrimSuffix(r.URL.Path, "/"))
-		// Panic if URL can not be parsed if a trailing slash is trimmed.
-		if err != nil {
-			panic(err)
-		}
-		r.URL = u
+		r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")
 		h.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
I noticed that OIDC authentication was broken with the message `{"code":13,"message":"handling OIDC callback: Provider.Exchange: authentication request state and authorization state are not equal: invalid parameter","details":[]}`, beginning with the changes from https://github.com/flipt-io/flipt/pull/1754. 

This fix stops the `http.Request.URL` struct from being overwritten to preserve the query data.

EDIT: Just realised that this is the same change that @GeorgeMac suggested (https://github.com/flipt-io/flipt/pull/1754#discussion_r1230635329)