### PR TITLE
feat: Reorder Rollouts

### DIFF
--- a/config/migrations/sqlite3/10_rollouts.up.sql
+++ b/config/migrations/sqlite3/10_rollouts.up.sql
@@ -4,10 +4,9 @@ CREATE TABLE IF NOT EXISTS rollouts (
   flag_key VARCHAR(255) NOT NULL,
   type INTEGER DEFAULT 0 NOT NULL,
   description TEXT NOT NULL,
-  rank INTEGER DEFAULT 0 NOT NULL,
+  rank INTEGER DEFAULT 1 NOT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  UNIQUE (namespace_key, flag_key, rank),
   FOREIGN KEY (namespace_key, flag_key) REFERENCES flags (namespace_key, key) ON DELETE CASCADE
 );
 

--- a/ui/src/app/flags/Evaluation.tsx
+++ b/ui/src/app/flags/Evaluation.tsx
@@ -250,7 +250,7 @@ export default function Evaluation() {
                 </p>
               </div>
               <div
-                className="pattern-boxes w-full border p-2 pattern-bg-gray-50 pattern-gray-100 pattern-opacity-100 pattern-size-2 dark:pattern-bg-black dark:pattern-gray-900  
+                className="pattern-boxes w-full border p-4 pattern-bg-gray-50 pattern-gray-100 pattern-opacity-100 pattern-size-2 dark:pattern-bg-black dark:pattern-gray-900  
   lg:w-3/4 lg:p-6"
               >
                 <DndContext

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -99,7 +99,7 @@ export default function Rollouts(props: RolloutsProps) {
     orderRollouts(
       namespace.key,
       flag.key,
-      rollouts.map((rule) => rule.id)
+      rollouts.map((rollout) => rollout.id)
     )
       .then(() => {
         incrementRolloutsVersion();

--- a/ui/src/components/rollouts/Rollout.tsx
+++ b/ui/src/components/rollouts/Rollout.tsx
@@ -1,18 +1,19 @@
 import { Menu, Transition } from '@headlessui/react';
 import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 import { forwardRef, Fragment, Ref } from 'react';
+import { IFlag } from '~/types/Flag';
 import { IRollout, rolloutTypeToLabel } from '~/types/Rollout';
 import { ISegment } from '~/types/Segment';
 import { classNames } from '~/utils/helpers';
 import QuickEditRolloutForm from './forms/QuickEditRolloutForm';
 
 type RolloutProps = {
-  flagKey: string;
+  flag: IFlag;
   rollout: IRollout;
   segments: ISegment[];
-  onSuccess: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
+  onSuccess?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
   style?: React.CSSProperties;
   className?: string;
   readOnly?: boolean;
@@ -21,7 +22,7 @@ type RolloutProps = {
 const Rollout = forwardRef(
   (
     {
-      flagKey,
+      flag,
       rollout,
       segments,
       onSuccess,
@@ -119,7 +120,7 @@ const Rollout = forwardRef(
       <div className="flex w-full flex-1 items-center p-2 text-xs lg:p-0">
         <div className="flex grow flex-col items-center justify-center sm:ml-2 md:flex-row md:justify-between">
           <QuickEditRolloutForm
-            flagKey={flagKey}
+            flag={flag}
             rollout={rollout}
             segments={segments}
             onSuccess={onSuccess}

--- a/ui/src/components/rollouts/SortableRollout.tsx
+++ b/ui/src/components/rollouts/SortableRollout.tsx
@@ -1,20 +1,21 @@
 import { useSortable } from '@dnd-kit/sortable';
+import { IFlag } from '~/types/Flag';
 import { IRollout } from '~/types/Rollout';
 import { ISegment } from '~/types/Segment';
 import Rollout from './Rollout';
 
 type SortableRolloutProps = {
-  flagKey: string;
+  flag: IFlag;
   rollout: IRollout;
   segments: ISegment[];
-  onSuccess: () => void;
-  onEdit: () => void;
-  onDelete: () => void;
+  onSuccess?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
   readOnly?: boolean;
 };
 
 export default function SortableRollout(props: SortableRolloutProps) {
-  const { flagKey, rollout, segments, onSuccess, onEdit, onDelete, readOnly } =
+  const { flag, rollout, segments, onSuccess, onEdit, onDelete, readOnly } =
     props;
   const {
     isDragging,
@@ -45,7 +46,7 @@ export default function SortableRollout(props: SortableRolloutProps) {
       {...attributes}
       style={style}
       className={className}
-      flagKey={flagKey}
+      flag={flag}
       rollout={rollout}
       segments={segments}
       onSuccess={onSuccess}

--- a/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
@@ -10,15 +10,16 @@ import Loading from '~/components/Loading';
 import { updateRollout } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
+import { IFlag } from '~/types/Flag';
 import { IRollout, RolloutType } from '~/types/Rollout';
 import { FilterableSegment, ISegment } from '~/types/Segment';
 import { truncateKey } from '~/utils/helpers';
 
 type QuickEditRolloutFormProps = {
-  onSuccess: () => void;
-  flagKey: string;
+  flag: IFlag;
   rollout: IRollout;
   segments: ISegment[];
+  onSuccess?: () => void;
 };
 
 interface RolloutFormValues {
@@ -28,7 +29,7 @@ interface RolloutFormValues {
 }
 
 export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
-  const { onSuccess, flagKey, rollout, segments } = props;
+  const { onSuccess, flag, rollout, segments } = props;
 
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
@@ -53,7 +54,7 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
     let rolloutSegment = rollout;
     rolloutSegment.threshold = undefined;
 
-    return updateRollout(namespace.key, flagKey, rollout.id, {
+    return updateRollout(namespace.key, flag.key, rollout.id, {
       ...rolloutSegment,
       segment: {
         segmentKey: values.segmentKey || '',
@@ -66,7 +67,7 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
     let rolloutThreshold = rollout;
     rolloutThreshold.segment = undefined;
 
-    return updateRollout(namespace.key, flagKey, rollout.id, {
+    return updateRollout(namespace.key, flag.key, rollout.id, {
       ...rolloutThreshold,
       threshold: {
         percentage: values.percentage || 0,
@@ -104,9 +105,9 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
 
         handleSubmit(values)
           .then(() => {
-            onSuccess();
             clearError();
             setSuccess('Successfully updated rollout');
+            onSuccess && onSuccess();
           })
           .catch((err) => {
             setError(err);

--- a/ui/src/components/rules/Rule.tsx
+++ b/ui/src/components/rules/Rule.tsx
@@ -11,8 +11,8 @@ type RuleProps = {
   flag: IFlag;
   rule: IEvaluatable;
   segments: ISegment[];
-  onSuccess: () => void;
-  onDelete: () => void;
+  onSuccess?: () => void;
+  onDelete?: () => void;
   style?: React.CSSProperties;
   className?: string;
   readOnly?: boolean;
@@ -37,7 +37,7 @@ const Rule = forwardRef(
       key={rule.id}
       ref={ref}
       style={style}
-      className={`${className} w-full items-center space-y-2 rounded-md border shadow-md shadow-violet-100 bg-white border-violet-300 hover:shadow-violet-200 sm:flex sm:flex-col lg:px-6 lg:py-2`}
+      className={`${className} w-full items-center space-y-2 rounded-md border shadow-md shadow-violet-100 bg-white border-violet-300 hover:shadow-violet-200 sm:flex sm:flex-col lg:px-4 lg:py-2`}
     >
       <div className="w-full border-b p-2 bg-white border-gray-200 ">
         <div className="flex w-full flex-wrap items-center justify-between sm:flex-nowrap">

--- a/ui/src/components/rules/forms/MultiDistributionForm.tsx
+++ b/ui/src/components/rules/forms/MultiDistributionForm.tsx
@@ -11,7 +11,7 @@ export default function MultiDistributionFormInputs(
   const { distributions, setDistributions } = props;
 
   return (
-    <div>
+    <div className="sm:pb-4">
       <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
         <div>
           <label

--- a/ui/src/components/rules/forms/QuickEditRuleForm.tsx
+++ b/ui/src/components/rules/forms/QuickEditRuleForm.tsx
@@ -16,10 +16,10 @@ import { truncateKey } from '~/utils/helpers';
 import { distTypeMulti, distTypes, distTypeSingle } from './RuleForm';
 
 type QuickEditRuleFormProps = {
-  onSuccess: () => void;
   flag: IFlag;
   rule: IEvaluatable;
   segments: ISegment[];
+  onSuccess?: () => void;
 };
 
 export const validRollout = (rollouts: IVariantRollout[]): boolean => {
@@ -156,7 +156,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
           ?.then(() => {
             clearError();
             setSuccess('Successfully updated rule');
-            onSuccess();
+            onSuccess && onSuccess();
           })
           .catch((err) => {
             setError(err);
@@ -282,12 +282,9 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                           {formik.values.rollouts &&
                             formik.values.rollouts.length > 0 &&
                             formik.values.rollouts?.map((dist, index) => (
-                              <>
+                              <div key={index}>
                                 {dist && (
-                                  <div
-                                    className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-1"
-                                    key={index}
-                                  >
+                                  <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-1">
                                     <div>
                                       <label
                                         htmlFor={`rollouts.[${index}].distribution.rollout`}
@@ -317,7 +314,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                                     </div>
                                   </div>
                                 )}
-                              </>
+                              </div>
                             ))}
                         </>
                       )}

--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -186,16 +186,6 @@ export async function createRollout(
   return post(`/namespaces/${namespaceKey}/flags/${flagKey}/rollouts`, values);
 }
 
-export async function deleteRollout(
-  namespaceKey: string,
-  flagKey: string,
-  rolloutId: string
-) {
-  return del(
-    `/namespaces/${namespaceKey}/flags/${flagKey}/rollouts/${rolloutId}`
-  );
-}
-
 export async function updateRollout(
   namespaceKey: string,
   flagKey: string,
@@ -206,6 +196,42 @@ export async function updateRollout(
     `/namespaces/${namespaceKey}/flags/${flagKey}/rollouts/${rolloutId}`,
     values
   );
+}
+
+export async function deleteRollout(
+  namespaceKey: string,
+  flagKey: string,
+  rolloutId: string
+) {
+  return del(
+    `/namespaces/${namespaceKey}/flags/${flagKey}/rollouts/${rolloutId}`
+  );
+}
+
+export async function orderRollouts(
+  namespaceKey: string,
+  flagKey: string,
+  rolloutIds: string[]
+) {
+  const req = setCsrf({
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      rolloutIds: rolloutIds
+    })
+  });
+
+  const res = await fetch(
+    `${apiURL}/namespaces/${namespaceKey}/flags/${flagKey}/rollouts/order`,
+    req
+  );
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.message);
+  }
+  return res.ok;
 }
 
 //

--- a/ui/src/types/Distribution.ts
+++ b/ui/src/types/Distribution.ts
@@ -12,3 +12,9 @@ export interface IDistribution extends IDistributionBase {
   createdAt: string;
   updatedAt: string;
 }
+
+export enum DistributionType {
+  None = 'none',
+  Single = 'single',
+  Multi = 'multi'
+}

--- a/ui/tests/rules.spec.ts
+++ b/ui/tests/rules.spec.ts
@@ -52,18 +52,18 @@ test.describe('Rules', () => {
   test('can update rule', async ({ page }) => {
     await page.getByRole('link', { name: 'test-rule' }).click();
     await page.getByRole('link', { name: 'Evaluation' }).click();
-    await page.getByRole('link', { name: 'Edit |' }).click();
-    await page
-      .getByRole('dialog', { name: 'Edit Rule' })
-      .getByText('123')
-      .click();
 
-    await page.locator('input[name="\\31 23"]').click();
-    await page.locator('input[name="\\31 23"]').fill('40');
-    await page.locator('input[name="\\31 23"]').press('Tab');
-    await page.locator('input[name="\\34 56"]').fill('60');
+    await page
+      .locator('input[name="rollouts\\.\\[0\\]\\.distribution\\.rollout"]')
+      .click();
+    await page
+      .locator('input[name="rollouts\\.\\[0\\]\\.distribution\\.rollout"]')
+      .fill('40');
+    await page
+      .locator('input[name="rollouts\\.\\[1\\]\\.distribution\\.rollout"]')
+      .click();
     await page.getByRole('button', { name: 'Update' }).click();
-    await page.getByText('Successfully updated rule').click();
+    await expect(page.getByText('Successfully updated rule')).toBeVisible();
   });
 });
 
@@ -92,12 +92,14 @@ test.describe('Rules - Read Only', () => {
   test('can not update rule', async ({ page }) => {
     await page.getByRole('link', { name: 'test-rule' }).click();
     await page.getByRole('link', { name: 'Evaluation' }).click();
-    await expect(page.getByRole('link', { name: 'Edit |' })).toBeHidden();
+    await page.locator('[id="headlessui-menu-button-\\:r4\\:"]').click();
+    await expect(page.getByRole('link', { name: 'Edit' })).toBeHidden();
   });
 
   test('can not delete rule', async ({ page }) => {
     await page.getByRole('link', { name: 'test-rule' }).click();
     await page.getByRole('link', { name: 'Evaluation' }).click();
+    await page.locator('[id="headlessui-menu-button-\\:r4\\:"]').click();
     await expect(page.getByRole('link', { name: 'Delete' })).toBeHidden();
   });
 });


### PR DESCRIPTION
Fixes: FLI-476

- Adds back ability to re-order rules
- Adds ability to re-order rollouts
- Fixes ability to re-order rollouts in SQL
- Adds re-order rollout tests

**The video is from before the fix in the DB just to show drag-drop func**

https://github.com/flipt-io/flipt/assets/209477/7cd0d3f2-d956-4f6b-9872-5f9ebc41ed68

