### PR TITLE
feat(rollouts): Add FS store implementation of rollouts

### DIFF
--- a/internal/server/rollout.go
+++ b/internal/server/rollout.go
@@ -2,9 +2,7 @@ package server
 
 import (
 	"context"
-	"encoding/base64"
 
-	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/storage"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 	"go.uber.org/zap"
@@ -23,15 +21,6 @@ func (s *Server) ListRollouts(ctx context.Context, r *flipt.ListRolloutRequest) 
 
 	opts := []storage.QueryOption{storage.WithLimit(uint64(r.GetLimit()))}
 
-	if r.GetPageToken() != "" {
-		tok, err := base64.StdEncoding.DecodeString(r.GetPageToken())
-		if err != nil {
-			return nil, errors.ErrInvalidf("pageToken is not valid: %q", r.GetPageToken())
-		}
-
-		opts = append(opts, storage.WithPageToken(string(tok)))
-	}
-
 	results, err := s.store.ListRollouts(ctx, r.NamespaceKey, r.FlagKey, opts...)
 	if err != nil {
 		return nil, err
@@ -47,7 +36,7 @@ func (s *Server) ListRollouts(ctx context.Context, r *flipt.ListRolloutRequest) 
 	}
 
 	resp.TotalCount = int32(total)
-	resp.NextPageToken = base64.StdEncoding.EncodeToString([]byte(results.NextPageToken))
+	resp.NextPageToken = results.NextPageToken
 
 	s.logger.Debug("list rollout rules", zap.Stringer("response", &resp))
 	return &resp, nil

--- a/internal/storage/fs/fixtures/fswithindex/prod/prod.features.yml
+++ b/internal/storage/fs/fixtures/fswithindex/prod/prod.features.yml
@@ -28,6 +28,20 @@ flags:
       distributions:
         - variant: prod-variant
           rollout: 100
+- key: flag_boolean
+  name: FLAG_BOOLEAN
+  type: BOOLEAN_FLAG_TYPE
+  description: Boolean Flag Description
+  enabled: false
+  rollouts:
+  - description: enabled for segment1
+    segment:
+      key: segment1
+      value: true
+  - description: enabled for 50%
+    threshold:
+      percentage: 50
+      value: true
 - key: redemptory
   name: redemptory
   description: description

--- a/internal/storage/fs/fixtures/fswithindex/sandbox/sandbox.features.yaml
+++ b/internal/storage/fs/fixtures/fswithindex/sandbox/sandbox.features.yaml
@@ -28,6 +28,20 @@ flags:
       distributions:
         - variant: sandbox-variant
           rollout: 100
+- key: flag_boolean
+  name: FLAG_BOOLEAN
+  type: BOOLEAN_FLAG_TYPE
+  description: Boolean Flag Description
+  enabled: false
+  rollouts:
+  - description: enabled for segment1
+    segment:
+      key: segment1
+      value: true
+  - description: enabled for 50%
+    threshold:
+      percentage: 50
+      value: true
 - key: redemptory
   name: redemptory
   description: description

--- a/internal/storage/fs/fixtures/fswithoutindex/prod/features.yml
+++ b/internal/storage/fs/fixtures/fswithoutindex/prod/features.yml
@@ -28,6 +28,20 @@ flags:
         distributions:
           - variant: prod-variant
             rollout: 100
+  - key: flag_boolean
+    name: FLAG_BOOLEAN
+    type: BOOLEAN_FLAG_TYPE
+    description: Boolean Flag Description
+    enabled: false
+    rollouts:
+    - description: enabled for segment2
+      segment:
+        key: segment2
+        value: true
+    - description: enabled for 50%
+      threshold:
+        percentage: 50
+        value: true
 segments:
   - key: segment2
     name: segment2

--- a/internal/storage/fs/fixtures/fswithoutindex/prod/features.yml
+++ b/internal/storage/fs/fixtures/fswithoutindex/prod/features.yml
@@ -28,7 +28,7 @@ flags:
         distributions:
           - variant: prod-variant
             rollout: 100
-  - key: flag_boolean
+  - key: flag_boolean_2
     name: FLAG_BOOLEAN
     type: BOOLEAN_FLAG_TYPE
     description: Boolean Flag Description

--- a/internal/storage/fs/fixtures/fswithoutindex/prod/prod.features.yaml
+++ b/internal/storage/fs/fixtures/fswithoutindex/prod/prod.features.yaml
@@ -28,6 +28,21 @@ flags:
       distributions:
         - variant: prod-variant
           rollout: 100
+- key: flag_boolean
+  name: FLAG_BOOLEAN
+  type: BOOLEAN_FLAG_TYPE
+  description: Boolean Flag Description
+  enabled: false
+  rollouts:
+  - description: enabled for segment1
+    segment:
+      key: segment1
+      value: true
+  - description: enabled for 50%
+    threshold:
+      percentage: 50
+      value: true
+
 - key: redemptory
   name: redemptory
   description: description

--- a/internal/storage/fs/fixtures/fswithoutindex/staging/features.yml
+++ b/internal/storage/fs/fixtures/fswithoutindex/staging/features.yml
@@ -28,6 +28,20 @@ flags:
         distributions:
           - variant: staging-variant
             rollout: 100
+  - key: flag_boolean
+    name: FLAG_BOOLEAN
+    type: BOOLEAN_FLAG_TYPE
+    description: Boolean Flag Description
+    enabled: false
+    rollouts:
+    - description: enabled for segment2
+      segment:
+        key: segment2
+        value: true
+    - description: enabled for 50%
+      threshold:
+        percentage: 50
+        value: true
 segments:
   - key: segment2
     name: segment2

--- a/internal/storage/fs/fixtures/fswithoutindex/staging/features.yml
+++ b/internal/storage/fs/fixtures/fswithoutindex/staging/features.yml
@@ -28,7 +28,7 @@ flags:
         distributions:
           - variant: staging-variant
             rollout: 100
-  - key: flag_boolean
+  - key: flag_boolean_2
     name: FLAG_BOOLEAN
     type: BOOLEAN_FLAG_TYPE
     description: Boolean Flag Description

--- a/internal/storage/fs/fixtures/fswithoutindex/staging/sandbox/features.yaml
+++ b/internal/storage/fs/fixtures/fswithoutindex/staging/sandbox/features.yaml
@@ -28,6 +28,20 @@ flags:
         distributions:
           - variant: sandbox-variant
             rollout: 100
+  - key: flag_boolean
+    name: FLAG_BOOLEAN
+    type: BOOLEAN_FLAG_TYPE
+    description: Boolean Flag Description
+    enabled: false
+    rollouts:
+    - description: enabled for segment2
+      segment:
+        key: segment2
+        value: true
+    - description: enabled for 50%
+      threshold:
+        percentage: 50
+        value: true
 segments:
   - key: segment2
     name: segment2

--- a/internal/storage/fs/fixtures/fswithoutindex/staging/sandbox/features.yaml
+++ b/internal/storage/fs/fixtures/fswithoutindex/staging/sandbox/features.yaml
@@ -28,7 +28,7 @@ flags:
         distributions:
           - variant: sandbox-variant
             rollout: 100
-  - key: flag_boolean
+  - key: flag_boolean_2
     name: FLAG_BOOLEAN
     type: BOOLEAN_FLAG_TYPE
     description: Boolean Flag Description

--- a/internal/storage/fs/fixtures/fswithoutindex/staging/sandbox/sandbox.features.yml
+++ b/internal/storage/fs/fixtures/fswithoutindex/staging/sandbox/sandbox.features.yml
@@ -28,6 +28,20 @@ flags:
       distributions:
         - variant: sandbox-variant
           rollout: 100
+- key: flag_boolean
+  name: FLAG_BOOLEAN
+  type: BOOLEAN_FLAG_TYPE
+  description: Boolean Flag Description
+  enabled: false
+  rollouts:
+  - description: enabled for segment1
+    segment:
+      key: segment1
+      value: true
+  - description: enabled for 50%
+    threshold:
+      percentage: 50
+      value: true
 - key: redemptory
   name: redemptory
   description: description

--- a/internal/storage/fs/fixtures/fswithoutindex/staging/staging.features.yaml
+++ b/internal/storage/fs/fixtures/fswithoutindex/staging/staging.features.yaml
@@ -28,6 +28,20 @@ flags:
       distributions:
         - variant: staging-variant
           rollout: 100
+- key: flag_boolean
+  name: FLAG_BOOLEAN
+  type: BOOLEAN_FLAG_TYPE
+  description: Boolean Flag Description
+  enabled: false
+  rollouts:
+  - description: enabled for segment1
+    segment:
+      key: segment1
+      value: true
+  - description: enabled for 50%
+    threshold:
+      percentage: 50
+      value: true
 - key: redemptory
   name: redemptory
   description: description

--- a/internal/storage/fs/snapshot_test.go
+++ b/internal/storage/fs/snapshot_test.go
@@ -23,7 +23,7 @@ func TestFSWithIndex(t *testing.T) {
 	fwi, _ := fs.Sub(testdata, "fixtures/fswithindex")
 
 	filenames, err := listStateFiles(zap.NewNop(), fwi)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := []string{
 		"prod/prod.features.yml",
@@ -36,13 +36,13 @@ func TestFSWithIndex(t *testing.T) {
 
 	for _, f := range filenames {
 		fr, err := fwi.Open(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		readers = append(readers, fr)
 	}
 
 	ss, err := snapshotFromReaders(readers...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tfs := &FSIndexSuite{
 		store: ss,
@@ -60,12 +60,12 @@ func (fis *FSIndexSuite) TestCountFlag() {
 	t := fis.T()
 
 	flagCount, err := fis.store.CountFlags(context.TODO(), "production")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 12, int(flagCount))
 
 	flagCount, err = fis.store.CountFlags(context.TODO(), "sandbox")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 12, int(flagCount))
 }
 
@@ -129,7 +129,7 @@ func (fis *FSIndexSuite) TestGetFlag() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			flag, err := fis.store.GetFlag(context.TODO(), tc.namespace, tc.flagKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.flag.Key, flag.Key)
 			assert.Equal(t, tc.flag.NamespaceKey, flag.NamespaceKey)
@@ -186,7 +186,7 @@ func (fis *FSIndexSuite) TestListFlags() {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, flags.Results, 5)
 			assert.Equal(t, "5", flags.NextPageToken)
 		})
@@ -221,7 +221,7 @@ func (fis *FSIndexSuite) TestGetNamespace() {
 
 	for _, tc := range testCases {
 		ns, err := fis.store.GetNamespace(context.TODO(), tc.namespaceKey)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, tc.fliptNs.Key, ns.Key)
 		assert.Equal(t, tc.fliptNs.Name, ns.Name)
@@ -234,7 +234,7 @@ func (fis *FSIndexSuite) TestCountNamespaces() {
 	t := fis.T()
 
 	namespacesCount, err := fis.store.CountNamespaces(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 3, int(namespacesCount))
 }
@@ -243,7 +243,7 @@ func (fis *FSIndexSuite) TestListNamespaces() {
 	t := fis.T()
 
 	namespaces, err := fis.store.ListNamespaces(context.TODO(), storage.WithLimit(2), storage.WithPageToken("0"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, namespaces.Results, 2)
 	assert.Equal(t, "2", namespaces.NextPageToken)
@@ -326,7 +326,7 @@ func (fis *FSIndexSuite) TestGetSegment() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sgmt, err := fis.store.GetSegment(context.TODO(), tc.namespace, tc.segmentKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.segment.Key, sgmt.Key)
 			assert.Equal(t, tc.segment.Name, sgmt.Name)
@@ -386,7 +386,7 @@ func (fis *FSIndexSuite) TestListSegments() {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, flags.Results, 5)
 			assert.Equal(t, "5", flags.NextPageToken)
 		})
@@ -397,12 +397,12 @@ func (fis *FSIndexSuite) TestCountSegment() {
 	t := fis.T()
 
 	segmentCount, err := fis.store.CountSegments(context.TODO(), "production")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 11, int(segmentCount))
 
 	segmentCount, err = fis.store.CountSegments(context.TODO(), "sandbox")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 11, int(segmentCount))
 }
 
@@ -429,7 +429,7 @@ func (fis *FSIndexSuite) TestGetEvaluationRollouts() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rollouts, err := fis.store.GetEvaluationRollouts(context.TODO(), tc.namespace, tc.flagKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Len(t, rollouts, 2)
 
@@ -510,7 +510,7 @@ func (fis *FSIndexSuite) TestGetEvaluationRules() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rules, err := fis.store.GetEvaluationRules(context.TODO(), tc.namespace, tc.flagKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Len(t, rules, 1)
 
@@ -557,12 +557,12 @@ func (fis *FSIndexSuite) TestGetEvaluationDistributions() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rules, err := fis.store.ListRules(context.TODO(), tc.namespace, tc.flagKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, rules.Results, 1)
 
 			dist, err := fis.store.GetEvaluationDistributions(context.TODO(), rules.Results[0].Id)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedVariantName, dist[0].VariantKey)
 			assert.Equal(t, float32(100), dist[0].Rollout)
@@ -624,11 +624,11 @@ func (fis *FSIndexSuite) TestListAndGetRollouts() {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			for _, rollout := range rollouts.Results {
 				r, err := fis.store.GetRollout(context.TODO(), tc.namespace, rollout.Id)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				assert.Equal(t, r, rollout)
 			}
@@ -678,11 +678,11 @@ func (fis *FSIndexSuite) TestListAndGetRules() {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			for _, rule := range rules.Results {
 				r, err := fis.store.GetRule(context.TODO(), tc.namespace, rule.Id)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				assert.Equal(t, r, rule)
 			}
@@ -698,7 +698,7 @@ type FSWithoutIndexSuite struct {
 func TestFSWithoutIndex(t *testing.T) {
 	fwoi, _ := fs.Sub(testdata, "fixtures/fswithoutindex")
 	filenames, err := listStateFiles(zap.NewNop(), fwoi)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expected := []string{
 		"prod/prod.features.yaml",
@@ -715,13 +715,13 @@ func TestFSWithoutIndex(t *testing.T) {
 
 	for _, f := range filenames {
 		fr, err := fwoi.Open(f)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		readers = append(readers, fr)
 	}
 
 	ss, err := snapshotFromReaders(readers...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	tfs := &FSWithoutIndexSuite{
 		store: ss,
@@ -734,17 +734,17 @@ func (fis *FSWithoutIndexSuite) TestCountFlag() {
 	t := fis.T()
 
 	flagCount, err := fis.store.CountFlags(context.TODO(), "production")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.Equal(t, 13, int(flagCount))
+	assert.Equal(t, 14, int(flagCount))
 
 	flagCount, err = fis.store.CountFlags(context.TODO(), "sandbox")
-	assert.NoError(t, err)
-	assert.Equal(t, 13, int(flagCount))
+	require.NoError(t, err)
+	assert.Equal(t, 14, int(flagCount))
 
 	flagCount, err = fis.store.CountFlags(context.TODO(), "staging")
-	assert.NoError(t, err)
-	assert.Equal(t, 13, int(flagCount))
+	require.NoError(t, err)
+	assert.Equal(t, 14, int(flagCount))
 }
 
 func (fis *FSWithoutIndexSuite) TestGetFlag() {
@@ -899,7 +899,7 @@ func (fis *FSWithoutIndexSuite) TestGetFlag() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			flag, err := fis.store.GetFlag(context.TODO(), tc.namespace, tc.flagKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.flag.Key, flag.Key)
 			assert.Equal(t, tc.flag.NamespaceKey, flag.NamespaceKey)
@@ -961,7 +961,7 @@ func (fis *FSWithoutIndexSuite) TestListFlags() {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, flags.Results, 5)
 			assert.Equal(t, "5", flags.NextPageToken)
 		})
@@ -1005,7 +1005,7 @@ func (fis *FSWithoutIndexSuite) TestGetNamespace() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ns, err := fis.store.GetNamespace(context.TODO(), tc.namespaceKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.fliptNs.Key, ns.Key)
 			assert.Equal(t, tc.fliptNs.Name, ns.Name)
@@ -1017,7 +1017,7 @@ func (fis *FSWithoutIndexSuite) TestCountNamespaces() {
 	t := fis.T()
 
 	namespacesCount, err := fis.store.CountNamespaces(context.TODO())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 4, int(namespacesCount))
 }
@@ -1026,7 +1026,7 @@ func (fis *FSWithoutIndexSuite) TestListNamespaces() {
 	t := fis.T()
 
 	namespaces, err := fis.store.ListNamespaces(context.TODO(), storage.WithLimit(3), storage.WithPageToken("0"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Len(t, namespaces.Results, 3)
 	assert.Equal(t, "3", namespaces.NextPageToken)
@@ -1220,7 +1220,7 @@ func (fis *FSWithoutIndexSuite) TestGetSegment() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			sgmt, err := fis.store.GetSegment(context.TODO(), tc.namespace, tc.segmentKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.segment.Key, sgmt.Key)
 			assert.Equal(t, tc.segment.Name, sgmt.Name)
@@ -1244,16 +1244,16 @@ func (fis *FSWithoutIndexSuite) TestCountSegment() {
 	t := fis.T()
 
 	segmentCount, err := fis.store.CountSegments(context.TODO(), "production")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, 12, int(segmentCount))
 
 	segmentCount, err = fis.store.CountSegments(context.TODO(), "sandbox")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 12, int(segmentCount))
 
 	segmentCount, err = fis.store.CountSegments(context.TODO(), "staging")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 12, int(segmentCount))
 }
 
@@ -1299,7 +1299,7 @@ func (fis *FSWithoutIndexSuite) TestListSegments() {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, flags.Results, 5)
 			assert.Equal(t, "5", flags.NextPageToken)
 		})
@@ -1334,7 +1334,7 @@ func (fis *FSWithoutIndexSuite) TestGetEvaluationRollouts() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rollouts, err := fis.store.GetEvaluationRollouts(context.TODO(), tc.namespace, tc.flagKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Len(t, rollouts, 2)
 
@@ -1438,7 +1438,7 @@ func (fis *FSWithoutIndexSuite) TestGetEvaluationRules() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rules, err := fis.store.GetEvaluationRules(context.TODO(), tc.namespace, tc.flagKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Len(t, rules, 1)
 
@@ -1491,12 +1491,12 @@ func (fis *FSWithoutIndexSuite) TestGetEvaluationDistributions() {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			rules, err := fis.store.ListRules(context.TODO(), tc.namespace, tc.flagKey)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, rules.Results, 1)
 
 			dist, err := fis.store.GetEvaluationDistributions(context.TODO(), rules.Results[0].Id)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			assert.Equal(t, tc.expectedVariantName, dist[0].VariantKey)
 			assert.Equal(t, float32(100), dist[0].Rollout)
@@ -1509,14 +1509,17 @@ func (fis *FSWithoutIndexSuite) TestCountRollouts() {
 
 	rolloutsCount, err := fis.store.CountRollouts(context.TODO(), "production", "flag_boolean")
 	require.NoError(t, err)
+
 	assert.Equal(t, 2, int(rolloutsCount))
 
 	rolloutsCount, err = fis.store.CountRollouts(context.TODO(), "sandbox", "flag_boolean")
 	require.NoError(t, err)
+
 	assert.Equal(t, 2, int(rolloutsCount))
 
 	rolloutsCount, err = fis.store.CountRollouts(context.TODO(), "staging", "flag_boolean")
 	require.NoError(t, err)
+
 	assert.Equal(t, 2, int(rolloutsCount))
 }
 
@@ -1567,11 +1570,11 @@ func (fis *FSWithoutIndexSuite) TestListAndGetRollouts() {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			for _, rollout := range rollouts.Results {
 				r, err := fis.store.GetRollout(context.TODO(), tc.namespace, rollout.Id)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				assert.Equal(t, r, rollout)
 			}
@@ -1626,11 +1629,11 @@ func (fis *FSWithoutIndexSuite) TestListAndGetRules() {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			for _, rule := range rules.Results {
 				r, err := fis.store.GetRule(context.TODO(), tc.namespace, rule.Id)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				assert.Equal(t, r, rule)
 			}

--- a/internal/storage/fs/sync.go
+++ b/internal/storage/fs/sync.go
@@ -138,17 +138,17 @@ func (s *syncedStore) CountRollouts(ctx context.Context, namespaceKey, flagKey s
 }
 
 func (s *syncedStore) CreateRollout(ctx context.Context, r *flipt.CreateRolloutRequest) (*flipt.Rollout, error) {
-	panic("not implemented")
+	return nil, ErrNotImplemented
 }
 
 func (s *syncedStore) UpdateRollout(ctx context.Context, r *flipt.UpdateRolloutRequest) (*flipt.Rollout, error) {
-	panic("not implemented")
+	return nil, ErrNotImplemented
 }
 
 func (s *syncedStore) DeleteRollout(ctx context.Context, r *flipt.DeleteRolloutRequest) error {
-	panic("not implemented")
+	return ErrNotImplemented
 }
 
 func (s *syncedStore) OrderRollouts(ctx context.Context, r *flipt.OrderRolloutsRequest) error {
-	panic("not implemented")
+	return ErrNotImplemented
 }

--- a/internal/storage/fs/sync.go
+++ b/internal/storage/fs/sync.go
@@ -121,11 +121,17 @@ func (s *syncedStore) GetRollout(ctx context.Context, namespaceKey, id string) (
 }
 
 func (s *syncedStore) ListRollouts(ctx context.Context, namespaceKey, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rollout], error) {
-	panic("not implemented")
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.storeSnapshot.ListRollouts(ctx, namespaceKey, flagKey, opts...)
 }
 
 func (s *syncedStore) CountRollouts(ctx context.Context, namespaceKey, flagKey string) (uint64, error) {
-	panic("not implemented")
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.storeSnapshot.CountRollouts(ctx, namespaceKey, flagKey)
 }
 
 func (s *syncedStore) CreateRollout(ctx context.Context, r *flipt.CreateRolloutRequest) (*flipt.Rollout, error) {

--- a/internal/storage/fs/sync.go
+++ b/internal/storage/fs/sync.go
@@ -117,7 +117,10 @@ func (s *syncedStore) CountNamespaces(ctx context.Context) (uint64, error) {
 }
 
 func (s *syncedStore) GetRollout(ctx context.Context, namespaceKey, id string) (*flipt.Rollout, error) {
-	panic("not implemented")
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.storeSnapshot.GetRollout(ctx, namespaceKey, id)
 }
 
 func (s *syncedStore) ListRollouts(ctx context.Context, namespaceKey, flagKey string, opts ...storage.QueryOption) (storage.ResultSet[*flipt.Rollout], error) {

--- a/internal/storage/sql/common/rollout.go
+++ b/internal/storage/sql/common/rollout.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -134,10 +135,9 @@ func (s *Store) ListRollouts(ctx context.Context, namespaceKey, flagKey string, 
 	var offset uint64
 
 	if params.PageToken != "" {
-		var token PageToken
-
-		if err := json.Unmarshal([]byte(params.PageToken), &token); err != nil {
-			return results, fmt.Errorf("decoding page token %w", err)
+		token, err := decodePageToken(s.logger, params.PageToken)
+		if err != nil {
+			return results, err
 		}
 
 		offset = token.Offset
@@ -291,7 +291,7 @@ func (s *Store) ListRollouts(ctx context.Context, namespaceKey, flagKey string, 
 		if err != nil {
 			return results, fmt.Errorf("encoding page token %w", err)
 		}
-		results.NextPageToken = string(out)
+		results.NextPageToken = base64.StdEncoding.EncodeToString(out)
 	}
 
 	return results, nil

--- a/internal/storage/sql/flag_test.go
+++ b/internal/storage/sql/flag_test.go
@@ -283,7 +283,7 @@ func (s *DBTestSuite) TestListFlagsPagination_LimitWithNextPage() {
 
 	pageToken := &common.PageToken{}
 	pTokenB, err := base64.StdEncoding.DecodeString(res.NextPageToken)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = json.Unmarshal(pTokenB, pageToken)
 	require.NoError(t, err)

--- a/internal/storage/sql/rollout_test.go
+++ b/internal/storage/sql/rollout_test.go
@@ -2,6 +2,7 @@ package sql_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -349,8 +350,12 @@ func (s *DBTestSuite) TestListRolloutsPagination_LimitWithNextPage() {
 	assert.NotEmpty(t, res.NextPageToken)
 
 	pageToken := &common.PageToken{}
-	err = json.Unmarshal([]byte(res.NextPageToken), pageToken)
+	pTokenB, err := base64.StdEncoding.DecodeString(res.NextPageToken)
 	require.NoError(t, err)
+
+	err = json.Unmarshal(pTokenB, pageToken)
+	require.NoError(t, err)
+
 	assert.NotEmpty(t, pageToken.Key)
 	assert.Equal(t, uint64(1), pageToken.Offset)
 


### PR DESCRIPTION
Adds FS store implementation for rollouts. There are a few things happening here:
1. Adding the logic to account for rollouts off of the `yml` files for FS
2. Adding unit tests for the FS implementation
3. Adding integration tests for the read only suite that will evaluate boolean/batch on the eval-v2 routes

Completes FLI-455
Completes FLI-419
