### PR TITLE
feat: create eval rollout threshold

### DIFF
--- a/ui/src/app/flags/EditFlag.tsx
+++ b/ui/src/app/flags/EditFlag.tsx
@@ -1,15 +1,13 @@
 import { useOutletContext } from 'react-router-dom';
 import FlagForm from '~/components/flags/FlagForm';
 import MoreInfo from '~/components/MoreInfo';
-import { FlagType } from '~/types/Flag';
+import { FlagType, flagTypeToLabel } from '~/types/Flag';
 import { FlagProps } from './FlagProps';
 import Rollouts from './rollouts/Rollouts';
 import Variants from './variants/Variants';
 
 export default function EditFlag() {
   const { flag, onFlagChange } = useOutletContext<FlagProps>();
-
-  const flagTypeToLabel = (t: string) => FlagType[t as keyof typeof FlagType];
 
   return (
     <>

--- a/ui/src/app/flags/EditFlag.tsx
+++ b/ui/src/app/flags/EditFlag.tsx
@@ -4,6 +4,7 @@ import MoreInfo from '~/components/MoreInfo';
 import { FlagType } from '~/types/Flag';
 import { FlagProps } from './FlagProps';
 import Variants from './variants/Variants';
+import Rollouts from './rollouts/Rollouts';
 
 export default function EditFlag() {
   const { flag, onFlagChange } = useOutletContext<FlagProps>();
@@ -35,6 +36,9 @@ export default function EditFlag() {
 
         {flagTypeToLabel(flag.type) === FlagType.VARIANT_FLAG_TYPE && (
           <Variants flag={flag} flagChanged={onFlagChange} />
+        )}
+        {flagTypeToLabel(flag.type) === FlagType.BOOLEAN_FLAG_TYPE && (
+          <Rollouts flag={flag} flagChanged={onFlagChange} />
         )}
       </div>
     </>

--- a/ui/src/app/flags/EditFlag.tsx
+++ b/ui/src/app/flags/EditFlag.tsx
@@ -3,8 +3,8 @@ import FlagForm from '~/components/flags/FlagForm';
 import MoreInfo from '~/components/MoreInfo';
 import { FlagType } from '~/types/Flag';
 import { FlagProps } from './FlagProps';
-import Variants from './variants/Variants';
 import Rollouts from './rollouts/Rollouts';
+import Variants from './variants/Variants';
 
 export default function EditFlag() {
   const { flag, onFlagChange } = useOutletContext<FlagProps>();

--- a/ui/src/app/flags/Evaluation.tsx
+++ b/ui/src/app/flags/Evaluation.tsx
@@ -190,9 +190,7 @@ export default function Evaluation() {
           handleDelete={() =>
             deleteRule(namespace.key, flag.key, deletingRule?.id ?? '')
           }
-          onSuccess={() => {
-            incrementRulesVersion();
-          }}
+          onSuccess={incrementRulesVersion}
         />
       </Modal>
 
@@ -203,7 +201,7 @@ export default function Evaluation() {
           rank={(rules?.length || 0) + 1}
           segments={segments}
           setOpen={setShowRuleForm}
-          rulesChanged={incrementRulesVersion}
+          onSuccess={incrementRulesVersion}
         />
       </Slideover>
 

--- a/ui/src/app/flags/Flag.tsx
+++ b/ui/src/app/flags/Flag.tsx
@@ -22,7 +22,7 @@ import { copyFlag, deleteFlag, getFlag } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
 import { useTimezone } from '~/data/hooks/timezone';
-import { IFlag } from '~/types/Flag';
+import { FlagType, flagTypeToLabel, IFlag } from '~/types/Flag';
 
 export default function Flag() {
   let { flagKey } = useParams();
@@ -47,17 +47,6 @@ export default function Flag() {
     setFlagVersion(flagVersion + 1);
   };
 
-  const tabs = [
-    {
-      name: 'Details',
-      to: ''
-    },
-    {
-      name: 'Evaluation',
-      to: 'evaluation'
-    }
-  ];
-
   useEffect(() => {
     if (!flagKey) return;
 
@@ -71,6 +60,18 @@ export default function Flag() {
   }, [flagVersion, flagKey, namespace.key, clearError, setError]);
 
   if (!flag) return <Loading />;
+
+  const tabs = [
+    {
+      name: 'Details',
+      to: ''
+    },
+    {
+      name: 'Evaluation',
+      to: 'evaluation',
+      disabled: flagTypeToLabel(flag.type) === FlagType.BOOLEAN_FLAG_TYPE
+    }
+  ];
 
   return (
     <>

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { selectReadonly } from '~/app/meta/metaSlice';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import EmptyState from '~/components/EmptyState';
-import RolloutForm from '~/components/flags/RolloutForm';
+import RolloutForm from '~/components/rollouts/RolloutForm';
 import Button from '~/components/forms/buttons/Button';
 import Modal from '~/components/Modal';
 import DeletePanel from '~/components/panels/DeletePanel';

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -4,10 +4,10 @@ import { useSelector } from 'react-redux';
 import { selectReadonly } from '~/app/meta/metaSlice';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import EmptyState from '~/components/EmptyState';
-import RolloutForm from '~/components/rollouts/RolloutForm';
 import Button from '~/components/forms/buttons/Button';
 import Modal from '~/components/Modal';
 import DeletePanel from '~/components/panels/DeletePanel';
+import RolloutForm from '~/components/rollouts/RolloutForm';
 import Slideover from '~/components/Slideover';
 import { deleteRollout, listRollouts } from '~/data/api';
 import { IFlag } from '~/types/Flag';
@@ -64,12 +64,13 @@ export default function Rollouts(props: RolloutsProps) {
         ref={rolloutFormRef}
       >
         <RolloutForm
-          ref={rolloutFormRef}
-          flagKey={flag.key}
+          flag={flag}
+          rank={1}
           rollout={editingRollout || undefined}
           setOpen={setShowRolloutForm}
           onSuccess={() => {
             setShowRolloutForm(false);
+            incrementRolloutsVersion();
             flagChanged();
           }}
         />

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -44,7 +44,7 @@ export default function Rollouts(props: RolloutsProps) {
       flag.key
     )) as IRolloutList;
 
-    setRollouts(rolloutList.rollouts);
+    setRollouts(rolloutList.rules);
   }, [namespace.key, flag.key]);
 
   const incrementRolloutsVersion = () => {
@@ -65,7 +65,7 @@ export default function Rollouts(props: RolloutsProps) {
       >
         <RolloutForm
           flag={flag}
-          rank={1}
+          rank={(rollouts?.length || 0) + 1}
           rollout={editingRollout || undefined}
           setOpen={setShowRolloutForm}
           onSuccess={() => {

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectReadonly } from '~/app/meta/metaSlice';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
+import EmptyState from '~/components/EmptyState';
 import RolloutForm from '~/components/flags/RolloutForm';
 import Button from '~/components/forms/buttons/Button';
 import Modal from '~/components/Modal';
@@ -129,6 +130,20 @@ export default function Rollouts(props: RolloutsProps) {
                 <span>New Rollout</span>
               </Button>
             </div>
+          )}
+        </div>
+        <div className="mt-10">
+          {rollouts && rollouts.length > 0 ? (
+            <></>
+          ) : (
+            <EmptyState
+              text="New Rollout"
+              disabled={readOnly}
+              onClick={() => {
+                setEditingRollout(null);
+                setShowRolloutForm(true);
+              }}
+            />
           )}
         </div>
       </div>

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -29,7 +29,7 @@ export default function Rollouts(props: RolloutsProps) {
   const [editingRollout, setEditingRollout] = useState<IRollout | null>(null);
   const [showDeleteRolloutModal, setShowDeleteRolloutModal] =
     useState<boolean>(false);
-  const [deletingRollout, setDeletingRollout] = useState<IRollout | null>(null);
+  const [deletingRollout] = useState<IRollout | null>(null);
 
   const rolloutFormRef = useRef(null);
 
@@ -95,9 +95,7 @@ export default function Rollouts(props: RolloutsProps) {
             () =>
               deleteRollout(namespace.key, flag.key, deletingRollout?.id ?? '') // TODO: Determine impact of blank ID param
           }
-          onSuccess={() => {
-            flagChanged();
-          }}
+          onSuccess={flagChanged}
         />
       </Modal>
 

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -1,0 +1,137 @@
+import { PlusIcon } from '@heroicons/react/24/outline';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { selectReadonly } from '~/app/meta/metaSlice';
+import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
+import RolloutForm from '~/components/flags/RolloutForm';
+import Button from '~/components/forms/buttons/Button';
+import Modal from '~/components/Modal';
+import DeletePanel from '~/components/panels/DeletePanel';
+import Slideover from '~/components/Slideover';
+import { deleteRollout, listRollouts } from '~/data/api';
+import { IFlag } from '~/types/Flag';
+import { IRollout, IRolloutList } from '~/types/Rollout';
+
+type RolloutsProps = {
+  flag: IFlag;
+  flagChanged: () => void;
+};
+
+export default function Rollouts(props: RolloutsProps) {
+  const { flag, flagChanged } = props;
+
+  const [rollouts, setRollouts] = useState<IRollout[]>([]);
+
+  const [rolloutsVersion, setRolloutsVersion] = useState(0);
+  const [showRolloutForm, setShowRolloutForm] = useState<boolean>(false);
+
+  const [editingRollout, setEditingRollout] = useState<IRollout | null>(null);
+  const [showDeleteRolloutModal, setShowDeleteRolloutModal] =
+    useState<boolean>(false);
+  const [deletingRollout, setDeletingRollout] = useState<IRollout | null>(null);
+
+  const rolloutFormRef = useRef(null);
+
+  const namespace = useSelector(selectCurrentNamespace);
+  const readOnly = useSelector(selectReadonly);
+
+  const loadData = useCallback(async () => {
+    // TODO: load segments
+
+    const rolloutList = (await listRollouts(
+      namespace.key,
+      flag.key
+    )) as IRolloutList;
+
+    setRollouts(rolloutList.rollouts);
+  }, [namespace.key, flag.key]);
+
+  const incrementRolloutsVersion = () => {
+    setRolloutsVersion(rolloutsVersion + 1);
+  };
+
+  useEffect(() => {
+    loadData();
+  }, [loadData, rolloutsVersion]);
+
+  return (
+    <>
+      {/* rollout edit form */}
+      <Slideover
+        open={showRolloutForm}
+        setOpen={setShowRolloutForm}
+        ref={rolloutFormRef}
+      >
+        <RolloutForm
+          ref={rolloutFormRef}
+          flagKey={flag.key}
+          rollout={editingRollout || undefined}
+          setOpen={setShowRolloutForm}
+          onSuccess={() => {
+            setShowRolloutForm(false);
+            flagChanged();
+          }}
+        />
+      </Slideover>
+
+      {/* rollout delete modal */}
+      <Modal open={showDeleteRolloutModal} setOpen={setShowDeleteRolloutModal}>
+        <DeletePanel
+          panelMessage={
+            <>
+              Are you sure you want to delete this rule at
+              <span className="font-medium text-violet-500">
+                {' '}
+                position {deletingRollout?.rank}
+              </span>
+              ? This action cannot be undone.
+            </>
+          }
+          panelType="Rollout"
+          setOpen={setShowDeleteRolloutModal}
+          handleDelete={
+            () =>
+              deleteRollout(namespace.key, flag.key, deletingRollout?.id ?? '') // TODO: Determine impact of blank ID param
+          }
+          onSuccess={() => {
+            flagChanged();
+          }}
+        />
+      </Modal>
+
+      {/* rollouts */}
+      <div className="mt-10">
+        <div className="sm:flex sm:items-center">
+          <div className="sm:flex-auto">
+            <h1 className="text-lg font-medium leading-6 text-gray-900">
+              Rollouts
+            </h1>
+            <p className="mt-1 text-sm text-gray-500">
+              Return boolean values based on rules you define
+            </p>
+          </div>
+          {rollouts && rollouts.length > 0 && (
+            <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+              <Button
+                primary
+                type="button"
+                disabled={readOnly}
+                title={readOnly ? 'Not allowed in Read-Only mode' : undefined}
+                onClick={() => {
+                  setEditingRollout(null);
+                  setShowRolloutForm(true);
+                }}
+              >
+                <PlusIcon
+                  className="-ml-1.5 mr-1 h-5 w-5 text-white"
+                  aria-hidden="true"
+                />
+                <span>New Rollout</span>
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -34,7 +34,8 @@ import { useSuccess } from '~/data/hooks/success';
 import { useTimezone } from '~/data/hooks/timezone';
 import {
   ComparisonType,
-  ConstraintOperators,
+  constraintOperatorToLabel,
+  constraintTypeToLabel,
   IConstraint
 } from '~/types/Constraint';
 import { ISegment } from '~/types/Segment';
@@ -82,11 +83,6 @@ export default function Segment() {
         setError(err);
       });
   }, [segmentVersion, namespace.key, segmentKey, clearError, setError]);
-
-  const constraintTypeToLabel = (t: string) =>
-    ComparisonType[t as keyof typeof ComparisonType];
-
-  const constraintOperatorToLabel = (o: string) => ConstraintOperators[o];
 
   const constraintFormRef = useRef(null);
 

--- a/ui/src/components/TabBar.tsx
+++ b/ui/src/components/TabBar.tsx
@@ -4,6 +4,7 @@ import { classNames } from '~/utils/helpers';
 export interface Tab {
   name: string;
   to: string;
+  disabled?: boolean;
 }
 
 type TabBarProps = {
@@ -17,23 +18,32 @@ export default function TabBar(props: TabBarProps) {
     <div className="mt-3 flex flex-row sm:mt-5">
       <div className="border-b-2 border-gray-200">
         <nav className="-mb-px flex space-x-8">
-          {tabs.map((tab) => (
-            <NavLink
-              end
-              key={tab.name}
-              to={tab.to}
-              className={({ isActive }) =>
-                classNames(
-                  isActive
-                    ? 'text-violet-600 border-violet-500'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
-                  'whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium'
-                )
-              }
-            >
-              {tab.name}
-            </NavLink>
-          ))}
+          {tabs.map((tab) =>
+            tab.disabled ? (
+              <a
+                key={tab.name}
+                className="cursor-not-allowed whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium text-gray-500"
+              >
+                {tab.name}
+              </a>
+            ) : (
+              <NavLink
+                end
+                key={tab.name}
+                to={tab.to}
+                className={({ isActive }) =>
+                  classNames(
+                    isActive
+                      ? 'text-violet-600 border-violet-500'
+                      : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+                    'whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium'
+                  )
+                }
+              >
+                {tab.name}
+              </NavLink>
+            )
+          )}
         </nav>
       </div>
     </div>

--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -18,7 +18,7 @@ import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import Pagination from '~/components/Pagination';
 import Searchbox from '~/components/Searchbox';
 import { useTimezone } from '~/data/hooks/timezone';
-import { IFlag } from '~/types/Flag';
+import { FlagType, IFlag } from '~/types/Flag';
 import { truncateKey } from '~/utils/helpers';
 
 type FlagTableProps = {
@@ -81,6 +81,14 @@ export default function FlagTable(props: FlagTableProps) {
       ),
       meta: {
         className: 'whitespace-nowrap py-4 px-3 text-sm'
+      }
+    }),
+    columnHelper.accessor('type', {
+      header: 'Type',
+      cell: (info) =>
+        FlagType[info.getValue() as unknown as keyof typeof FlagType],
+      meta: {
+        className: 'whitespace-nowrap py-4 px-3 text-sm text-gray-600'
       }
     }),
     columnHelper.accessor('description', {

--- a/ui/src/components/flags/RolloutForm.tsx
+++ b/ui/src/components/flags/RolloutForm.tsx
@@ -1,0 +1,1 @@
+export default function RolloutForm() {}

--- a/ui/src/components/flags/RolloutForm.tsx
+++ b/ui/src/components/flags/RolloutForm.tsx
@@ -1,1 +1,0 @@
-export default function RolloutForm() {}

--- a/ui/src/components/forms/Combobox.tsx
+++ b/ui/src/components/forms/Combobox.tsx
@@ -3,8 +3,9 @@ import { CheckIcon, ChevronUpDownIcon } from '@heroicons/react/24/outline';
 import { useField } from 'formik';
 import { useState } from 'react';
 import { classNames } from '~/utils/helpers';
+import { ISelectable } from './Listbox';
 
-type ComboboxProps<T extends ISelectable> = {
+type ComboboxProps<T extends IFilterable> = {
   id: string;
   name: string;
   placeholder?: string;
@@ -15,14 +16,12 @@ type ComboboxProps<T extends ISelectable> = {
   className?: string;
 };
 
-export interface ISelectable {
-  key: string;
+export interface IFilterable extends ISelectable {
   status?: 'active' | 'inactive';
   filterValue: string;
-  displayValue: string;
 }
 
-export default function Combobox<T extends ISelectable>(
+export default function Combobox<T extends IFilterable>(
   props: ComboboxProps<T>
 ) {
   const {

--- a/ui/src/components/forms/Select.tsx
+++ b/ui/src/components/forms/Select.tsx
@@ -6,12 +6,13 @@ type SelectProps = {
   options?: { value: string; label: string }[];
   children?: React.ReactNode;
   className?: string;
+  defaultValue?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
 export default function Select(props: SelectProps) {
-  const { id, name, options, children, className, value, onChange } = props;
+  const { id, name, options, value, children, className, onChange } = props;
 
   const [field] = useField({
     name,
@@ -22,6 +23,7 @@ export default function Select(props: SelectProps) {
     <select
       {...field}
       id={id}
+      name={name}
       className={`${className} block rounded-md py-2 pl-3 pr-10 text-base text-gray-900 bg-gray-50 border-gray-300 focus:outline-none focus:ring-violet-300 focus:border-violet-300 sm:text-sm`}
       value={value}
       onChange={onChange || field.onChange}

--- a/ui/src/components/forms/Select.tsx
+++ b/ui/src/components/forms/Select.tsx
@@ -6,13 +6,12 @@ type SelectProps = {
   options?: { value: string; label: string }[];
   children?: React.ReactNode;
   className?: string;
-  defaultValue?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
 export default function Select(props: SelectProps) {
-  const { id, name, options, value, children, className, onChange } = props;
+  const { id, name, options, children, className, value, onChange } = props;
 
   const [field] = useField({
     name,

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -51,7 +51,9 @@ export default function RolloutForm(props: RolloutFormProps) {
     rolloutRuleTypeThreshold
   );
 
-  const handleThresholdSubmit = (values: IRollout & IRolloutRuleThreshold) => {
+  const handleThresholdSubmit = (
+    values: IRolloutBase & IRolloutRuleThreshold
+  ) => {
     return createRollout(namespace.key, flag.key, {
       rank,
       type: rolloutRuleType as RolloutType,

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -12,7 +12,7 @@ import { createRollout } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
 import { IFlag } from '~/types/Flag';
-import { IRollout, IRolloutRuleThreshold, RolloutType } from '~/types/Rollout';
+import { IRollout, RolloutType } from '~/types/Rollout';
 import ThresholdRuleFormInputs from './rules/ThresholdRuleForm';
 
 const rolloutRuleTypeSegment = 'SEGMENT_ROLLOUT_TYPE';
@@ -39,6 +39,13 @@ type RolloutFormProps = {
   rank: number;
 };
 
+interface RolloutFormValues {
+  type: string;
+  description?: string;
+  percentage?: number;
+  value: boolean;
+}
+
 export default function RolloutForm(props: RolloutFormProps) {
   const { setOpen, onSuccess, flag, rank } = props;
 
@@ -51,24 +58,22 @@ export default function RolloutForm(props: RolloutFormProps) {
     rolloutRuleTypeThreshold
   );
 
-  const handleThresholdSubmit = (
-    values: IRolloutBase & IRolloutRuleThreshold
-  ) => {
+  const handleThresholdSubmit = (values: RolloutFormValues) => {
     return createRollout(namespace.key, flag.key, {
       rank,
       type: rolloutRuleType as RolloutType,
       description: values.description,
       threshold: {
-        percentage: values.percentage,
+        percentage: values.percentage || 0,
         value: values.value
       }
     });
   };
 
-  const initialValues = {
+  const initialValues: RolloutFormValues = {
     type: rolloutRuleType,
     description: '',
-    percentage: 50,
+    percentage: 50, // TODO: make this 0?
     value: true
   };
 

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -6,6 +6,7 @@ import { useSelector } from 'react-redux';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import Button from '~/components/forms/buttons/Button';
 import Input from '~/components/forms/Input';
+import Select from '~/components/forms/Select';
 import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { createRollout } from '~/data/api';
@@ -43,7 +44,7 @@ interface RolloutFormValues {
   type: string;
   description?: string;
   percentage?: number;
-  value: boolean;
+  value: string;
 }
 
 export default function RolloutForm(props: RolloutFormProps) {
@@ -65,7 +66,7 @@ export default function RolloutForm(props: RolloutFormProps) {
       description: values.description,
       threshold: {
         percentage: values.percentage || 0,
-        value: values.value
+        value: values.value === 'true'
       }
     });
   };
@@ -74,7 +75,7 @@ export default function RolloutForm(props: RolloutFormProps) {
     type: rolloutRuleType,
     description: '',
     percentage: 50, // TODO: make this 0?
-    value: true
+    value: 'true'
   };
 
   return (
@@ -179,6 +180,23 @@ export default function RolloutForm(props: RolloutFormProps) {
                 <ThresholdRuleFormInputs />
               )}
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+                <label
+                  htmlFor="value"
+                  className="mb-2 block text-sm font-medium text-gray-900"
+                >
+                  Value
+                </label>
+                <Select
+                  id="value"
+                  name="value"
+                  options={[
+                    { label: 'True', value: 'true' },
+                    { label: 'False', value: 'false' }
+                  ]}
+                  className="w-full cursor-pointer appearance-none self-center rounded-lg align-middle bg-gray-200 dark:bg-gray-700"
+                />
+              </div>
+              <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                 <div>
                   <label
                     htmlFor="description"
@@ -206,9 +224,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                 primary
                 type="submit"
                 className="min-w-[80px]"
-                disabled={
-                  !(formik.dirty && formik.isValid && !formik.isSubmitting)
-                }
+                disabled={!formik.isValid || formik.isSubmitting}
               >
                 {formik.isSubmitting ? <Loading isPrimary /> : 'Create'}
               </Button>

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -1,0 +1,193 @@
+import { Dialog } from '@headlessui/react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { Formik } from 'formik';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Form } from 'react-router-dom';
+import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
+import Button from '~/components/forms/buttons/Button';
+import Loading from '~/components/Loading';
+import MoreInfo from '~/components/MoreInfo';
+import { useError } from '~/data/hooks/error';
+import { useSuccess } from '~/data/hooks/success';
+import { IRollout, IRolloutRuleThreshold, RolloutType } from '~/types/Rollout';
+import ThresholdRuleFormInputs from './rules/ThresholdRuleForm';
+
+const rolloutRuleTypeSegment = 'SEGMENT_ROLLOUT_TYPE';
+const rolloutRuleTypeThreshold = 'THRESHOLD_ROLLOUT_TYPE';
+
+const rolloutRuleTypes = [
+  {
+    id: rolloutRuleTypeSegment,
+    name: RolloutType.SEGMENT_ROLLOUT_TYPE,
+    description: 'Rollout to a specific segment'
+  },
+  {
+    id: rolloutRuleTypeThreshold,
+    name: RolloutType.THRESHOLD_ROLLOUT_TYPE,
+    description: 'Rollout to a percentage of entities'
+  }
+];
+
+type RolloutFormProps = {
+  setOpen: (open: boolean) => void;
+  rulesChanged: () => void;
+  flagKey: string;
+  rollout: IRollout | undefined;
+  rank: number;
+};
+
+export default function RolloutForm(props: RolloutFormProps) {
+  const { setOpen, rulesChanged, flagKey, rollout, rank } = props;
+
+  const { setError, clearError } = useError();
+  const { setSuccess } = useSuccess();
+
+  const namespace = useSelector(selectCurrentNamespace);
+
+  const [rolloutRuleType, setRolloutRuleType] = useState(
+    rolloutRuleTypeThreshold
+  );
+
+  const [thresholdRule, setThresholdRule] = useState<IRolloutRuleThreshold>(
+    (rollout?.rule as IRolloutRuleThreshold) || {
+      percentage: 50,
+      value: true
+    }
+  );
+
+  const handleSubmit = () => {
+    return Promise.resolve();
+  };
+
+  return (
+    <Formik
+      initialValues={
+        {
+          // segmentKey: selectedSegment?.key || ''
+        }
+      }
+      //   validationSchema={Yup.object({
+      //     segmentKey: keyValidation
+      //   })}
+      onSubmit={(_, { setSubmitting }) => {
+        handleSubmit()
+          .then(() => {
+            rulesChanged();
+            clearError();
+            setSuccess('Successfully created rollout');
+            setOpen(false);
+          })
+          .catch((err) => {
+            setError(err);
+          })
+          .finally(() => {
+            setSubmitting(false);
+          });
+      }}
+    >
+      {(formik) => {
+        return (
+          <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+            <div className="flex-1">
+              <div className="px-4 py-6 bg-gray-50 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <Dialog.Title className="text-lg font-medium text-gray-900">
+                      New Rollout
+                    </Dialog.Title>
+                    <MoreInfo href="https://www.flipt.io/docs/concepts#rollouts">
+                      Learn more about rollouts
+                    </MoreInfo>
+                  </div>
+                  <div className="flex h-7 items-center">
+                    <button
+                      type="button"
+                      className="text-gray-400 hover:text-gray-500"
+                      onClick={() => setOpen(false)}
+                    >
+                      <span className="sr-only">Close panel</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div className="space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0">
+                <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+                  <div>
+                    <label
+                      htmlFor="ruleType"
+                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    >
+                      Type
+                    </label>
+                  </div>
+                  <div className="sm:col-span-2">
+                    <fieldset>
+                      <legend className="sr-only">Type</legend>
+                      <div className="space-y-5">
+                        {rolloutRuleTypes.map((rolloutRule) => (
+                          <div
+                            key={rolloutRule.id}
+                            className="relative flex items-start"
+                          >
+                            <div className="flex h-5 items-center">
+                              <input
+                                id={rolloutRule.id}
+                                aria-describedby={`${rolloutRule.id}-description`}
+                                name="ruleType"
+                                type="radio"
+                                className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                                onChange={() => {
+                                  setRolloutRuleType(rolloutRule.id);
+                                }}
+                                checked={rolloutRule.id === rolloutRuleType}
+                                value={rolloutRule.id}
+                              />
+                            </div>
+                            <div className="ml-3 text-sm">
+                              <label
+                                htmlFor={rolloutRule.id}
+                                className="font-medium text-gray-700"
+                              >
+                                {rolloutRule.name}
+                              </label>
+                              <p
+                                id={`${rolloutRule.id}-description`}
+                                className="text-gray-500"
+                              >
+                                {rolloutRule.description}
+                              </p>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </fieldset>
+                  </div>
+                </div>
+                {rolloutRuleType === rolloutRuleTypeThreshold && (
+                  <ThresholdRuleFormInputs rule={thresholdRule} />
+                )}
+              </div>
+            </div>
+            <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+              <div className="flex justify-end space-x-3">
+                <Button onClick={() => setOpen(false)}>Cancel</Button>
+                <Button
+                  primary
+                  type="submit"
+                  className="min-w-[80px]"
+                  disabled={
+                    !(formik.dirty && formik.isValid && !formik.isSubmitting)
+                  }
+                >
+                  {formik.isSubmitting ? <Loading isPrimary /> : 'Create'}
+                </Button>
+              </div>
+            </div>
+          </Form>
+        );
+      }}
+    </Formik>
+  );
+}

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import Button from '~/components/forms/buttons/Button';
+import Input from '~/components/forms/Input';
 import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { createRollout } from '~/data/api';
@@ -50,10 +51,11 @@ export default function RolloutForm(props: RolloutFormProps) {
     rolloutRuleTypeThreshold
   );
 
-  const handleThresholdSubmit = (values: IRolloutRuleThreshold) => {
+  const handleThresholdSubmit = (values: IRollout & IRolloutRuleThreshold) => {
     return createRollout(namespace.key, flag.key, {
       rank,
       type: rolloutRuleType as RolloutType,
+      description: values.description,
       threshold: {
         percentage: values.percentage,
         value: values.value
@@ -63,7 +65,8 @@ export default function RolloutForm(props: RolloutFormProps) {
 
   const initialValues = {
     type: rolloutRuleType,
-    percentage: 60,
+    description: '',
+    percentage: 50,
     value: true
   };
 
@@ -168,6 +171,25 @@ export default function RolloutForm(props: RolloutFormProps) {
               {rolloutRuleType === rolloutRuleTypeThreshold && (
                 <ThresholdRuleFormInputs />
               )}
+              <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+                <div>
+                  <label
+                    htmlFor="description"
+                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                  >
+                    Description
+                  </label>
+                  <span
+                    className="text-xs text-gray-400"
+                    id="description-optional"
+                  >
+                    Optional
+                  </span>
+                </div>
+                <div className="sm:col-span-2">
+                  <Input name="description" id="description" />
+                </div>
+              </div>
             </div>
           </div>
           <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -1,15 +1,16 @@
 import { Dialog } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
-import { Formik } from 'formik';
+import { Form, Formik } from 'formik';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Form } from 'react-router-dom';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import Button from '~/components/forms/buttons/Button';
 import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
+import { createRollout } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
+import { IFlag } from '~/types/Flag';
 import { IRollout, IRolloutRuleThreshold, RolloutType } from '~/types/Rollout';
 import ThresholdRuleFormInputs from './rules/ThresholdRuleForm';
 
@@ -31,14 +32,14 @@ const rolloutRuleTypes = [
 
 type RolloutFormProps = {
   setOpen: (open: boolean) => void;
-  rulesChanged: () => void;
-  flagKey: string;
-  rollout: IRollout | undefined;
+  onSuccess: () => void;
+  flag: IFlag;
+  rollout?: IRollout;
   rank: number;
 };
 
 export default function RolloutForm(props: RolloutFormProps) {
-  const { setOpen, rulesChanged, flagKey, rollout, rank } = props;
+  const { setOpen, onSuccess, flag, rank } = props;
 
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
@@ -49,31 +50,31 @@ export default function RolloutForm(props: RolloutFormProps) {
     rolloutRuleTypeThreshold
   );
 
-  const [thresholdRule, setThresholdRule] = useState<IRolloutRuleThreshold>(
-    (rollout?.rule as IRolloutRuleThreshold) || {
-      percentage: 50,
-      value: true
-    }
-  );
+  const handleThresholdSubmit = (values: IRolloutRuleThreshold) => {
+    return createRollout(namespace.key, flag.key, {
+      rank,
+      type: rolloutRuleType as RolloutType,
+      threshold: {
+        percentage: values.percentage,
+        value: values.value
+      }
+    });
+  };
 
-  const handleSubmit = () => {
-    return Promise.resolve();
+  const initialValues = {
+    type: rolloutRuleType,
+    percentage: 60,
+    value: true
   };
 
   return (
     <Formik
-      initialValues={
-        {
-          // segmentKey: selectedSegment?.key || ''
-        }
-      }
-      //   validationSchema={Yup.object({
-      //     segmentKey: keyValidation
-      //   })}
-      onSubmit={(_, { setSubmitting }) => {
-        handleSubmit()
+      enableReinitialize
+      initialValues={initialValues}
+      onSubmit={(values, { setSubmitting }) => {
+        handleThresholdSubmit(values)
           .then(() => {
-            rulesChanged();
+            onSuccess();
             clearError();
             setSuccess('Successfully created rollout');
             setOpen(false);
@@ -86,108 +87,106 @@ export default function RolloutForm(props: RolloutFormProps) {
           });
       }}
     >
-      {(formik) => {
-        return (
-          <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
-            <div className="flex-1">
-              <div className="px-4 py-6 bg-gray-50 sm:px-6">
-                <div className="flex items-start justify-between space-x-3">
-                  <div className="space-y-1">
-                    <Dialog.Title className="text-lg font-medium text-gray-900">
-                      New Rollout
-                    </Dialog.Title>
-                    <MoreInfo href="https://www.flipt.io/docs/concepts#rollouts">
-                      Learn more about rollouts
-                    </MoreInfo>
-                  </div>
-                  <div className="flex h-7 items-center">
-                    <button
-                      type="button"
-                      className="text-gray-400 hover:text-gray-500"
-                      onClick={() => setOpen(false)}
-                    >
-                      <span className="sr-only">Close panel</span>
-                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                    </button>
-                  </div>
+      {(formik) => (
+        <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+          <div className="flex-1">
+            <div className="px-4 py-6 bg-gray-50 sm:px-6">
+              <div className="flex items-start justify-between space-x-3">
+                <div className="space-y-1">
+                  <Dialog.Title className="text-lg font-medium text-gray-900">
+                    New Rollout
+                  </Dialog.Title>
+                  <MoreInfo href="https://www.flipt.io/docs/concepts#rollouts">
+                    Learn more about rollouts
+                  </MoreInfo>
+                </div>
+                <div className="flex h-7 items-center">
+                  <button
+                    type="button"
+                    className="text-gray-400 hover:text-gray-500"
+                    onClick={() => setOpen(false)}
+                  >
+                    <span className="sr-only">Close panel</span>
+                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                  </button>
                 </div>
               </div>
-              <div className="space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0">
-                <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
-                  <div>
-                    <label
-                      htmlFor="ruleType"
-                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
-                    >
-                      Type
-                    </label>
-                  </div>
-                  <div className="sm:col-span-2">
-                    <fieldset>
-                      <legend className="sr-only">Type</legend>
-                      <div className="space-y-5">
-                        {rolloutRuleTypes.map((rolloutRule) => (
-                          <div
-                            key={rolloutRule.id}
-                            className="relative flex items-start"
-                          >
-                            <div className="flex h-5 items-center">
-                              <input
-                                id={rolloutRule.id}
-                                aria-describedby={`${rolloutRule.id}-description`}
-                                name="ruleType"
-                                type="radio"
-                                className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
-                                onChange={() => {
-                                  setRolloutRuleType(rolloutRule.id);
-                                }}
-                                checked={rolloutRule.id === rolloutRuleType}
-                                value={rolloutRule.id}
-                              />
-                            </div>
-                            <div className="ml-3 text-sm">
-                              <label
-                                htmlFor={rolloutRule.id}
-                                className="font-medium text-gray-700"
-                              >
-                                {rolloutRule.name}
-                              </label>
-                              <p
-                                id={`${rolloutRule.id}-description`}
-                                className="text-gray-500"
-                              >
-                                {rolloutRule.description}
-                              </p>
-                            </div>
+            </div>
+            <div className="space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0">
+              <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+                <div>
+                  <label
+                    htmlFor="type"
+                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                  >
+                    Type
+                  </label>
+                </div>
+                <div className="sm:col-span-2">
+                  <fieldset>
+                    <legend className="sr-only">Type</legend>
+                    <div className="space-y-5">
+                      {rolloutRuleTypes.map((rolloutRule) => (
+                        <div
+                          key={rolloutRule.id}
+                          className="relative flex items-start"
+                        >
+                          <div className="flex h-5 items-center">
+                            <input
+                              id={rolloutRule.id}
+                              aria-describedby={`${rolloutRule.id}-description`}
+                              name="type"
+                              type="radio"
+                              className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                              onChange={() => {
+                                setRolloutRuleType(rolloutRule.id);
+                              }}
+                              checked={rolloutRule.id === rolloutRuleType}
+                              value={rolloutRule.id}
+                            />
                           </div>
-                        ))}
-                      </div>
-                    </fieldset>
-                  </div>
+                          <div className="ml-3 text-sm">
+                            <label
+                              htmlFor={rolloutRule.id}
+                              className="font-medium text-gray-700"
+                            >
+                              {rolloutRule.name}
+                            </label>
+                            <p
+                              id={`${rolloutRule.id}-description`}
+                              className="text-gray-500"
+                            >
+                              {rolloutRule.description}
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </fieldset>
                 </div>
-                {rolloutRuleType === rolloutRuleTypeThreshold && (
-                  <ThresholdRuleFormInputs rule={thresholdRule} />
-                )}
               </div>
+              {rolloutRuleType === rolloutRuleTypeThreshold && (
+                <ThresholdRuleFormInputs />
+              )}
             </div>
-            <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
-              <div className="flex justify-end space-x-3">
-                <Button onClick={() => setOpen(false)}>Cancel</Button>
-                <Button
-                  primary
-                  type="submit"
-                  className="min-w-[80px]"
-                  disabled={
-                    !(formik.dirty && formik.isValid && !formik.isSubmitting)
-                  }
-                >
-                  {formik.isSubmitting ? <Loading isPrimary /> : 'Create'}
-                </Button>
-              </div>
+          </div>
+          <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+            <div className="flex justify-end space-x-3">
+              <Button onClick={() => setOpen(false)}>Cancel</Button>
+              <Button
+                primary
+                type="submit"
+                className="min-w-[80px]"
+                disabled={
+                  !(formik.dirty && formik.isValid && !formik.isSubmitting)
+                }
+              >
+                {formik.isSubmitting ? <Loading isPrimary /> : 'Create'}
+              </Button>
             </div>
-          </Form>
-        );
-      }}
+          </div>
+        </Form>
+      )}
     </Formik>
   );
 }

--- a/ui/src/components/rollouts/rules/ThresholdRuleForm.tsx
+++ b/ui/src/components/rollouts/rules/ThresholdRuleForm.tsx
@@ -1,29 +1,64 @@
-import { IRolloutRuleThreshold } from '~/types/Rollout';
+import { useFormikContext } from 'formik';
+import Input from '~/components/forms/Input';
+import Select from '~/components/forms/Select';
 
-type ThresholdRuleFormInputProps = {
-  rule: IRolloutRuleThreshold;
-};
+interface ThresholdRuleFormInputsFields {
+  percentage: number;
+  value: boolean;
+}
 
-export default function ThresholdRuleFormInputs(
-  props: ThresholdRuleFormInputProps
-) {
-  const { rule } = props;
-
+export default function InnerThresholdRuleFormInputs() {
+  const { values, setFieldValue } =
+    useFormikContext<ThresholdRuleFormInputsFields>();
   return (
-    <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
-      <label
-        htmlFor="percentage"
-        className="mb-2 block text-sm font-medium text-gray-900"
-      >
-        Percentage
-      </label>
-      <input
-        id="percentage"
-        type="range"
-        defaultValue="50"
-        value={rule?.percentage}
-        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 dark:bg-gray-700"
-      />
-    </div>
+    <>
+      <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+        <label
+          htmlFor="percentage"
+          className="mb-2 block text-sm font-medium text-gray-900"
+        >
+          Percentage
+        </label>
+        <Input
+          id="percentage-slider"
+          name="percentage"
+          type="range"
+          value={values.percentage}
+          onChange={(e) =>
+            setFieldValue('percentage', parseInt(e.target.value))
+          }
+          className="h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle bg-gray-200 dark:bg-gray-700"
+        />
+        <Input
+          type="number"
+          id="percentage"
+          name="percentage"
+          value={values.percentage}
+          onChange={(e) =>
+            setFieldValue('percentage', parseInt(e.target.value))
+          }
+          className="w-20 text-center"
+        />
+      </div>
+      <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+        <label
+          htmlFor="value"
+          className="mb-2 block text-sm font-medium text-gray-900"
+        >
+          Value
+        </label>
+        <Select
+          id="value"
+          name="value"
+          value={values.value.toString()}
+          onChange={(e) => setFieldValue('value', e.target.value === 'true')}
+          options={[
+            { label: 'True', value: 'true' },
+            { label: 'False', value: 'false' }
+          ]}
+          className="w-full cursor-pointer appearance-none self-center rounded-lg align-middle bg-gray-200 dark:bg-gray-700"
+        />
+      </div>
+    </>
   );
 }

--- a/ui/src/components/rollouts/rules/ThresholdRuleForm.tsx
+++ b/ui/src/components/rollouts/rules/ThresholdRuleForm.tsx
@@ -1,0 +1,29 @@
+import { IRolloutRuleThreshold } from '~/types/Rollout';
+
+type ThresholdRuleFormInputProps = {
+  rule: IRolloutRuleThreshold;
+};
+
+export default function ThresholdRuleFormInputs(
+  props: ThresholdRuleFormInputProps
+) {
+  const { rule } = props;
+
+  return (
+    <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+      <label
+        htmlFor="percentage"
+        className="mb-2 block text-sm font-medium text-gray-900"
+      >
+        Percentage
+      </label>
+      <input
+        id="percentage"
+        type="range"
+        defaultValue="50"
+        value={rule?.percentage}
+        className="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 dark:bg-gray-700"
+      />
+    </div>
+  );
+}

--- a/ui/src/components/rollouts/rules/ThresholdRuleForm.tsx
+++ b/ui/src/components/rollouts/rules/ThresholdRuleForm.tsx
@@ -1,6 +1,5 @@
 import { useFormikContext } from 'formik';
 import Input from '~/components/forms/Input';
-import Select from '~/components/forms/Select';
 
 interface ThresholdRuleFormInputsFields {
   percentage: number;
@@ -40,25 +39,6 @@ export default function InnerThresholdRuleFormInputs() {
             setFieldValue('percentage', parseInt(e.target.value))
           }
           className="text-center"
-        />
-      </div>
-      <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
-        <label
-          htmlFor="value"
-          className="mb-2 block text-sm font-medium text-gray-900"
-        >
-          Value
-        </label>
-        <Select
-          id="value"
-          name="value"
-          value={values.value.toString()}
-          onChange={(e) => setFieldValue('value', e.target.value === 'true')}
-          options={[
-            { label: 'True', value: 'true' },
-            { label: 'False', value: 'false' }
-          ]}
-          className="w-full cursor-pointer appearance-none self-center rounded-lg align-middle bg-gray-200 dark:bg-gray-700"
         />
       </div>
     </>

--- a/ui/src/components/rollouts/rules/ThresholdRuleForm.tsx
+++ b/ui/src/components/rollouts/rules/ThresholdRuleForm.tsx
@@ -32,12 +32,14 @@ export default function InnerThresholdRuleFormInputs() {
         <Input
           type="number"
           id="percentage"
+          max={100}
+          min={0}
           name="percentage"
           value={values.percentage}
           onChange={(e) =>
             setFieldValue('percentage', parseInt(e.target.value))
           }
-          className="w-20 text-center"
+          className="text-center"
         />
       </div>
       <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">

--- a/ui/src/components/rules/EditRuleForm.tsx
+++ b/ui/src/components/rules/EditRuleForm.tsx
@@ -6,15 +6,14 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import Button from '~/components/forms/buttons/Button';
-import Combobox, { ISelectable } from '~/components/forms/Combobox';
+import Combobox from '~/components/forms/Combobox';
 import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { updateDistribution } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
 import { IEvaluatable, IRollout } from '~/types/Evaluatable';
-import { ISegment } from '~/types/Segment';
-import { IVariant } from '~/types/Variant';
+import { FilterableSegment, FilterableVariant } from './RuleForm';
 
 type RuleFormProps = {
   setOpen: (open: boolean) => void;
@@ -42,10 +41,6 @@ const validRollout = (rollouts: IRollout[]): boolean => {
 
   return sum <= 100;
 };
-
-type SelectableSegment = ISegment & ISelectable;
-
-type SelectableVariant = IVariant & ISelectable;
 
 export default function EditRuleForm(props: RuleFormProps) {
   const { setOpen, rule, onSuccess } = props;
@@ -153,7 +148,7 @@ export default function EditRuleForm(props: RuleFormProps) {
                     </label>
                   </div>
                   <div className="sm:col-span-2">
-                    <Combobox<SelectableSegment>
+                    <Combobox<FilterableSegment>
                       id="segmentKey"
                       name="segmentKey"
                       disabled
@@ -230,7 +225,7 @@ export default function EditRuleForm(props: RuleFormProps) {
                       </label>
                     </div>
                     <div className="sm:col-span-2">
-                      <Combobox<SelectableVariant>
+                      <Combobox<FilterableVariant>
                         id="variant"
                         name="variant"
                         selected={{

--- a/ui/src/components/rules/RuleForm.tsx
+++ b/ui/src/components/rules/RuleForm.tsx
@@ -105,7 +105,7 @@ export default function RuleForm(props: RuleFormProps) {
 
   useEffect(() => {
     if (
-      ruleType === distTypeSingle &&
+      ruleType === distTypeMulti &&
       distributions &&
       !validRollout(distributions)
     ) {

--- a/ui/src/components/rules/RuleForm.tsx
+++ b/ui/src/components/rules/RuleForm.tsx
@@ -70,14 +70,14 @@ const validRollout = (distributions: IDistributionVariant[]): boolean => {
 
 type RuleFormProps = {
   setOpen: (open: boolean) => void;
-  rulesChanged: () => void;
+  onSuccess: () => void;
   flag: IFlag;
   rank: number;
   segments: ISegment[];
 };
 
 export default function RuleForm(props: RuleFormProps) {
-  const { setOpen, rulesChanged, flag, rank, segments } = props;
+  const { setOpen, onSuccess, flag, rank, segments } = props;
 
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
@@ -155,7 +155,7 @@ export default function RuleForm(props: RuleFormProps) {
       onSubmit={(_, { setSubmitting }) => {
         handleSubmit()
           .then(() => {
-            rulesChanged();
+            onSuccess();
             clearError();
             setSuccess('Successfully created rule');
             setOpen(false);

--- a/ui/src/components/rules/RuleForm.tsx
+++ b/ui/src/components/rules/RuleForm.tsx
@@ -7,7 +7,8 @@ import { Link } from 'react-router-dom';
 import * as Yup from 'yup';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import Button from '~/components/forms/buttons/Button';
-import Combobox, { ISelectable } from '~/components/forms/Combobox';
+import Combobox, { IFilterable } from '~/components/forms/Combobox';
+import { ISelectable } from '~/components/forms/Listbox';
 import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { createDistribution, createRule } from '~/data/api';
@@ -17,27 +18,27 @@ import { keyValidation } from '~/data/validations';
 import { IDistributionVariant } from '~/types/Distribution';
 import { IFlag } from '~/types/Flag';
 import { ISegment } from '~/types/Segment';
-import { SelectableVariant } from '~/types/Variant';
+import { IVariant } from '~/types/Variant';
 import { truncateKey } from '~/utils/helpers';
 import MultiDistributionFormInputs from './distributions/MultiDistributionForm';
 import SingleDistributionFormInput from './distributions/SingleDistributionForm';
 
-type RuleFormProps = {
-  setOpen: (open: boolean) => void;
-  rulesChanged: () => void;
-  flag: IFlag;
-  rank: number;
-  segments: ISegment[];
-};
+export type FilterableSegment = ISegment & IFilterable;
+export type FilterableVariant = IVariant & IFilterable;
+export type SelectableSegment = ISegment & ISelectable;
+export type SelectableVariant = IVariant & ISelectable;
+
+const distTypeSingle = 'single';
+const distTypeMulti = 'multi';
 
 const distTypes = [
   {
-    id: 'single',
+    id: distTypeSingle,
     name: 'Single Variant',
     description: 'Always returns the same variant'
   },
   {
-    id: 'multi',
+    id: distTypeMulti,
     name: 'Multi-Variant',
     description: 'Returns different variants based on percentages'
   }
@@ -67,7 +68,13 @@ const validRollout = (distributions: IDistributionVariant[]): boolean => {
   return sum <= 100;
 };
 
-type SelectableSegment = ISegment & ISelectable;
+type RuleFormProps = {
+  setOpen: (open: boolean) => void;
+  rulesChanged: () => void;
+  flag: IFlag;
+  rank: number;
+  segments: ISegment[];
+};
 
 export default function RuleForm(props: RuleFormProps) {
   const { setOpen, rulesChanged, flag, rank, segments } = props;
@@ -79,12 +86,12 @@ export default function RuleForm(props: RuleFormProps) {
 
   const [distributionsValid, setDistributionsValid] = useState<boolean>(true);
 
-  const [ruleType, setRuleType] = useState('single');
+  const [ruleType, setRuleType] = useState(distTypeSingle);
 
   const [selectedSegment, setSelectedSegment] =
-    useState<SelectableSegment | null>(null);
+    useState<FilterableSegment | null>(null);
   const [selectedVariant, setSelectedVariant] =
-    useState<SelectableVariant | null>(null);
+    useState<FilterableVariant | null>(null);
 
   const [distributions, setDistributions] = useState(() => {
     const percentages = computePercentages(flag.variants?.length || 0);
@@ -97,7 +104,11 @@ export default function RuleForm(props: RuleFormProps) {
   });
 
   useEffect(() => {
-    if (ruleType === 'multi' && distributions && !validRollout(distributions)) {
+    if (
+      ruleType === distTypeSingle &&
+      distributions &&
+      !validRollout(distributions)
+    ) {
       setDistributionsValid(false);
     } else {
       setDistributionsValid(true);
@@ -115,7 +126,7 @@ export default function RuleForm(props: RuleFormProps) {
       rank
     });
 
-    if (ruleType === 'multi') {
+    if (ruleType === distTypeMulti) {
       const distPromises = distributions?.map((dist: IDistributionVariant) =>
         createDistribution(namespace.key, flag.key, rule.id, {
           variantId: dist.variantId,
@@ -123,15 +134,13 @@ export default function RuleForm(props: RuleFormProps) {
         })
       );
       if (distPromises) await Promise.all(distPromises);
-    } else {
-      if (selectedVariant) {
-        // we allow creating rules without variants
+    } else if (selectedVariant) {
+      // we allow creating rules without variants
 
-        await createDistribution(namespace.key, flag.key, rule.id, {
-          variantId: selectedVariant.id,
-          rollout: 100
-        });
-      }
+      await createDistribution(namespace.key, flag.key, rule.id, {
+        variantId: selectedVariant.id,
+        rollout: 100
+      });
     }
   };
 
@@ -196,7 +205,7 @@ export default function RuleForm(props: RuleFormProps) {
                     </label>
                   </div>
                   <div className="sm:col-span-2">
-                    <Combobox<SelectableSegment>
+                    <Combobox<FilterableSegment>
                       id="segmentKey"
                       name="segmentKey"
                       placeholder="Select or search for a segment"
@@ -264,14 +273,14 @@ export default function RuleForm(props: RuleFormProps) {
                     </div>
                   </div>
                 )}
-                {flag.variants && ruleType === 'single' && (
+                {flag.variants && ruleType === distTypeSingle && (
                   <SingleDistributionFormInput
                     variants={flag.variants}
                     selectedVariant={selectedVariant}
                     setSelectedVariant={setSelectedVariant}
                   />
                 )}
-                {flag.variants && ruleType === 'multi' && (
+                {flag.variants && ruleType === distTypeMulti && (
                   <MultiDistributionFormInputs
                     distributions={distributions}
                     setDistributions={setDistributions}

--- a/ui/src/components/rules/distributions/SingleDistributionForm.tsx
+++ b/ui/src/components/rules/distributions/SingleDistributionForm.tsx
@@ -1,10 +1,11 @@
 import Combobox from '~/components/forms/Combobox';
-import { IVariant, SelectableVariant } from '~/types/Variant';
+import { FilterableVariant } from '~/components/rules/RuleForm';
+import { IVariant } from '~/types/Variant';
 
 type SingleDistributionFormInputProps = {
   variants: IVariant[];
-  selectedVariant: SelectableVariant | null;
-  setSelectedVariant: (variant: SelectableVariant | null) => void;
+  selectedVariant: FilterableVariant | null;
+  setSelectedVariant: (variant: FilterableVariant | null) => void;
 };
 
 export default function SingleDistributionFormInput(
@@ -22,7 +23,7 @@ export default function SingleDistributionFormInput(
         </label>
       </div>
       <div className="sm:col-span-2">
-        <Combobox<SelectableVariant>
+        <Combobox<FilterableVariant>
           id="variant"
           name="variant"
           placeholder="Select or search for a variant"

--- a/ui/src/components/segments/ConstraintForm.tsx
+++ b/ui/src/components/segments/ConstraintForm.tsx
@@ -30,6 +30,10 @@ import {
 } from '~/types/Constraint';
 import { Timezone } from '~/types/Preferences';
 
+const constraintComparisonTypeBoolean = 'BOOLEAN_COMPARISON_TYPE';
+const constraintComparisonTypeDateTime = 'DATETIME_COMPARISON_TYPE';
+const constraintComparisonTypeString = 'STRING_COMPARISON_TYPE';
+
 const constraintComparisonTypes = () =>
   (Object.keys(ComparisonType) as Array<keyof typeof ComparisonType>).map(
     (t) => ({
@@ -232,14 +236,15 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
 
   const [hasValue, setHasValue] = useState(true);
   const [type, setType] = useState(
-    constraint?.type || 'STRING_COMPARISON_TYPE'
+    constraint?.type || constraintComparisonTypeString
   );
 
   const namespace = useSelector(selectCurrentNamespace);
 
   const initialValues = {
     property: constraint?.property || '',
-    type: constraint?.type || ('STRING_COMPARISON_TYPE' as ComparisonType),
+    type:
+      constraint?.type || (constraintComparisonTypeString as ComparisonType),
     operator: constraint?.operator || 'eq',
     value: constraint?.value || '',
     description: constraint?.description || ''
@@ -338,7 +343,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                       formik.setFieldValue('type', type);
                       setType(type);
 
-                      if (e.target.value === 'BOOLEAN_COMPARISON_TYPE') {
+                      if (e.target.value === constraintComparisonTypeBoolean) {
                         formik.setFieldValue('operator', 'true');
                         setHasValue(false);
                       } else {
@@ -370,12 +375,12 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                   />
                 </div>
               </div>
-              {hasValue && type != 'DATETIME_COMPARISON_TYPE' && (
-                <ConstraintValueInput name="value" id="value" />
-              )}
-              {hasValue && type === 'DATETIME_COMPARISON_TYPE' && (
-                <ConstraintValueDateTimeInput name="value" id="value" />
-              )}
+              {hasValue &&
+                (type === constraintComparisonTypeDateTime ? (
+                  <ConstraintValueDateTimeInput name="value" id="value" />
+                ) : (
+                  <ConstraintValueInput name="value" id="value" />
+                ))}
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                 <div>
                   <label

--- a/ui/src/components/segments/ConstraintForm.tsx
+++ b/ui/src/components/segments/ConstraintForm.tsx
@@ -245,7 +245,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
     description: constraint?.description || ''
   };
 
-  const handleSubmit = async (values: IConstraintBase) => {
+  const handleSubmit = (values: IConstraintBase) => {
     if (isNew) {
       return createConstraint(namespace.key, segmentKey, values);
     }

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -73,7 +73,7 @@ export default function SegmentTable(props: SegmentTableProps) {
           info.getValue() as unknown as keyof typeof SegmentMatchType
         ],
       meta: {
-        className: 'whitespace-nowrap py-4 px-3 text-sm'
+        className: 'whitespace-nowrap py-4 px-3 text-sm text-gray-600'
       }
     }),
     columnHelper.accessor('description', {

--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -6,6 +6,7 @@ import { IFlagBase } from 'types/Flag';
 import { IRuleBase } from 'types/Rule';
 import { ISegmentBase } from 'types/Segment';
 import { IVariantBase } from 'types/Variant';
+import { IRolloutBase } from '~/types/Rollout';
 
 const apiURL = '/api/v1';
 const authURL = '/auth/v1';
@@ -169,6 +170,41 @@ export async function copyFlag(
   for (let variant of flag.variants) {
     await createVariant(to.namespaceKey, flag.key, variant);
   }
+}
+
+// rollouts
+export async function listRollouts(namespaceKey: string, flagKey: string) {
+  return get(`/namespaces/${namespaceKey}/flags/${flagKey}/rollouts`);
+}
+
+export async function createRollout(
+  namespaceKey: string,
+  flagKey: string,
+  values: IRolloutBase
+) {
+  return post(`/namespaces/${namespaceKey}/flags/${flagKey}/rollouts`, values);
+}
+
+export async function deleteRollout(
+  namespaceKey: string,
+  flagKey: string,
+  rolloutId: string
+) {
+  return del(
+    `/namespaces/${namespaceKey}/flags/${flagKey}/rollouts/${rolloutId}`
+  );
+}
+
+export async function updateRollout(
+  namespaceKey: string,
+  flagKey: string,
+  rolloutId: string,
+  values: IRolloutBase
+) {
+  return put(
+    `/namespaces/${namespaceKey}/flags/${flagKey}/rollouts/${rolloutId}`,
+    values
+  );
 }
 
 //

--- a/ui/src/types/Constraint.ts
+++ b/ui/src/types/Constraint.ts
@@ -70,3 +70,8 @@ export const ConstraintOperators: Record<string, string> = {
   ...ConstraintBooleanOperators,
   ...ConstraintDateTimeOperators
 };
+
+export const constraintTypeToLabel = (t: string) =>
+  ComparisonType[t as keyof typeof ComparisonType];
+
+export const constraintOperatorToLabel = (o: string) => ConstraintOperators[o];

--- a/ui/src/types/Flag.ts
+++ b/ui/src/types/Flag.ts
@@ -23,3 +23,6 @@ export interface IFlag extends IFlagBase {
 export interface IFlagList extends IPageable {
   flags: IFlag[];
 }
+
+export const flagTypeToLabel = (t: string) =>
+  FlagType[t as keyof typeof FlagType];

--- a/ui/src/types/Rollout.ts
+++ b/ui/src/types/Rollout.ts
@@ -30,5 +30,5 @@ export interface IRollout extends IRolloutBase {
 }
 
 export interface IRolloutList extends IPageable {
-  rollouts: IRollout[];
+  rules: IRollout[];
 }

--- a/ui/src/types/Rollout.ts
+++ b/ui/src/types/Rollout.ts
@@ -19,7 +19,8 @@ export interface IRolloutBase {
   type: RolloutType;
   rank: number;
   description?: string;
-  rule: IRolloutRuleSegment | IRolloutRuleThreshold;
+  threshold?: IRolloutRuleThreshold;
+  segment?: IRolloutRuleSegment;
 }
 
 export interface IRollout extends IRolloutBase {

--- a/ui/src/types/Rollout.ts
+++ b/ui/src/types/Rollout.ts
@@ -1,17 +1,16 @@
 import { IPageable } from './Pageable';
 
 export enum RolloutType {
-  UNKNOW_ROLLOUT_TYPE = 'Unknown',
   SEGMENT_ROLLOUT_TYPE = 'Segment',
   THRESHOLD_ROLLOUT_TYPE = 'Threshold'
 }
 
-export interface RolloutSegment {
+export interface IRolloutRuleSegment {
   segmentKey: string;
   value: boolean;
 }
 
-export interface RolloutThreshold {
+export interface IRolloutRuleThreshold {
   percentage: number;
   value: boolean;
 }
@@ -20,7 +19,7 @@ export interface IRolloutBase {
   type: RolloutType;
   rank: number;
   description?: string;
-  rule: RolloutSegment | RolloutThreshold;
+  rule: IRolloutRuleSegment | IRolloutRuleThreshold;
 }
 
 export interface IRollout extends IRolloutBase {

--- a/ui/src/types/Rollout.ts
+++ b/ui/src/types/Rollout.ts
@@ -1,0 +1,34 @@
+import { IPageable } from './Pageable';
+
+export enum RolloutType {
+  UNKNOW_ROLLOUT_TYPE = 'Unknown',
+  SEGMENT_ROLLOUT_TYPE = 'Segment',
+  THRESHOLD_ROLLOUT_TYPE = 'Threshold'
+}
+
+export interface RolloutSegment {
+  segmentKey: string;
+  value: boolean;
+}
+
+export interface RolloutThreshold {
+  percentage: number;
+  value: boolean;
+}
+
+export interface IRolloutBase {
+  type: RolloutType;
+  rank: number;
+  description?: string;
+  rule: RolloutSegment | RolloutThreshold;
+}
+
+export interface IRollout extends IRolloutBase {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface IRolloutList extends IPageable {
+  rollouts: IRollout[];
+}

--- a/ui/src/types/Variant.ts
+++ b/ui/src/types/Variant.ts
@@ -1,5 +1,3 @@
-import { ISelectable } from '~/components/forms/Combobox';
-
 export interface IVariantBase {
   key: string;
   name: string;
@@ -12,5 +10,3 @@ export interface IVariant extends IVariantBase {
   createdAt: string;
   updatedAt: string;
 }
-
-export type SelectableVariant = IVariant & ISelectable;


### PR DESCRIPTION
Fixes: FLI-474

<img width="1493" alt="CleanShot 2023-07-06 at 20 14 02@2x" src="https://github.com/flipt-io/flipt/assets/209477/6ef1bcd6-f14b-4944-857c-8222dffd9e47">

adds ability to create a rollout threshold rule with percentage/value

don't have list/delete/update yet.. but those are to come next

also adds `type` to Flag Table:

<img width="1449" alt="CleanShot 2023-07-06 at 17 19 43@2x" src="https://github.com/flipt-io/flipt/assets/209477/42dab8ef-26ad-4fc7-90c3-e8ed3a78bcdd">
