### PR TITLE
test(integration): ensure all list limits are enforced correctly

### DIFF
--- a/build/testing/integration/readonly/readonly_test.go
+++ b/build/testing/integration/readonly/readonly_test.go
@@ -110,6 +110,9 @@ func TestReadOnly(t *testing.T) {
 					})
 					require.NoError(t, err)
 
+					// ensure each page is of length 10
+					assert.Len(t, flags.Flags, 10)
+
 					found = append(found, flags.Flags...)
 
 					if flags.NextPageToken == "" {
@@ -171,6 +174,9 @@ func TestReadOnly(t *testing.T) {
 						PageToken:    nextPage,
 					})
 					require.NoError(t, err)
+
+					// ensure each page is of length 10
+					assert.Len(t, segments.Segments, 10)
 
 					found = append(found, segments.Segments...)
 
@@ -255,6 +261,9 @@ func TestReadOnly(t *testing.T) {
 						PageToken:    nextPage,
 					})
 					require.NoError(t, err)
+
+					// ensure each page is of length 10
+					assert.Len(t, rules.Rules, 10)
 
 					found = append(found, rules.Rules...)
 


### PR DESCRIPTION
In this PR there is a fix for this issue: https://github.com/flipt-io/flipt/pull/1784

This adds a check to each of the list integration tests we have to actually check the page size.
So far this test has been ensuring that after a full walk the result is the entire contents of Flipt.
However, it wasn't ensuring that each page was exactly the size of the explicit limit.

The trailing slash code is stripping all the query parameters, but this test passed because the result is still the entire contents of Flipt being returned.
I will get this merged once it is rebased on the fix provided by @MattNotarangelo.