### PR TITLE
fix(ui): memoize selectors for namespaces

### DIFF
--- a/ui/src/app/namespaces/namespacesSlice.ts
+++ b/ui/src/app/namespaces/namespacesSlice.ts
@@ -1,5 +1,9 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import {
+  createAsyncThunk,
+  createSelector,
+  createSlice
+} from '@reduxjs/toolkit';
 import {
   createNamespace,
   deleteNamespace,
@@ -68,17 +72,27 @@ export const namespacesSlice = createSlice({
 
 export const { currentNamespaceChanged } = namespacesSlice.actions;
 
-export const selectNamespaces = (state: RootState) =>
-  Object.entries(state.namespaces.namespaces).map(
-    ([_, value]) => value
-  ) as INamespace[];
+export const selectNamespaces = createSelector(
+  [
+    (state: RootState) =>
+      Object.entries(state.namespaces.namespaces).map(
+        ([_, value]) => value
+      ) as INamespace[]
+  ],
+  (namespaces) => namespaces
+);
 
-export const selectCurrentNamespace = (state: RootState) => {
-  if (state.namespaces.status === LoadingStatus.SUCCEEDED) {
-    return state.namespaces.namespaces[state.namespaces.currentNamespace];
-  }
-  return { key: 'default', name: 'Default', description: '' } as INamespace;
-};
+export const selectCurrentNamespace = createSelector(
+  [
+    (state: RootState) => {
+      if (state.namespaces.status === LoadingStatus.SUCCEEDED) {
+        return state.namespaces.namespaces[state.namespaces.currentNamespace];
+      }
+      return { key: 'default', name: 'Default', description: '' } as INamespace;
+    }
+  ],
+  (currentNamespace) => currentNamespace
+);
 
 export const fetchNamespacesAsync = createAsyncThunk(
   'namespaces/fetchNamespaces',


### PR DESCRIPTION
fixes: FLI-482

```
Selector selectNamespaces returned a different result when called with the same parameters. This can lead to unnecessary rerenders.
Selectors that return a new reference (such as an object or an array) should be memoized: https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization 
Object { state: {…}, selected: (2) […], selected2: (2) […] }
```

<https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization>