### PR TITLE
chore(github): move all db unit tests to dagger

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
   test:
     name: "Tests (Go)"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        database: ["mysql", "postgres", "cockroachdb", "sqlite"]
     steps:
       - uses: actions/checkout@v3
 
@@ -32,10 +35,11 @@ jobs:
           cd /usr/local
           curl -L https://dl.dagger.io/dagger/install.sh | sh
 
-      - uses: GeorgeMac/mage-action@gm/tools-add-path-debug
+      - name: Unit Test ${{ matrix.database }}
+        uses: GeorgeMac/mage-action@gm/tools-add-path-debug
         with:
           version: latest
-          args: dagger:run test:unit
+          args: dagger:run test:${{ matrix.database }}
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3.1.4
@@ -82,23 +86,3 @@ jobs:
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3.1.4
-
-  database:
-    name: Database Test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        database: ["mysql", "postgres", "cockroachdb"]
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.20"
-          check-latest: true
-          cache: true
-
-      - name: Unit Test ${{ matrix.database }}
-        env:
-          FLIPT_TEST_DATABASE_PROTOCOL: ${{ matrix.database }}
-        run: go test -count=1 -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: GeorgeMac/mage-action@gm/tools-add-path-debug
         with:
           version: latest
-          args: dagger:run test:${{ matrix.database }}
+          args: dagger:run "test:database ${{ matrix.database }}"
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3.1.4

--- a/build/magefile.go
+++ b/build/magefile.go
@@ -101,7 +101,12 @@ func (t Test) Database(ctx context.Context, db string) error {
 			return err
 		}
 
-		return testing.Unit(testing.All[db](ctx, client, base))
+		test, ok := testing.All[db]
+		if !ok {
+			return fmt.Errorf("unexpected database name: %q", db)
+		}
+
+		return testing.Unit(test(ctx, client, base))
 	})
 }
 

--- a/build/testing/test.go
+++ b/build/testing/test.go
@@ -51,10 +51,10 @@ func Unit(ctx context.Context, client *dagger.Client, flipt *dagger.Container) e
 }
 
 var All = map[string]Wrapper{
-	"sqlite":    WithSQLite,
-	"postgres":  WithPostgres,
-	"mysql":     WithMySQL,
-	"cockroach": WithCockroach,
+	"sqlite":      WithSQLite,
+	"postgres":    WithPostgres,
+	"mysql":       WithMySQL,
+	"cockroachdb": WithCockroach,
 }
 
 type Wrapper func(context.Context, *dagger.Client, *dagger.Container) (context.Context, *dagger.Client, *dagger.Container)


### PR DESCRIPTION
This moves all unit tests in CI to use the Dagger mage targets.

We will need to update the branch protection rules to accomodate this.