### PR TITLE
feat(console-evaluation): use v2 evaluation in console rather than v1 evaluation

### DIFF
--- a/ui/src/app/console/Console.tsx
+++ b/ui/src/app/console/Console.tsx
@@ -13,7 +13,7 @@ import Button from '~/components/forms/buttons/Button';
 import Combobox from '~/components/forms/Combobox';
 import Input from '~/components/forms/Input';
 import TextArea from '~/components/forms/TextArea';
-import { evaluate, listFlags } from '~/data/api';
+import { evaluateV2, listFlags } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import {
   jsonValidation,
@@ -21,7 +21,7 @@ import {
   requiredValidation
 } from '~/data/validations';
 import { IConsole } from '~/types/Console';
-import { FilterableFlag, IFlagList } from '~/types/Flag';
+import { FilterableFlag, flagTypeToLabel, IFlagList } from '~/types/Flag';
 import { INamespace } from '~/types/Namespace';
 import { classNames } from '~/utils/helpers';
 
@@ -60,14 +60,17 @@ export default function Console() {
           ...flag,
           status,
           filterValue: flag.key,
-          displayValue: flag.name
+          displayValue: `${flag.name} | ${flagTypeToLabel(flag.type)}`
         };
       })
     );
   }, [namespace.key]);
 
-  const handleSubmit = (values: IConsole) => {
+  const handleSubmit = (values: IConsole, flagType: string) => {
     const { flagKey, entityId, context } = values;
+
+    const boolean = flagType === 'BOOLEAN_FLAG_TYPE';
+
     // need to unescape the context string
     const parsed = context ? JSON.parse(context) : undefined;
 
@@ -76,7 +79,7 @@ export default function Console() {
       context: parsed
     };
 
-    evaluate(namespace.key, flagKey, rest)
+    evaluateV2(boolean, namespace.key, flagKey, rest)
       .then((resp) => {
         setHasEvaluationError(false);
         setResponse(JSON.stringify(resp, null, 2));
@@ -127,7 +130,7 @@ export default function Console() {
                   context: jsonValidation
                 })}
                 onSubmit={(values) => {
-                  handleSubmit(values);
+                  handleSubmit(values, selectedFlag?.type || '');
                 }}
                 onReset={() => {
                   setResponse(null);

--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -10,6 +10,7 @@ import { IRolloutBase } from '~/types/Rollout';
 
 const apiURL = '/api/v1';
 const authURL = '/auth/v1';
+const evaluateURL = '/evaluate/v1';
 const metaURL = '/meta';
 const csrfTokenHeaderKey = 'x-csrf-token';
 
@@ -409,6 +410,24 @@ export async function evaluate(
     ...values
   };
   return post('/evaluate', body);
+}
+
+//
+// evaluateV2
+export async function evaluateV2(
+  boolean: boolean,
+  namespaceKey: string,
+  flagKey: string,
+  values: any
+) {
+  const route = boolean ? '/boolean' : '/variant';
+
+  const body = {
+    namespaceKey,
+    flagKey,
+    ...values
+  };
+  return post(route, body, evaluateURL);
 }
 
 //

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     proxy: {
       '/api/v1': fliptAddr,
       '/auth/v1': fliptAddr,
+      '/evaluate/v1': fliptAddr,
       '/meta': fliptAddr
     },
     origin: 'http://localhost:5173'


### PR DESCRIPTION
Proxying to use evaluation v2 endpoints for the `Console` page rather than evaluation v1 endpoints (legacy).


<img width="800" alt="Screenshot 2023-07-12 at 12 40 55 PM" src="https://github.com/flipt-io/flipt/assets/13950726/cef87551-69bc-443f-ac30-27bf89328339">


<img width="800" alt="Screenshot 2023-07-12 at 12 41 19 PM" src="https://github.com/flipt-io/flipt/assets/13950726/cee59865-33c1-4c8f-871b-e4a056e5cf24">


Completes FLI-477
