### PR TITLE
feat: add audit logging for rollout actions

### DIFF
--- a/internal/server/audit/audit.go
+++ b/internal/server/audit/audit.go
@@ -36,6 +36,7 @@ const (
 	DistributionType Type = "distribution"
 	FlagType         Type = "flag"
 	NamespaceType    Type = "namespace"
+	RolloutType      Type = "rollout"
 	RuleType         Type = "rule"
 	SegmentType      Type = "segment"
 	TokenType        Type = "token"

--- a/internal/server/audit/types.go
+++ b/internal/server/audit/types.go
@@ -150,3 +150,46 @@ func NewRule(r *flipt.Rule) *Rule {
 		NamespaceKey:  r.NamespaceKey,
 	}
 }
+
+type Rollout struct {
+	NamespaceKey string            `json:"namespace_key"`
+	FlagKey      string            `json:"flag_key"`
+	Rank         int32             `json:"rank"`
+	Description  string            `json:"description"`
+	Threshold    *RolloutThreshold `json:"threshold,omitempty"`
+	Segment      *RolloutSegment   `json:"segment,omitempty"`
+}
+
+type RolloutThreshold struct {
+	Percentage float32 `json:"percentage"`
+	Value      bool    `json:"value"`
+}
+
+type RolloutSegment struct {
+	Key   string `json:"Key"`
+	Value bool   `json:"value"`
+}
+
+func NewRollout(r *flipt.Rollout) *Rollout {
+	rollout := &Rollout{
+		NamespaceKey: r.NamespaceKey,
+		FlagKey:      r.FlagKey,
+		Rank:         r.Rank,
+		Description:  r.Description,
+	}
+
+	switch rout := r.Rule.(type) {
+	case *flipt.Rollout_Segment:
+		rollout.Segment = &RolloutSegment{
+			Key:   rout.Segment.SegmentKey,
+			Value: rout.Segment.Value,
+		}
+	case *flipt.Rollout_Threshold:
+		rollout.Threshold = &RolloutThreshold{
+			Percentage: rout.Threshold.Percentage,
+			Value:      rout.Threshold.Value,
+		}
+	}
+
+	return rollout
+}

--- a/internal/server/audit/types.go
+++ b/internal/server/audit/types.go
@@ -166,7 +166,7 @@ type RolloutThreshold struct {
 }
 
 type RolloutSegment struct {
-	Key   string `json:"Key"`
+	Key   string `json:"key"`
 	Value bool   `json:"value"`
 }
 

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -269,6 +269,8 @@ func AuditUnaryInterceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
 			event = audit.NewEvent(audit.NamespaceType, audit.Delete, actor, r)
 		case *flipt.DeleteRuleRequest:
 			event = audit.NewEvent(audit.RuleType, audit.Delete, actor, r)
+		case *flipt.DeleteRolloutRequest:
+			event = audit.NewEvent(audit.RolloutType, audit.Delete, actor, r)
 		}
 
 		// Short circuiting the middleware here since we have a non-nil event from
@@ -303,6 +305,10 @@ func AuditUnaryInterceptor(logger *zap.Logger) grpc.UnaryServerInterceptor {
 		case *flipt.Namespace:
 			if action != "" {
 				event = audit.NewEvent(audit.NamespaceType, action, actor, audit.NewNamespace(r))
+			}
+		case *flipt.Rollout:
+			if action != "" {
+				event = audit.NewEvent(audit.RolloutType, action, actor, audit.NewRollout(r))
 			}
 		case *flipt.Rule:
 			if action != "" {


### PR DESCRIPTION
Add audit logging for `rollout` type, for the `create`, `update`, and `delete` action.

Completes FLI-457