### PR TITLE
test(integration): ensure Evaluation.Variant returns as expected

### DIFF
--- a/build/testing/integration/api/api.go
+++ b/build/testing/integration/api/api.go
@@ -119,10 +119,10 @@ func API(t *testing.T, ctx context.Context, client sdk.SDK, namespace string, au
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, "test", disabled.Key)
-		assert.Equal(t, "Test", disabled.Name)
-		assert.Equal(t, "This is a test flag", disabled.Description)
-		assert.True(t, disabled.Enabled, "Flag should be enabled")
+		assert.Equal(t, "disabled", disabled.Key)
+		assert.Equal(t, "Disabled", disabled.Name)
+		assert.Equal(t, "This is a disabled test flag", disabled.Description)
+		assert.False(t, disabled.Enabled, "Flag should be disabled")
 
 		t.Log("Retrieve flag with key \"test\".")
 
@@ -639,12 +639,10 @@ func API(t *testing.T, ctx context.Context, client sdk.SDK, namespace string, au
 					EntityId:     uuid.Must(uuid.NewV4()).String(),
 					Context:      map[string]string{},
 				})
-				require.NoError(t, err)
 
-				assert.False(t, result.Match, "Evaluation should not have matched.")
-				assert.Equal(t, evaluation.EvaluationReason_FLAG_NOT_FOUND_EVALUATION_REASON, result.Reason)
-				assert.Empty(t, result.SegmentKey)
-				assert.Empty(t, result.VariantKey)
+				msg := fmt.Sprintf("rpc error: code = NotFound desc = flag \"%s/unknown_flag\" not found", namespace)
+				require.EqualError(t, err, msg)
+				require.Nil(t, result)
 			})
 		})
 	})
@@ -679,6 +677,12 @@ func API(t *testing.T, ctx context.Context, client sdk.SDK, namespace string, au
 		err = client.Flipt().DeleteFlag(ctx, &flipt.DeleteFlagRequest{
 			NamespaceKey: namespace,
 			Key:          "test",
+		})
+		require.NoError(t, err)
+
+		err = client.Flipt().DeleteFlag(ctx, &flipt.DeleteFlagRequest{
+			NamespaceKey: namespace,
+			Key:          "disabled",
 		})
 		require.NoError(t, err)
 

--- a/build/testing/integration/api/api.go
+++ b/build/testing/integration/api/api.go
@@ -110,7 +110,7 @@ func API(t *testing.T, ctx context.Context, client sdk.SDK, namespace string, au
 
 		t.Log("Create a new flag in a disabled state.")
 
-		_, err = client.Flipt().CreateFlag(ctx, &flipt.CreateFlagRequest{
+		disabled, err := client.Flipt().CreateFlag(ctx, &flipt.CreateFlagRequest{
 			NamespaceKey: namespace,
 			Key:          "disabled",
 			Name:         "Disabled",
@@ -119,10 +119,10 @@ func API(t *testing.T, ctx context.Context, client sdk.SDK, namespace string, au
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, "test", created.Key)
-		assert.Equal(t, "Test", created.Name)
-		assert.Equal(t, "This is a test flag", created.Description)
-		assert.True(t, created.Enabled, "Flag should be enabled")
+		assert.Equal(t, "test", disabled.Key)
+		assert.Equal(t, "Test", disabled.Name)
+		assert.Equal(t, "This is a test flag", disabled.Description)
+		assert.True(t, disabled.Enabled, "Flag should be enabled")
 
 		t.Log("Retrieve flag with key \"test\".")
 
@@ -163,10 +163,14 @@ func API(t *testing.T, ctx context.Context, client sdk.SDK, namespace string, au
 		})
 		require.NoError(t, err)
 
-		assert.Len(t, flags.Flags, 1)
+		assert.Len(t, flags.Flags, 2)
 		assert.Equal(t, updated.Key, flags.Flags[0].Key)
 		assert.Equal(t, updated.Name, flags.Flags[0].Name)
 		assert.Equal(t, updated.Description, flags.Flags[0].Description)
+
+		assert.Equal(t, disabled.Key, flags.Flags[1].Key)
+		assert.Equal(t, disabled.Name, flags.Flags[1].Name)
+		assert.Equal(t, disabled.Description, flags.Flags[1].Description)
 
 		for _, key := range []string{"one", "two"} {
 			t.Logf("Create variant with key %q.", key)

--- a/build/testing/integration/readonly/testdata/default.yaml
+++ b/build/testing/integration/readonly/testdata/default.yaml
@@ -1,7 +1,7 @@
 version: "1.0"
 flags:
 - key: flag_disabled
-  Name: FLAG_DISABLED
+  name: FLAG_DISABLED
   description: Disabled Flag Description
 - key: flag_001
   name: FLAG_001

--- a/build/testing/integration/readonly/testdata/default.yaml
+++ b/build/testing/integration/readonly/testdata/default.yaml
@@ -1,5 +1,8 @@
 version: "1.0"
 flags:
+- key: flag_disabled
+  Name: FLAG_DISABLED
+  description: Disabled Flag Description
 - key: flag_001
   name: FLAG_001
   description: Some Description

--- a/build/testing/integration/readonly/testdata/production.yaml
+++ b/build/testing/integration/readonly/testdata/production.yaml
@@ -2,7 +2,7 @@ version: "1.0"
 namespace: production
 flags:
 - key: flag_disabled
-  Name: FLAG_DISABLED
+  name: FLAG_DISABLED
   description: Disabled Flag Description
 - key: flag_001
   name: FLAG_001

--- a/build/testing/integration/readonly/testdata/production.yaml
+++ b/build/testing/integration/readonly/testdata/production.yaml
@@ -1,4 +1,4 @@
-version: "2.0"
+version: "1.0"
 namespace: production
 flags:
 - key: flag_disabled

--- a/build/testing/integration/readonly/testdata/production.yaml
+++ b/build/testing/integration/readonly/testdata/production.yaml
@@ -1,6 +1,9 @@
-version: "1.0"
+version: "2.0"
 namespace: production
 flags:
+- key: flag_disabled
+  Name: FLAG_DISABLED
+  description: Disabled Flag Description
 - key: flag_001
   name: FLAG_001
   description: Some Description


### PR DESCRIPTION
Fixes FLI-463

This PR ensures that `Evaluation.Variant` works as expected in both the `api` and `readonly` suites.
It uses the new SDK types to exercise this API to ensure the variant endpoint is compatible with the existing Evaluation RPC on the Flipt service. It also adds a few cases to ensure some of the negative cases (flag disabled, not found and so on).

- [x] `api` suite cases
- [x] `readonly` suite cases