### PR TITLE
chore: fix deprecated archive replacement

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -45,8 +45,11 @@ sboms:
 
 archives:
   - id: main
-    replacements:
-      amd64: x86_64
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
https://goreleaser.com/deprecations/#archivesreplacements

This caused the nightly build to fail: https://github.com/flipt-io/flipt/actions/runs/5415977052/jobs/9845050343