### PR TITLE
fix(wip): repro validate fail

### DIFF
--- a/build/testing/integration/readonly/testdata/production.yaml
+++ b/build/testing/integration/readonly/testdata/production.yaml
@@ -364,7 +364,7 @@ flags:
 - key: flag_002
   name: FLAG_002
   description: Some Description
-  enabled: true
+  nabled: true
   variants:
   - key: variant_001
     name: VARIANT_001

--- a/internal/cue/validate.go
+++ b/internal/cue/validate.go
@@ -111,7 +111,7 @@ func writeErrorDetails(format string, cerrs []Error, w io.Writer) error {
 func ValidateFiles(dst io.Writer, files []string, format string) error {
 	cctx := cuecontext.New()
 
-	cerrs := make([]Error, 0)
+	var cerrs []Error
 
 	for _, f := range files {
 		b, err := os.ReadFile(f)
@@ -130,6 +130,11 @@ func ValidateFiles(dst io.Writer, files []string, format string) error {
 
 			for _, m := range ce {
 				ips := m.InputPositions()
+				fmt.Printf("Pos: [line: %d, col: %d]\n", m.Position().Line(), m.Position().Column())
+				for _, ip := range ips {
+					fmt.Printf("Input position: [line: %d, col: %d]\n", ip.Line(), ip.Column())
+				}
+
 				if len(ips) > 0 {
 					fp := ips[0]
 					format, args := m.Msg()


### PR DESCRIPTION
we're only reporting the first position from 'input positions' as the position of the error which isn't always correct.

from the Go doc it seems the [`Error.InputPositions()`](https://pkg.go.dev/cuelang.org/go@v0.5.0/cue/errors#Error) contains all positions that contribute to the error not just the actual error itself, thus us picking the first `[0]` will not always be correct

> 	// InputPositions reports positions that contributed to an error, including
	// the expressions resulting in the conflict, as well as values that were
	// the input to this expression.

In this branch I modified the code to print out all of the positions:

```
workspace/flipt - [reproduce-validate-fail] » ./bin/flipt validate build/testing/integration/readonly/testdata/production.yaml
Pos: [line: 0, col: 0]
Input position: [line: 7, col: 8]
Input position: [line: 367, col: 4]
Input position: [line: 3, col: 12]
Input position: [line: 3, col: 9]
❌ Validation failure!


- Message: field not allowed
  File   : build/testing/integration/readonly/testdata/production.yaml
  Line   : 7
  Column : 8
```

You can see that it's printing both `[line: 7, col: 8]` and `[line: 367, col: 4]`

`[line: 7, col: 8]` is 
```
- key: flag_001
  name: FLAG_001
  description: Some Description
  enabled: true
```

which is correct no error,  while

`[line: 367, col: 4]` is the actual error which contains the line:

```
- key: flag_002
  name: FLAG_002
  description: Some Description
  nabled: true
```

(`enabled` is misspelled)

Im thinking we may be using the wrong method to find the actual error as it seems `Errors` is giving us somewhat of a tree or similar structure?