### PR TITLE
add typescript format to export

### DIFF
--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ type exportCommand struct {
 	address   string
 	token     string
 	namespace string
+	format    string
 }
 
 func newExportCommand() *cobra.Command {
@@ -55,6 +57,13 @@ func newExportCommand() *cobra.Command {
 		"namespace", "n",
 		flipt.DefaultNamespace,
 		"source namespace for exported resources.",
+	)
+
+	cmd.Flags().StringVarP(
+		&export.format,
+		"format", "f",
+		"YML",
+		"export format (YML, TS).",
 	)
 
 	return cmd
@@ -101,5 +110,5 @@ func (c *exportCommand) run(cmd *cobra.Command, _ []string) error {
 }
 
 func (c *exportCommand) export(ctx context.Context, dst io.Writer, lister ext.Lister) error {
-	return ext.NewExporter(lister, c.namespace).Export(ctx, dst)
+	return ext.NewExporter(lister, c.namespace).Export(ctx, dst, ext.Format(strings.ToUpper(c.format)))
 }

--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -87,7 +87,14 @@ func (c *exportCommand) run(cmd *cobra.Command, _ []string) error {
 
 		defer fi.Close()
 
-		fmt.Fprintf(fi, "# exported by Flipt (%s) on %s\n\n", version, time.Now().UTC().Format(time.RFC3339))
+		var commentChar string
+		switch strings.ToUpper(c.format) {
+		case "TS":
+			commentChar = "//"
+		default:
+			commentChar = "#"
+		}
+		fmt.Fprintf(fi, "%s exported by Flipt (%s) on %s\n\n", commentChar, version, time.Now().UTC().Format(time.RFC3339))
 
 		out = fi
 	}

--- a/internal/ext/encoder_ts.go
+++ b/internal/ext/encoder_ts.go
@@ -1,0 +1,129 @@
+package ext
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/template"
+)
+
+type EncoderTS struct {
+	writer io.Writer
+}
+
+func NewTSEncoder(w io.Writer) *EncoderTS {
+	return &EncoderTS{
+		writer: w,
+	}
+}
+
+func (e *EncoderTS) Encode(v interface{}) error {
+	document, ok := v.(*Document)
+	if !ok {
+		return fmt.Errorf("invalid document type")
+	}
+
+	// Generate Typescript code
+	code := generateTypescriptCode(*document)
+
+	// Write the code to the writer
+	_, err := e.writer.Write([]byte(code))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *EncoderTS) Close() error {
+	if closer, ok := e.writer.(io.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+func generateTypescriptCode(document Document) string {
+	codeTemplate := `export type Namespaces = {
+  {{ .Namespace }}: {
+    Flags: {{ .FlagsType }};
+    Context: {{ .ContextFields }};
+  };
+};`
+
+	data := struct {
+		Namespace     string
+		FlagsType     string
+		ContextFields string
+	}{
+		Namespace:     document.Namespace,
+		FlagsType:     generateFlagsCode(document.Flags),
+		ContextFields: generateContextCode(document.Segments),
+	}
+
+	tmpl := template.Must(template.New("typescriptCode").Parse(codeTemplate))
+
+	var builder strings.Builder
+	err := tmpl.Execute(&builder, data)
+	if err != nil {
+		fmt.Println("Error generating Typescript code:", err)
+		return ""
+	}
+
+	return builder.String()
+}
+
+func generateFlagsCode(flags []*Flag) string {
+	var builder strings.Builder
+
+	for i, flag := range flags {
+		variantKeys := make([]string, len(flag.Variants))
+		for j, variant := range flag.Variants {
+			variantKeys[j] = variant.Key
+		}
+
+		unionType := generateUnionType(variantKeys)
+
+		builder.WriteString(fmt.Sprintf("{ key: '%s'; value: %s }", flag.Key, unionType))
+
+		if i < len(flags)-1 {
+			builder.WriteString(" | ")
+		}
+	}
+
+	return builder.String()
+}
+
+func generateUnionType(keys []string) string {
+	return "'" + strings.Join(keys, "' | '") + "'"
+}
+
+func generateContextCode(segments []*Segment) string {
+	var builder strings.Builder
+
+	for _, segment := range segments {
+		for _, constraint := range segment.Constraints {
+			fieldName := constraint.Property
+			fieldType := determineFieldType(constraint.Type)
+
+			fieldCode := fmt.Sprintf("%s: %s; ", fieldName, fieldType)
+			builder.WriteString(fieldCode)
+		}
+	}
+
+	if builder.Len() > 0 {
+		return "{ " + builder.String() + "}"
+	}
+
+	return "never"
+}
+
+func determineFieldType(value string) string {
+	switch value {
+	case "NUMBER_COMPARISON_TYPE":
+		return "number"
+	case "BOOLEAN_COMPARISON_TYPE":
+		return "boolean"
+	default:
+		return "string"
+	}
+}

--- a/internal/ext/exporter_test.go
+++ b/internal/ext/exporter_test.go
@@ -131,3 +131,89 @@ func TestExport(t *testing.T) {
 
 	assert.YAMLEq(t, string(in), b.String())
 }
+
+func TestExportTs(t *testing.T) {
+	lister := mockLister{
+		flags: []*flipt.Flag{
+			{
+				Key:         "flag1",
+				Name:        "flag1",
+				Description: "description",
+				Enabled:     true,
+				Variants: []*flipt.Variant{
+					{
+						Id:   "1",
+						Key:  "variant1",
+						Name: "variant1",
+					},
+					{
+						Id:  "2",
+						Key: "variant2",
+					},
+				},
+			},
+			{
+				Key:         "flag2",
+				Name:        "flag2",
+				Description: "description",
+				Enabled:     true,
+				Variants:    []*flipt.Variant{},
+			},
+		},
+		segments: []*flipt.Segment{
+			{
+				Key:         "segment1",
+				Name:        "segment1",
+				Description: "description",
+				MatchType:   flipt.MatchType_ANY_MATCH_TYPE,
+				Constraints: []*flipt.Constraint{
+					{
+						Id:          "1",
+						Type:        flipt.ComparisonType_STRING_COMPARISON_TYPE,
+						Property:    "foo",
+						Operator:    "eq",
+						Value:       "baz",
+						Description: "desc",
+					},
+					{
+						Id:          "2",
+						Type:        flipt.ComparisonType_NUMBER_COMPARISON_TYPE,
+						Property:    "fizz",
+						Operator:    "neq",
+						Value:       "1",
+						Description: "desc",
+					},
+				},
+			},
+			{
+				Key:         "segment2",
+				Name:        "segment2",
+				Description: "description",
+				MatchType:   flipt.MatchType_ANY_MATCH_TYPE,
+				Constraints: []*flipt.Constraint{
+					{
+						Id:          "3",
+						Type:        flipt.ComparisonType_BOOLEAN_COMPARISON_TYPE,
+						Property:    "baz",
+						Operator:    "eq",
+						Value:       "true",
+						Description: "desc",
+					},
+				},
+			},
+		},
+	}
+
+	var (
+		exporter = NewExporter(lister, storage.DefaultNamespace)
+		b        = new(bytes.Buffer)
+	)
+
+	err := exporter.Export(context.Background(), b, "TS")
+	assert.NoError(t, err)
+
+	in, err := os.ReadFile("testdata/export.ts")
+	assert.NoError(t, err)
+
+	assert.Equal(t, string(in), b.String())
+}

--- a/internal/ext/testdata/export.ts
+++ b/internal/ext/testdata/export.ts
@@ -1,0 +1,6 @@
+export type Namespaces = {
+  default: {
+    Flags: { key: 'flag1'; value: 'variant1' | 'variant2' } | { key: 'flag2'; value: '' };
+    Context: { foo: string; fizz: number; baz: boolean; };
+  };
+};


### PR DESCRIPTION
Alright, here's my proposal / proof of concept for https://github.com/flipt-io/flipt-node/issues/6

I added a Format argument to the export CLI and a TypescriptEncoder. That should probably be in its own package? I'm not super familiar with Go, apologies.

This format creates an export such as 

```ts
export type Namespaces = {
  default: {
    Flags: { key: 'flag1'; value: 'variant1' | 'variant2' } | { key: 'flag2'; value: '' };
    Context: { foo: string; fizz: number; baz: boolean; };
  };
};
```

(`default` is a reserved word in JS so it cannot appear in the type name itself, but as a key it's fine.)

This can be used by the user to create strongly typed evaluation methods, for example [like this](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcByBDAtsAzmDAYzzgF44BvAKDjgBNgAzDAVwBsYAuSm2uAMTYYA5rm4U4Aa2CJuAckZDhARjkBuOADcMbFsHnaoASwwA7GKrgAfOHMMnzAJjlwAvtcpSZ8xSOcbtXX1bF1c1XloAYQhzUC5PRggIblwYY1NhDUYjAC8c7lMWLAAjYCgNYox8uGKktmAzDTDeZuaqUEhYOEYWU0IYIxi4YECWDBhgAB5eQREAaRlhkAnTOlx0bDwCYlwAbQAiBmZ2GH2AXQPZ0XOD6URzqgA+AApfYQXZASUPgBo4QhiE2W3EwOHwRDwByOrA4N320Viy3OAEpuM9QVsIXtDkwYacLvsrrhznAAGSeO7cK4fNzIg6jYAk6i0KDAGAsKCmWz2MwWFwYdZmRDhVxUKgA0ypLQ6PRkYajcbAZ4KJSqP4SRLJWw6TRyP7ZPLcZR-SrVNKy1zI8IAemtfDgAD0APxAA).

```ts
export type Namespaces = {
  default: {
    Flags: { key: 'flag1'; value: 'variant1' | 'variant2' } | { key: 'flag2'; value: '' };
    Context: { foo: string; fizz: number; baz: boolean; };
  };
};

export function evaluate<
  FlagKey extends Namespaces["default"]["Flags"]["key"]
>(flagKey: FlagKey, context: Namespaces["default"]["Context"]): (Namespaces["default"]["Flags"] & { key: FlagKey })["value"] {
  return 'variant1' as any;
}

const value = evaluate('flag1', { foo: 'alv', fizz: 1, baz: true });
//    ^? const value: "variant1" | "variant2"
```

Happy to discuss the format and make any changes to the code.

I can add support for the coming "flag types" easily. In the boolean case `value` type should just be `boolean`.

Also we can consider adding some helpers and easy ways to use these types in the flipt-node package.