### PR TITLE
fix: support variant desc in cue import schema

### DIFF
--- a/internal/cue/fixtures/valid.yaml
+++ b/internal/cue/fixtures/valid.yaml
@@ -9,6 +9,7 @@ flags:
     name: flipt
   - key: flipt
     name: flipt
+    description: I'm a description.
   rules:
   - segment: internal-users
     rank: 1

--- a/internal/cue/flipt.cue
+++ b/internal/cue/flipt.cue
@@ -16,6 +16,7 @@ segments: [...#Segment]
 #Variant: {
 	key:        string & =~"^.+$"
 	name:       string & =~"^.+$"
+	description?: string
 	attachment: {...} | *null
 }
 

--- a/internal/ext/importer_test.go
+++ b/internal/ext/importer_test.go
@@ -176,6 +176,7 @@ func TestImport(t *testing.T) {
 			variant := creator.variantReqs[0]
 			assert.Equal(t, "variant1", variant.Key)
 			assert.Equal(t, "variant1", variant.Name)
+			assert.Equal(t, "variant description", variant.Description)
 
 			if tc.hasAttachment {
 				attachment := `{

--- a/internal/ext/testdata/import.yml
+++ b/internal/ext/testdata/import.yml
@@ -6,6 +6,7 @@ flags:
     variants:
       - key: variant1
         name: variant1
+        description: variant description
         attachment:
           pi: 3.141
           happy: true

--- a/internal/ext/testdata/import_no_attachment.yml
+++ b/internal/ext/testdata/import_no_attachment.yml
@@ -6,6 +6,7 @@ flags:
     variants:
       - key: variant1
         name: variant1
+        description: variant description
     rules:
       - segment: segment1
         rank: 1


### PR DESCRIPTION
allow for variant description in `flipt validate`