### PR TITLE
chore: runs prettier after dependency update

### DIFF
--- a/ui/index.dev.html
+++ b/ui/index.dev.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full w-auto bg-white">
+<html lang="en" class="bg-white h-full w-auto">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.svg" />
@@ -28,23 +28,23 @@
               class="h-8 w-auto"
             />
           </div>
-          <div class="px-6 pt-24 bg-white sm:pt-20 lg:px-8">
+          <div class="bg-white px-6 pt-24 sm:pt-20 lg:px-8">
             <div class="mx-auto max-w-2xl text-center">
               <h2
-                class="text-2xl font-bold tracking-tight text-gray-900 sm:text-5xl"
+                class="text-gray-900 text-2xl font-bold tracking-tight sm:text-5xl"
               >
                 Not Found
               </h2>
-              <p class="mt-4 text-lg leading-8 text-gray-500">
+              <p class="text-gray-500 mt-4 text-lg leading-8">
                 This isn't the UI you're looking for...
               </p>
-              <p class="mt-20 text-lg leading-8 text-gray-700">
+              <p class="text-gray-700 mt-20 text-lg leading-8">
                 Run the following in another terminal:
               </p>
             </div>
           </div>
           <div
-            class="mx-auto my-8 max-w-md overflow-hidden rounded-lg text-white bg-gray-700"
+            class="text-white bg-gray-700 mx-auto my-8 max-w-md overflow-hidden rounded-lg"
           >
             <div class="px-4 py-5 sm:p-6">
               <pre><span class="text-violet-300">$</span>&nbsp;cd ui && npm run dev</pre>
@@ -53,7 +53,7 @@
           <div class="mt-16 flex items-center justify-center gap-x-6">
             <a
               href="https://www.flipt.io/discord"
-              class="text-sm font-semibold text-gray-600 hover:underline hover:decoration-violet-400 hover:underline-offset-4"
+              class="text-gray-600 text-sm font-semibold hover:underline hover:decoration-violet-400 hover:underline-offset-4"
             >
               Need Help? Join our Discord <span aria-hidden="true">&rarr;</span>
             </a>

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full w-auto bg-white">
+<html lang="en" class="bg-white h-full w-auto">
   <body class="h-full antialiased">
     <div id="root"></div>
 

--- a/ui/screenshot.js
+++ b/ui/screenshot.js
@@ -5,28 +5,31 @@ const fs = require('fs');
 const fliptAddr = process.env.FLIPT_ADDRESS ?? 'http://localhost:8080';
 
 const screenshot = async (page, name) => {
-  await page.screenshot({ path: 'screenshots/'+name });
+  await page.screenshot({ path: 'screenshots/' + name });
 };
 
 const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 
-const capture = async function(name, fn) {
+const capture = async function (name, fn) {
   try {
     const path = `${__dirname}/screenshot/fixtures/${name}.yml`;
     if (fs.existsSync(path)) {
-      exec(`flipt import --address=${fliptAddr} ${path}`, (error, stdout, stderr) => {
-        if (error) {
-          console.error(`error: ${error.message}`);
-          return;
-        }
+      exec(
+        `flipt import --address=${fliptAddr} ${path}`,
+        (error, stdout, stderr) => {
+          if (error) {
+            console.error(`error: ${error.message}`);
+            return;
+          }
 
-        if (stderr) {
-          console.error(`stderr: ${stderr}`);
-          return;
-        }
+          if (stderr) {
+            console.error(`stderr: ${stderr}`);
+            return;
+          }
 
-        console.log(`stdout:\n${stdout}`);
-      })
+          console.log(`stdout:\n${stdout}`);
+        }
+      );
     }
   } catch (err) {
     // ignore and we will just skip seeding
@@ -35,7 +38,7 @@ const capture = async function(name, fn) {
 
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
-    viewport: { width: 1440, height: 900 },
+    viewport: { width: 1440, height: 900 }
   });
   const page = await context.newPage();
 

--- a/ui/screenshot/create-contraint.js
+++ b/ui/screenshot/create-contraint.js
@@ -1,16 +1,16 @@
 const { capture } = require('../screenshot.js');
 
-(async() => {
-    await capture('create_constraint', async (page) => {
-      await page.getByRole('link', { name: 'Segments' }).click();
-      await page.getByRole('link', { name: 'all-users' }).click();
-      await page.getByRole('button', { name: 'New Constraint' }).click();
-      await page.getByLabel('Property').fill('admin');
-      await page
-        .getByRole('combobox', { name: 'Type' })
-        .selectOption('BOOLEAN_COMPARISON_TYPE');
-      await page
-        .getByRole('combobox', { name: 'Operator' })
-        .selectOption('notpresent');
-    });
+(async () => {
+  await capture('create_constraint', async (page) => {
+    await page.getByRole('link', { name: 'Segments' }).click();
+    await page.getByRole('link', { name: 'all-users' }).click();
+    await page.getByRole('button', { name: 'New Constraint' }).click();
+    await page.getByLabel('Property').fill('admin');
+    await page
+      .getByRole('combobox', { name: 'Type' })
+      .selectOption('BOOLEAN_COMPARISON_TYPE');
+    await page
+      .getByRole('combobox', { name: 'Operator' })
+      .selectOption('notpresent');
+  });
 })();

--- a/ui/screenshot/create-flag.js
+++ b/ui/screenshot/create-flag.js
@@ -1,10 +1,12 @@
 const { capture } = require('../screenshot.js');
 
-(async() => {
-    await capture('create_flag', async (page) => {
-      await page.getByRole('button', { name: 'New Flag' }).click();
-      await page.getByLabel('Name').fill('New Login');
-      await page.getByLabel('Key').fill('new-login');
-      await page.getByLabel('Description').fill('Enables the new login page for users');
-    });
+(async () => {
+  await capture('create_flag', async (page) => {
+    await page.getByRole('button', { name: 'New Flag' }).click();
+    await page.getByLabel('Name').fill('New Login');
+    await page.getByLabel('Key').fill('new-login');
+    await page
+      .getByLabel('Description')
+      .fill('Enables the new login page for users');
+  });
 })();

--- a/ui/screenshot/create-rule.js
+++ b/ui/screenshot/create-rule.js
@@ -1,12 +1,12 @@
 const { capture } = require('../screenshot.js');
 
-(async() => {
-    await capture('create_rule', async (page) => {
-      await page.getByRole('link', { name: 'new-login' }).click();
-      await page.getByRole('link', { name: 'Evaluation' }).click();
-      await page.getByRole('button', { name: 'New Rule' }).click();
-      await page.locator('#segmentKey-select-button').click();
-      await page.getByText('all-users').click();
-      await page.getByLabel('Multi-Variant').check();
-    });
+(async () => {
+  await capture('create_rule', async (page) => {
+    await page.getByRole('link', { name: 'new-login' }).click();
+    await page.getByRole('link', { name: 'Evaluation' }).click();
+    await page.getByRole('button', { name: 'New Rule' }).click();
+    await page.locator('#segmentKey-select-button').click();
+    await page.getByText('all-users').click();
+    await page.getByLabel('Multi-Variant').check();
+  });
 })();

--- a/ui/screenshot/create-segment.js
+++ b/ui/screenshot/create-segment.js
@@ -1,10 +1,10 @@
 const { capture } = require('../screenshot.js');
 
-(async() => {
-    await capture('create_segment', async (page) => {
-      await page.getByRole('link', { name: 'Segments' }).click();
-      await page.getByRole('button', { name: 'New Segment' }).click();
-      await page.getByLabel('Name').fill('All Users');
-      await page.getByLabel('Key').fill('all-users');
-    });
+(async () => {
+  await capture('create_segment', async (page) => {
+    await page.getByRole('link', { name: 'Segments' }).click();
+    await page.getByRole('button', { name: 'New Segment' }).click();
+    await page.getByLabel('Name').fill('All Users');
+    await page.getByLabel('Key').fill('all-users');
+  });
 })();

--- a/ui/screenshot/create-variant.js
+++ b/ui/screenshot/create-variant.js
@@ -1,16 +1,16 @@
 const { capture } = require('../screenshot.js');
 
-(async() => {
-    await capture('create_variant', async (page) => {
-      await page.getByRole('link', { name: 'new-login' }).click();
-      await page.getByRole('button', { name: 'New Variant' }).click();
-      await page
-            .getByRole('dialog', { name: 'New Variant' })
-            .locator('#key')
-            .fill('big-blue-login-button');
-      await page
-            .getByRole('dialog', { name: 'New Variant' })
-            .locator('#name')
-            .fill('Big Blue Login Button');
-    });
+(async () => {
+  await capture('create_variant', async (page) => {
+    await page.getByRole('link', { name: 'new-login' }).click();
+    await page.getByRole('button', { name: 'New Variant' }).click();
+    await page
+      .getByRole('dialog', { name: 'New Variant' })
+      .locator('#key')
+      .fill('big-blue-login-button');
+    await page
+      .getByRole('dialog', { name: 'New Variant' })
+      .locator('#name')
+      .fill('Big Blue Login Button');
+  });
 })();

--- a/ui/src/app/ErrorLayout.tsx
+++ b/ui/src/app/ErrorLayout.tsx
@@ -21,11 +21,11 @@ export default function ErrorLayout() {
         </div>
         <div className="mx-auto max-w-xl py-16 sm:py-24">
           <div className="text-center">
-            <h1 className="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            <h1 className="text-gray-900 mt-2 text-4xl font-bold tracking-tight sm:text-5xl">
               Error
             </h1>
             {error && error.message && (
-              <p className="mt-2 text-lg text-gray-500">{error.message}</p>
+              <p className="text-gray-500 mt-2 text-lg">{error.message}</p>
             )}
           </div>
 
@@ -36,7 +36,7 @@ export default function ErrorLayout() {
                 e.preventDefault();
                 navigate(-1);
               }}
-              className="text-base font-medium text-violet-600 hover:text-violet-500"
+              className="text-violet-600 text-base font-medium hover:text-violet-500"
             >
               <span aria-hidden="true">&larr; </span>
               Go Back

--- a/ui/src/app/Layout.tsx
+++ b/ui/src/app/Layout.tsx
@@ -30,7 +30,7 @@ function InnerLayout() {
   return (
     <>
       <Sidebar setSidebarOpen={setSidebarOpen} sidebarOpen={sidebarOpen} />
-      <div className="flex min-h-screen flex-col bg-white md:pl-64">
+      <div className="bg-white flex min-h-screen flex-col md:pl-64">
         <Header setSidebarOpen={setSidebarOpen} />
 
         <main className="flex px-6 py-10">

--- a/ui/src/app/NotFoundLayout.tsx
+++ b/ui/src/app/NotFoundLayout.tsx
@@ -38,7 +38,7 @@ const links = [
 
 export default function NotFoundLayout() {
   return (
-    <div className="flex min-h-screen flex-col bg-white">
+    <div className="bg-white flex min-h-screen flex-col">
       <main className="mx-auto w-full max-w-7xl px-6 lg:px-8">
         <div className="flex-shrink-0 pt-16">
           <Link to="/">
@@ -53,21 +53,21 @@ export default function NotFoundLayout() {
         </div>
         <div className="mx-auto max-w-xl py-16 sm:py-24">
           <div className="text-center">
-            <p className="text-base font-semibold text-violet-600">404</p>
-            <h1 className="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
+            <p className="text-violet-600 text-base font-semibold">404</p>
+            <h1 className="text-gray-900 mt-2 text-4xl font-bold tracking-tight sm:text-5xl">
               Not Found
             </h1>
-            <p className="mt-2 text-lg text-gray-500">
+            <p className="text-gray-500 mt-2 text-lg">
               The page you are looking for could not be found.
             </p>
           </div>
           <div className="mt-12">
-            <h2 className="text-base font-semibold text-gray-500">
+            <h2 className="text-gray-500 text-base font-semibold">
               Popular pages
             </h2>
             <ul
               role="list"
-              className="mt-4 divide-y divide-gray-200 border-b border-t border-gray-200"
+              className="border-gray-200 mt-4 divide-y divide-gray-200 border-b border-t"
             >
               {links.map((link, linkIdx) => (
                 <li
@@ -75,15 +75,15 @@ export default function NotFoundLayout() {
                   className="relative flex items-start space-x-4 py-6"
                 >
                   <div className="flex-shrink-0">
-                    <span className="flex h-12 w-12 items-center justify-center rounded-lg bg-violet-50">
+                    <span className="bg-violet-50 flex h-12 w-12 items-center justify-center rounded-lg">
                       <link.icon
-                        className="h-6 w-6 text-violet-700"
+                        className="text-violet-700 h-6 w-6"
                         aria-hidden="true"
                       />
                     </span>
                   </div>
                   <div className="min-w-0 flex-1">
-                    <h3 className="text-base font-medium text-gray-900 hover:text-violet-500">
+                    <h3 className="text-gray-900 text-base font-medium hover:text-violet-500">
                       <span className="rounded-sm focus-within:ring-2 focus-within:ring-violet-500 focus-within:ring-offset-2">
                         <a
                           href={link.href}
@@ -99,13 +99,13 @@ export default function NotFoundLayout() {
                         </a>
                       </span>
                     </h3>
-                    <p className="text-base text-gray-500">
+                    <p className="text-gray-500 text-base">
                       {link.description}
                     </p>
                   </div>
                   <div className="flex-shrink-0 self-center">
                     <ChevronRightIcon
-                      className="h-5 w-5 text-gray-400"
+                      className="text-gray-400 h-5 w-5"
                       aria-hidden="true"
                     />
                   </div>
@@ -115,7 +115,7 @@ export default function NotFoundLayout() {
             <div className="mt-8">
               <a
                 href="/"
-                className="text-base font-medium text-violet-600 hover:text-violet-500"
+                className="text-violet-600 text-base font-medium hover:text-violet-500"
               >
                 <span aria-hidden="true">&larr; </span>
                 Home

--- a/ui/src/app/Settings.tsx
+++ b/ui/src/app/Settings.tsx
@@ -21,7 +21,7 @@ export default function Settings() {
     <>
       <div className="flex items-center justify-between">
         <div className="min-w-0 flex-1">
-          <h2 className="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">
+          <h2 className="text-gray-900 text-2xl font-bold leading-7 sm:truncate sm:text-3xl sm:tracking-tight">
             Settings
           </h2>
         </div>

--- a/ui/src/app/auth/Login.tsx
+++ b/ui/src/app/auth/Login.tsx
@@ -104,7 +104,7 @@ export default function Login() {
 
   return (
     <>
-      <div className="flex min-h-screen flex-col justify-center bg-white sm:px-6 lg:px-8">
+      <div className="bg-white flex min-h-screen flex-col justify-center sm:px-6 lg:px-8">
         <main className="flex px-6 py-10">
           <div className="w-full overflow-x-auto px-4 sm:px-6 lg:px-8">
             <div className="sm:mx-auto sm:w-full sm:max-w-md">
@@ -115,7 +115,7 @@ export default function Login() {
                 height={512}
                 className="m-auto h-20 w-auto"
               />
-              <h2 className="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900">
+              <h2 className="text-gray-900 mt-6 text-center text-3xl font-bold tracking-tight">
                 Login to Flipt
               </h2>
             </div>
@@ -127,7 +127,7 @@ export default function Login() {
                       <div key={provider.name}>
                         <a
                           href="#"
-                          className="inline-flex w-full justify-center rounded-md border px-4 py-2 text-sm font-medium shadow-sm bg-white text-gray-500 border-gray-300 hover:shadow-violet-300 hover:text-violet-500"
+                          className="bg-white text-gray-500 border-gray-300 inline-flex w-full justify-center rounded-md border px-4 py-2 text-sm font-medium shadow-sm hover:text-violet-500 hover:shadow-violet-300"
                           onClick={(e) => {
                             e.preventDefault();
                             authorize(provider.authorize_url);
@@ -148,12 +148,12 @@ export default function Login() {
                   </div>
                 )}
                 {(!providers || providers.length === 0) && (
-                  <div className="shadow bg-white sm:rounded-lg">
+                  <div className="bg-white shadow sm:rounded-lg">
                     <div className="px-4 py-5 sm:p-6">
-                      <h3 className="text-base font-semibold leading-6 text-gray-900">
+                      <h3 className="text-gray-900 text-base font-semibold leading-6">
                         No Providers
                       </h3>
-                      <div className="mt-2 max-w-xl text-sm text-gray-500">
+                      <div className="text-gray-500 mt-2 max-w-xl text-sm">
                         <p>
                           Authentication is set to{' '}
                           <span className="font-medium">required</span>,
@@ -164,7 +164,7 @@ export default function Login() {
                       <div className="mt-3 text-sm leading-6">
                         <a
                           href="https://www.flipt.io/docs/configuration/authentication#method-oidc"
-                          className="font-semibold text-violet-600 hover:text-violet-500"
+                          className="text-violet-600 font-semibold hover:text-violet-500"
                         >
                           Configuring Authentication
                           <span aria-hidden="true"> &rarr;</span>

--- a/ui/src/app/console/Console.tsx
+++ b/ui/src/app/console/Console.tsx
@@ -123,10 +123,10 @@ export default function Console() {
   return (
     <>
       <div className="flex flex-col">
-        <h1 className="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl">
+        <h1 className="text-gray-900 text-2xl font-bold leading-7 sm:truncate sm:text-3xl">
           Console
         </h1>
-        <p className="mt-2 text-sm text-gray-500">
+        <p className="text-gray-500 mt-2 text-sm">
           See the results of your flag evaluations and debug any issues
         </p>
       </div>
@@ -157,7 +157,7 @@ export default function Console() {
                         <div className="col-span-3">
                           <label
                             htmlFor="flagKey"
-                            className="block text-sm font-medium text-gray-700"
+                            className="text-gray-700 block text-sm font-medium"
                           >
                             Flag Key
                           </label>
@@ -174,7 +174,7 @@ export default function Console() {
                         <div className="col-span-3">
                           <label
                             htmlFor="entityId"
-                            className="block text-sm font-medium text-gray-700"
+                            className="text-gray-700 block text-sm font-medium"
                           >
                             Entity ID
                           </label>
@@ -188,7 +188,7 @@ export default function Console() {
                         <div className="col-span-3">
                           <label
                             htmlFor="context"
-                            className="block text-sm font-medium text-gray-700"
+                            className="text-gray-700 block text-sm font-medium"
                           >
                             Request Context
                           </label>
@@ -233,7 +233,7 @@ export default function Console() {
                 <pre className="p-2 text-sm md:h-full">
                   <code
                     className={classNames(
-                      hasEvaluationError ? 'border-4 border-red-400' : '',
+                      hasEvaluationError ? 'border-red-400 border-4' : '',
                       'json rounded-sm md:h-full'
                     )}
                   >

--- a/ui/src/app/flags/EditFlag.tsx
+++ b/ui/src/app/flags/EditFlag.tsx
@@ -16,7 +16,7 @@ export default function EditFlag() {
         <div className="my-10">
           <div className="md:grid md:grid-cols-3 md:gap-6">
             <div className="md:col-span-1">
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="text-gray-500 mt-1 text-sm">
                 Basic information about the flag and its status.
               </p>
               <MoreInfo

--- a/ui/src/app/flags/Evaluation.tsx
+++ b/ui/src/app/flags/Evaluation.tsx
@@ -174,7 +174,7 @@ export default function Evaluation() {
           panelMessage={
             <>
               Are you sure you want to delete this rule at
-              <span className="font-medium text-violet-500">
+              <span className="text-violet-500 font-medium">
                 {' '}
                 position {deletingRule?.rank}
               </span>
@@ -208,10 +208,10 @@ export default function Evaluation() {
       <div className="my-10">
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">
-            <h1 className="text-lg font-medium leading-6 text-gray-900">
+            <h1 className="text-gray-900 text-lg font-medium leading-6">
               Rules
             </h1>
-            <p className="mt-1 text-sm text-gray-600">
+            <p className="text-gray-600 mt-1 text-sm">
               Enable rich targeting and segmentation for evaluating your flags
             </p>
           </div>
@@ -225,7 +225,7 @@ export default function Evaluation() {
                 title={readOnly ? 'Not allowed in Read-Only mode' : undefined}
               >
                 <PlusIcon
-                  className="-ml-1.5 mr-1 h-5 w-5 text-white"
+                  className="text-white -ml-1.5 mr-1 h-5 w-5"
                   aria-hidden="true"
                 />
                 New Rule
@@ -237,13 +237,13 @@ export default function Evaluation() {
           {rules && rules.length > 0 ? (
             <div className="flex lg:space-x-5">
               <div className="hidden w-1/4 flex-col space-y-7 pr-3 lg:flex">
-                <p className="text-sm font-light text-gray-700">
+                <p className="text-gray-700 text-sm font-light">
                   Rules are evaluated in order from{' '}
                   <span className="font-semibold">top to bottom</span>. The
                   first rule that matches will be applied.
                 </p>
-                <p className="text-sm font-light text-gray-700">
-                  <InformationCircleIcon className="mr-1 inline-block h-4 w-4 text-gray-300" />
+                <p className="text-gray-700 text-sm font-light">
+                  <InformationCircleIcon className="text-gray-300 mr-1 inline-block h-4 w-4" />
                   You can re-arrange rules by clicking in the header and{' '}
                   <span className="font-semibold">dragging and dropping</span>{' '}
                   them into place.

--- a/ui/src/app/flags/Flag.tsx
+++ b/ui/src/app/flags/Flag.tsx
@@ -81,7 +81,7 @@ export default function Flag() {
           panelMessage={
             <>
               Are you sure you want to delete the flag{' '}
-              <span className="font-medium text-violet-500">{flag.key}</span>?
+              <span className="text-violet-500 font-medium">{flag.key}</span>?
               This action cannot be undone.
             </>
           }
@@ -100,7 +100,7 @@ export default function Flag() {
           panelMessage={
             <>
               Copy the flag{' '}
-              <span className="font-medium text-violet-500">{flag.key}</span> to
+              <span className="text-violet-500 font-medium">{flag.key}</span> to
               the namespace:
             </>
           }
@@ -123,16 +123,16 @@ export default function Flag() {
       {/* flag header / actions */}
       <div className="flex items-center justify-between">
         <div className="min-w-0 flex-1">
-          <h2 className="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">
+          <h2 className="text-gray-900 text-2xl font-bold leading-7 sm:truncate sm:text-3xl sm:tracking-tight">
             {flag.name}
           </h2>
           <div className="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
             <div
               title={inTimezone(flag.createdAt)}
-              className="mt-2 flex items-center text-sm text-gray-500"
+              className="text-gray-500 mt-2 flex items-center text-sm"
             >
               <CalendarIcon
-                className="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400"
+                className="text-gray-400 mr-1.5 h-5 w-5 flex-shrink-0"
                 aria-hidden="true"
               />
               Created{' '}

--- a/ui/src/app/flags/Flags.tsx
+++ b/ui/src/app/flags/Flags.tsx
@@ -36,10 +36,10 @@ export default function Flags() {
     <>
       <div className="flex-row justify-between pb-5 sm:flex sm:items-center">
         <div className="flex flex-col">
-          <h1 className="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl">
+          <h1 className="text-gray-900 text-2xl font-bold leading-7 sm:truncate sm:text-3xl">
             Flags
           </h1>
-          <p className="mt-2 text-sm text-gray-500">
+          <p className="text-gray-500 mt-2 text-sm">
             Flags represent features that you can easily enable or disable
           </p>
         </div>
@@ -51,7 +51,7 @@ export default function Flags() {
               title={readOnly ? 'Not allowed in Read-Only mode' : undefined}
             >
               <PlusIcon
-                className="-ml-1.5 mr-1 h-5 w-5 text-white"
+                className="text-white -ml-1.5 mr-1 h-5 w-5"
                 aria-hidden="true"
               />
               <span>New Flag</span>

--- a/ui/src/app/flags/NewFlag.tsx
+++ b/ui/src/app/flags/NewFlag.tsx
@@ -6,7 +6,7 @@ export default function NewFlag() {
     <>
       <div className="lg:flex lg:items-center lg:justify-between">
         <div className="min-w-0 flex-1">
-          <h2 className="text-2xl font-semibold leading-6 text-gray-900">
+          <h2 className="text-gray-900 text-2xl font-semibold leading-6">
             New Flag
           </h2>
         </div>
@@ -14,10 +14,10 @@ export default function NewFlag() {
       <div className="my-10">
         <div className="md:grid md:grid-cols-3 md:gap-6">
           <div className="md:col-span-1">
-            <h3 className="text-lg font-medium leading-6 text-gray-900">
+            <h3 className="text-gray-900 text-lg font-medium leading-6">
               Details
             </h3>
-            <p className="mt-2 text-sm text-gray-500">
+            <p className="text-gray-500 mt-2 text-sm">
               Basic information about the flag and its status.
             </p>
             <MoreInfo

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -160,7 +160,7 @@ export default function Rollouts(props: RolloutsProps) {
           panelMessage={
             <>
               Are you sure you want to delete this rule at
-              <span className="font-medium text-violet-500">
+              <span className="text-violet-500 font-medium">
                 {' '}
                 position {deletingRollout?.rank}
               </span>
@@ -219,10 +219,10 @@ export default function Rollouts(props: RolloutsProps) {
       <div className="mt-10">
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">
-            <h1 className="text-lg font-medium leading-6 text-gray-900">
+            <h1 className="text-gray-900 text-lg font-medium leading-6">
               Rollouts
             </h1>
-            <p className="mt-1 text-sm text-gray-500">
+            <p className="text-gray-500 mt-1 text-sm">
               Return boolean values based on rules you define
             </p>
           </div>
@@ -239,7 +239,7 @@ export default function Rollouts(props: RolloutsProps) {
                 }}
               >
                 <PlusIcon
-                  className="-ml-1.5 mr-1 h-5 w-5 text-white"
+                  className="text-white -ml-1.5 mr-1 h-5 w-5"
                   aria-hidden="true"
                 />
                 <span>New Rollout</span>
@@ -250,13 +250,13 @@ export default function Rollouts(props: RolloutsProps) {
         <div className="mt-10">
           <div className="flex lg:space-x-5">
             <div className="hidden w-1/4 flex-col space-y-7 pr-3 lg:flex">
-              <p className="text-sm font-light text-gray-700">
+              <p className="text-gray-700 text-sm font-light">
                 Rules are evaluated in order from{' '}
                 <span className="font-semibold">top to bottom</span>. The first
                 rule that matches will be applied.
               </p>
-              <p className="text-sm font-light text-gray-700">
-                <InformationCircleIcon className="mr-1 inline-block h-4 w-4 text-gray-300" />
+              <p className="text-gray-700 text-sm font-light">
+                <InformationCircleIcon className="text-gray-300 mr-1 inline-block h-4 w-4" />
                 You can re-arrange rules by clicking in the header and{' '}
                 <span className="font-semibold">dragging and dropping</span>{' '}
                 them into place.
@@ -310,11 +310,11 @@ export default function Rollouts(props: RolloutsProps) {
                 </DndContext>
               )}
               <div className="flex-col p-2 md:flex">
-                <div className="w-full items-center space-y-2 rounded-md border shadow-md shadow-violet-100 bg-white border-violet-300 hover:shadow-violet-200 sm:flex sm:flex-col lg:px-6 lg:py-2">
-                  <div className="w-full border-b p-2 bg-white border-gray-200 ">
+                <div className="bg-white border-violet-300 w-full items-center space-y-2 rounded-md border shadow-md shadow-violet-100 hover:shadow-violet-200 sm:flex sm:flex-col lg:px-6 lg:py-2">
+                  <div className="bg-white border-gray-200 w-full border-b p-2 ">
                     <div className="flex w-full flex-wrap items-center justify-between sm:flex-nowrap">
-                      <StarIcon className="hidden h-4 w-4 justify-start text-gray-400 hover:text-violet-300 sm:flex" />
-                      <h3 className="text-sm font-normal leading-6 text-gray-700">
+                      <StarIcon className="text-gray-400 hidden h-4 w-4 justify-start hover:text-violet-300 sm:flex" />
+                      <h3 className="text-gray-700 text-sm font-normal leading-6">
                         Default Rollout
                       </h3>
                       <span className="hidden h-4 w-4 justify-end sm:flex" />
@@ -323,7 +323,7 @@ export default function Rollouts(props: RolloutsProps) {
                   <div className="flex w-full flex-1 items-center p-2 text-xs lg:p-0">
                     <div className="flex grow flex-col items-center justify-center sm:ml-2">
                       <div className="flex flex-col pb-4 pt-2">
-                        <p className="text-sm font-light text-gray-500">
+                        <p className="text-gray-500 text-sm font-light">
                           This is the default value that will be returned if no
                           other rules match. It is directly tied to the flag
                           enabled state.
@@ -334,11 +334,11 @@ export default function Rollouts(props: RolloutsProps) {
                           <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:p-2">
                             <label
                               htmlFor="value"
-                              className="mb-2 block text-sm font-medium text-gray-900"
+                              className="text-gray-900 mb-2 block text-sm font-medium"
                             >
                               Value
                             </label>
-                            <span className="inline-flex w-fit items-center rounded-md px-3 py-1 text-sm font-medium ring-1 ring-inset ring-gray-500/10 text-gray-600 bg-gray-50">
+                            <span className="text-gray-600 bg-gray-50 inline-flex w-fit items-center rounded-md px-3 py-1 text-sm font-medium ring-1 ring-inset ring-gray-500/10">
                               {flag.enabled ? 'True' : 'False'}
                             </span>
                           </div>

--- a/ui/src/app/flags/rollouts/Rollouts.tsx
+++ b/ui/src/app/flags/rollouts/Rollouts.tsx
@@ -189,8 +189,8 @@ export default function Rollouts(props: RolloutsProps) {
           segments={segments}
           setOpen={setShowRolloutForm}
           onSuccess={() => {
-            setShowRolloutForm(false);
             incrementRolloutsVersion();
+            setShowRolloutForm(false);
           }}
         />
       </Slideover>
@@ -226,26 +226,24 @@ export default function Rollouts(props: RolloutsProps) {
               Return boolean values based on rules you define
             </p>
           </div>
-          {rollouts && rollouts.length > 0 && (
-            <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-              <Button
-                primary
-                type="button"
-                disabled={readOnly}
-                title={readOnly ? 'Not allowed in Read-Only mode' : undefined}
-                onClick={() => {
-                  setEditingRollout(null);
-                  setShowRolloutForm(true);
-                }}
-              >
-                <PlusIcon
-                  className="text-white -ml-1.5 mr-1 h-5 w-5"
-                  aria-hidden="true"
-                />
-                <span>New Rollout</span>
-              </Button>
-            </div>
-          )}
+          <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+            <Button
+              primary
+              type="button"
+              disabled={readOnly}
+              title={readOnly ? 'Not allowed in Read-Only mode' : undefined}
+              onClick={() => {
+                setEditingRollout(null);
+                setShowRolloutForm(true);
+              }}
+            >
+              <PlusIcon
+                className="text-white -ml-1.5 mr-1 h-5 w-5"
+                aria-hidden="true"
+              />
+              <span>New Rollout</span>
+            </Button>
+          </div>
         </div>
         <div className="mt-10">
           <div className="flex lg:space-x-5">
@@ -280,7 +278,7 @@ export default function Rollouts(props: RolloutsProps) {
                     <ul role="list" className="flex-col space-y-6 p-2 md:flex">
                       {rollouts.map((rollout) => (
                         <SortableRollout
-                          key={rollout.id}
+                          key={`${rollout.id}-${rollout.updatedAt}`}
                           flag={flag}
                           rollout={rollout}
                           segments={segments}
@@ -329,7 +327,7 @@ export default function Rollouts(props: RolloutsProps) {
                           enabled state.
                         </p>
                       </div>
-                      <div className="w-full flex-1">
+                      <div className="flex-1">
                         <div className="space-y-6 py-6 sm:space-y-0 sm:py-0">
                           <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:p-2">
                             <label

--- a/ui/src/app/flags/variants/Variants.tsx
+++ b/ui/src/app/flags/variants/Variants.tsx
@@ -58,7 +58,7 @@ export default function Variants(props: VariantsProps) {
           panelMessage={
             <>
               Are you sure you want to delete the variant{' '}
-              <span className="font-medium text-violet-500">
+              <span className="text-violet-500 font-medium">
                 {deletingVariant?.key}
               </span>
               ? This action cannot be undone.
@@ -80,10 +80,10 @@ export default function Variants(props: VariantsProps) {
       <div className="mt-10">
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">
-            <h1 className="text-lg font-medium leading-6 text-gray-900">
+            <h1 className="text-gray-900 text-lg font-medium leading-6">
               Variants
             </h1>
-            <p className="mt-1 text-sm text-gray-500">
+            <p className="text-gray-500 mt-1 text-sm">
               Return different values based on rules you define
             </p>
           </div>
@@ -100,7 +100,7 @@ export default function Variants(props: VariantsProps) {
                 }}
               >
                 <PlusIcon
-                  className="-ml-1.5 mr-1 h-5 w-5 text-white"
+                  className="text-white -ml-1.5 mr-1 h-5 w-5"
                   aria-hidden="true"
                 />
                 <span>New Variant</span>
@@ -115,19 +115,19 @@ export default function Variants(props: VariantsProps) {
                 <tr>
                   <th
                     scope="col"
-                    className="pb-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                    className="text-gray-900 pb-3.5 pl-4 pr-3 text-left text-sm font-semibold sm:pl-6"
                   >
                     Key
                   </th>
                   <th
                     scope="col"
-                    className="hidden px-3 pb-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell"
+                    className="text-gray-900 hidden px-3 pb-3.5 text-left text-sm font-semibold sm:table-cell"
                   >
                     Name
                   </th>
                   <th
                     scope="col"
-                    className="hidden px-3 pb-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell"
+                    className="text-gray-900 hidden px-3 pb-3.5 text-left text-sm font-semibold lg:table-cell"
                   >
                     Description
                   </th>
@@ -139,13 +139,13 @@ export default function Variants(props: VariantsProps) {
               <tbody className="divide-y divide-gray-200">
                 {flag.variants.map((variant) => (
                   <tr key={variant.key}>
-                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-600 sm:pl-6">
+                    <td className="text-gray-600 whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
                       {variant.key}
                     </td>
-                    <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 sm:table-cell">
+                    <td className="text-gray-500 hidden whitespace-nowrap px-3 py-4 text-sm sm:table-cell">
                       {variant.name}
                     </td>
-                    <td className="hidden truncate whitespace-nowrap px-3 py-4 text-sm text-gray-500 lg:table-cell">
+                    <td className="text-gray-500 hidden truncate whitespace-nowrap px-3 py-4 text-sm lg:table-cell">
                       {variant.description}
                     </td>
                     <td className="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
@@ -153,7 +153,7 @@ export default function Variants(props: VariantsProps) {
                         <>
                           <a
                             href="#"
-                            className="pr-2 text-violet-600 hover:text-violet-900"
+                            className="text-violet-600 pr-2 hover:text-violet-900"
                             onClick={(e) => {
                               e.preventDefault();
                               setEditingVariant(variant);
@@ -166,7 +166,7 @@ export default function Variants(props: VariantsProps) {
                           <span aria-hidden="true"> | </span>
                           <a
                             href="#"
-                            className="pl-2 text-violet-600 hover:text-violet-900"
+                            className="text-violet-600 pl-2 hover:text-violet-900"
                             onClick={(e) => {
                               e.preventDefault();
                               setDeletingVariant(variant);

--- a/ui/src/app/namespaces/Namespaces.tsx
+++ b/ui/src/app/namespaces/Namespaces.tsx
@@ -61,7 +61,7 @@ export default function Namespaces() {
           panelMessage={
             <>
               Are you sure you want to delete the namespace{' '}
-              <span className="font-medium text-violet-500">
+              <span className="text-violet-500 font-medium">
                 {deletingNamespace?.key}
               </span>
               ? This action cannot be undone.
@@ -80,8 +80,8 @@ export default function Namespaces() {
       <div className="my-10">
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">
-            <h1 className="text-xl font-semibold text-gray-700">Namespaces</h1>
-            <p className="mt-2 text-sm text-gray-500">
+            <h1 className="text-gray-700 text-xl font-semibold">Namespaces</h1>
+            <p className="text-gray-500 mt-2 text-sm">
               Namespaces allow you to group your flags, segments and rules under
               a single name
             </p>
@@ -97,7 +97,7 @@ export default function Namespaces() {
               }}
             >
               <PlusIcon
-                className="-ml-1.5 mr-1 h-5 w-5 text-white"
+                className="text-white -ml-1.5 mr-1 h-5 w-5"
                 aria-hidden="true"
               />
               <span>New Namespace</span>

--- a/ui/src/app/preferences/Preferences.tsx
+++ b/ui/src/app/preferences/Preferences.tsx
@@ -27,8 +27,8 @@ export default function Preferences() {
     <Formik initialValues={initialValues} onSubmit={() => {}}>
       <div className="my-10 divide-y divide-gray-200">
         <div className="space-y-1">
-          <h1 className="text-xl font-semibold text-gray-700">Preferences</h1>
-          <p className="mt-2 text-sm text-gray-500">
+          <h1 className="text-gray-700 text-xl font-semibold">Preferences</h1>
+          <p className="text-gray-500 mt-2 text-sm">
             Manage how information is displayed in the UI
           </p>
         </div>
@@ -37,7 +37,7 @@ export default function Preferences() {
             <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 sm:pt-5">
               <label
                 htmlFor="location"
-                className="text-sm font-medium text-gray-500"
+                className="text-gray-500 text-sm font-medium"
               >
                 Theme
               </label>
@@ -63,15 +63,15 @@ export default function Preferences() {
             >
               <Switch.Label
                 as="span"
-                className="text-sm font-medium text-gray-500"
+                className="text-gray-500 text-sm font-medium"
                 passive
               >
                 UTC Timezone
-                <p className="mt-2 text-sm text-gray-400">
+                <p className="text-gray-400 mt-2 text-sm">
                   Display dates and times in UTC timezone
                 </p>
               </Switch.Label>
-              <dd className="mt-1 flex text-sm text-gray-900 sm:col-span-2 sm:mt-0">
+              <dd className="text-gray-900 mt-1 flex text-sm sm:col-span-2 sm:mt-0">
                 <Switch
                   checked={timezone === Timezone.UTC}
                   onChange={() => {
@@ -85,7 +85,7 @@ export default function Preferences() {
                   }}
                   className={classNames(
                     timezone === Timezone.UTC ? 'bg-violet-400' : 'bg-gray-200',
-                    'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 transition-colors duration-200 ease-in-out border-transparent focus:outline-none sm:ml-auto'
+                    'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none sm:ml-auto'
                   )}
                 >
                   <span
@@ -94,7 +94,7 @@ export default function Preferences() {
                       timezone === Timezone.UTC
                         ? 'translate-x-5'
                         : 'translate-x-0',
-                      'inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out bg-white'
+                      'bg-white inline-block h-5 w-5 transform rounded-full shadow ring-0 transition duration-200 ease-in-out'
                     )}
                   />
                 </Switch>

--- a/ui/src/app/segments/NewSegment.tsx
+++ b/ui/src/app/segments/NewSegment.tsx
@@ -6,7 +6,7 @@ export default function NewSegment() {
     <>
       <div className="lg:flex lg:items-center lg:justify-between">
         <div className="min-w-0 flex-1">
-          <h2 className="text-2xl font-semibold leading-6 text-gray-900">
+          <h2 className="text-gray-900 text-2xl font-semibold leading-6">
             New Segment
           </h2>
         </div>
@@ -14,10 +14,10 @@ export default function NewSegment() {
       <div className="my-10">
         <div className="md:grid md:grid-cols-3 md:gap-6">
           <div className="md:col-span-1">
-            <h3 className="text-lg font-medium leading-6 text-gray-900">
+            <h3 className="text-gray-900 text-lg font-medium leading-6">
               Details
             </h3>
-            <p className="mt-2 text-sm text-gray-500">
+            <p className="text-gray-500 mt-2 text-sm">
               Basic information about the segment.
             </p>
             <MoreInfo

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -117,7 +117,7 @@ export default function Segment() {
           panelMessage={
             <>
               Are you sure you want to delete the constraint for{' '}
-              <span className="font-medium text-violet-500">
+              <span className="text-violet-500 font-medium">
                 {deletingConstraint?.property}
               </span>
               ? This action cannot be undone.
@@ -145,7 +145,7 @@ export default function Segment() {
           panelMessage={
             <>
               Are you sure you want to delete the segment{' '}
-              <span className="font-medium text-violet-500">{segment.key}</span>
+              <span className="text-violet-500 font-medium">{segment.key}</span>
               ? This action cannot be undone.
             </>
           }
@@ -164,7 +164,7 @@ export default function Segment() {
           panelMessage={
             <>
               Copy the segment{' '}
-              <span className="font-medium text-violet-500">{segment.key}</span>{' '}
+              <span className="text-violet-500 font-medium">{segment.key}</span>{' '}
               to the namespace:
             </>
           }
@@ -187,16 +187,16 @@ export default function Segment() {
       {/* segment header / delete button */}
       <div className="flex items-center justify-between">
         <div className="min-w-0 flex-1">
-          <h2 className="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl sm:tracking-tight">
+          <h2 className="text-gray-900 text-2xl font-bold leading-7 sm:truncate sm:text-3xl sm:tracking-tight">
             {segment.name}
           </h2>
           <div className="mt-1 flex flex-col sm:mt-0 sm:flex-row sm:flex-wrap sm:space-x-6">
             <div
               title={inTimezone(segment.createdAt)}
-              className="mt-2 flex items-center text-sm text-gray-500"
+              className="text-gray-500 mt-2 flex items-center text-sm"
             >
               <CalendarIcon
-                className="mr-1.5 h-5 w-5 flex-shrink-0 text-gray-400"
+                className="text-gray-400 mr-1.5 h-5 w-5 flex-shrink-0"
                 aria-hidden="true"
               />
               Created{' '}
@@ -236,10 +236,10 @@ export default function Segment() {
         <div className="my-10">
           <div className="md:grid md:grid-cols-3 md:gap-6">
             <div className="md:col-span-1">
-              <h3 className="text-lg font-medium leading-6 text-gray-900">
+              <h3 className="text-gray-900 text-lg font-medium leading-6">
                 Details
               </h3>
-              <p className="mt-1 text-sm text-gray-500">
+              <p className="text-gray-500 mt-1 text-sm">
                 Basic information about the segment
               </p>
               <MoreInfo
@@ -263,10 +263,10 @@ export default function Segment() {
           <div>
             <div className="sm:flex sm:items-center">
               <div className="sm:flex-auto">
-                <h1 className="text-lg font-medium leading-6 text-gray-900">
+                <h1 className="text-gray-900 text-lg font-medium leading-6">
                   Constraints
                 </h1>
-                <p className="mt-1 text-sm text-gray-500">
+                <p className="text-gray-500 mt-1 text-sm">
                   Determine if a request matches a segment
                 </p>
               </div>
@@ -296,31 +296,31 @@ export default function Segment() {
                     <tr>
                       <th
                         scope="col"
-                        className="pb-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+                        className="text-gray-900 pb-3.5 pl-4 pr-3 text-left text-sm font-semibold sm:pl-6"
                       >
                         Property
                       </th>
                       <th
                         scope="col"
-                        className="hidden px-3 pb-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell"
+                        className="text-gray-900 hidden px-3 pb-3.5 text-left text-sm font-semibold sm:table-cell"
                       >
                         Type
                       </th>
                       <th
                         scope="col"
-                        className="hidden px-3 pb-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell"
+                        className="text-gray-900 hidden px-3 pb-3.5 text-left text-sm font-semibold lg:table-cell"
                       >
                         Operator
                       </th>
                       <th
                         scope="col"
-                        className="hidden px-3 pb-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell"
+                        className="text-gray-900 hidden px-3 pb-3.5 text-left text-sm font-semibold lg:table-cell"
                       >
                         Value
                       </th>
                       <th
                         scope="col"
-                        className="hidden px-3 pb-3.5 text-left text-sm font-semibold text-gray-900 lg:table-cell"
+                        className="text-gray-900 hidden px-3 pb-3.5 text-left text-sm font-semibold lg:table-cell"
                       >
                         Description
                       </th>
@@ -335,22 +335,22 @@ export default function Segment() {
                   <tbody className="divide-y divide-gray-200">
                     {segment.constraints.map((constraint) => (
                       <tr key={constraint.id}>
-                        <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-600 sm:pl-6">
+                        <td className="text-gray-600 whitespace-nowrap py-4 pl-4 pr-3 text-sm sm:pl-6">
                           {constraint.property}
                         </td>
-                        <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 sm:table-cell">
+                        <td className="text-gray-500 hidden whitespace-nowrap px-3 py-4 text-sm sm:table-cell">
                           {constraintTypeToLabel(constraint.type)}
                         </td>
-                        <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 lg:table-cell">
+                        <td className="text-gray-500 hidden whitespace-nowrap px-3 py-4 text-sm lg:table-cell">
                           {ConstraintOperators[constraint.operator]}
                         </td>
-                        <td className="hidden whitespace-nowrap px-3 py-4 text-sm text-gray-500 lg:table-cell">
+                        <td className="text-gray-500 hidden whitespace-nowrap px-3 py-4 text-sm lg:table-cell">
                           {constraint.type === ConstraintType.DATETIME &&
                           constraint.value !== undefined
                             ? inTimezone(constraint.value)
                             : constraint.value}
                         </td>
-                        <td className="hidden truncate whitespace-nowrap px-3 py-4 text-sm text-gray-500 lg:table-cell">
+                        <td className="text-gray-500 hidden truncate whitespace-nowrap px-3 py-4 text-sm lg:table-cell">
                           {constraint.description}
                         </td>
                         <td className="whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
@@ -358,7 +358,7 @@ export default function Segment() {
                             <>
                               <a
                                 href="#"
-                                className="pr-2 text-violet-600 hover:text-violet-900"
+                                className="text-violet-600 pr-2 hover:text-violet-900"
                                 onClick={(e) => {
                                   e.preventDefault();
                                   setEditingConstraint(constraint);
@@ -373,7 +373,7 @@ export default function Segment() {
                               <span aria-hidden="true"> | </span>
                               <a
                                 href="#"
-                                className="pl-2 text-violet-600 hover:text-violet-900"
+                                className="text-violet-600 pl-2 hover:text-violet-900"
                                 onClick={(e) => {
                                   e.preventDefault();
                                   setDeletingConstraint(constraint);

--- a/ui/src/app/segments/Segments.tsx
+++ b/ui/src/app/segments/Segments.tsx
@@ -37,10 +37,10 @@ export default function Segments() {
     <>
       <div className="flex-row justify-between pb-5 sm:flex sm:items-center">
         <div className="flex flex-col">
-          <h1 className="text-2xl font-bold leading-7 text-gray-900 sm:truncate sm:text-3xl">
+          <h1 className="text-gray-900 text-2xl font-bold leading-7 sm:truncate sm:text-3xl">
             Segments
           </h1>
-          <p className="mt-2 text-sm text-gray-500">
+          <p className="text-gray-500 mt-2 text-sm">
             Segments enable request targeting based on defined criteria
           </p>
         </div>
@@ -52,7 +52,7 @@ export default function Segments() {
               title={readOnly ? 'Not allowed in Read-Only mode' : undefined}
             >
               <PlusIcon
-                className="-ml-1.5 mr-1 h-5 w-5 text-white"
+                className="text-white -ml-1.5 mr-1 h-5 w-5"
                 aria-hidden="true"
               />
               <span>New Segment</span>

--- a/ui/src/app/tokens/Tokens.tsx
+++ b/ui/src/app/tokens/Tokens.tsx
@@ -134,7 +134,7 @@ export default function Tokens() {
           panelMessage={
             <>
               Are you sure you want to delete the token{' '}
-              <span className="font-medium text-violet-500">
+              <span className="text-violet-500 font-medium">
                 {deletingToken?.name}
               </span>
               ? This action cannot be undone.
@@ -160,10 +160,10 @@ export default function Tokens() {
       <div className="my-10">
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">
-            <h1 className="text-xl font-semibold text-gray-700">
+            <h1 className="text-gray-700 text-xl font-semibold">
               Static Tokens
             </h1>
-            <p className="mt-2 text-sm text-gray-500">
+            <p className="text-gray-500 mt-2 text-sm">
               Static tokens are used to authenticate with the API
             </p>
           </div>
@@ -171,7 +171,7 @@ export default function Tokens() {
             <div className="mt-4">
               <Button primary onClick={() => setShowTokenForm(true)}>
                 <PlusIcon
-                  className="-ml-1.5 mr-1 h-5 w-5 text-white"
+                  className="text-white -ml-1.5 mr-1 h-5 w-5"
                   aria-hidden="true"
                 />
                 <span>New Token</span>
@@ -199,10 +199,10 @@ export default function Tokens() {
         ) : (
           <div className="mt-8 flex flex-col text-center">
             <Well>
-              <p className="text-sm text-gray-600">
+              <p className="text-gray-600 text-sm">
                 Token Authentication Disabled
               </p>
-              <p className="mt-4 text-sm text-gray-500">
+              <p className="text-gray-500 mt-4 text-sm">
                 See the configuration{' '}
                 <a
                   className="text-violet-500"

--- a/ui/src/components/EmptyState.tsx
+++ b/ui/src/components/EmptyState.tsx
@@ -25,24 +25,24 @@ export default function EmptyState(props: EmptyStateProps) {
     <button
       className={classNames(
         disabled ? 'hover:cursor-not-allowed' : 'hover: cursor-hand',
-        `${className} relative block h-full w-full rounded-lg border-2 border-dashed p-12 text-center border-gray-300 hover:border-gray-400 focus:outline-none`
+        `${className} border-gray-300 relative block h-full w-full rounded-lg border-2 border-dashed p-12 text-center hover:border-gray-400 focus:outline-none`
       )}
       disabled={!onClick || disabled}
       onClick={onClick}
     >
       {Icon && onClick && (
         <Icon
-          className="mx-auto h-12 w-12 text-violet-200"
+          className="text-violet-200 mx-auto h-12 w-12"
           aria-hidden="true"
         />
       )}
       {text && (
-        <span className="mt-2 block text-sm font-medium text-gray-900">
+        <span className="text-gray-900 mt-2 block text-sm font-medium">
           {text}
         </span>
       )}
       {secondaryText && (
-        <span className="mt-2 block text-sm text-gray-400">
+        <span className="text-gray-400 mt-2 block text-sm">
           {secondaryText}
         </span>
       )}

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -55,10 +55,10 @@ export default function Footer() {
   ];
 
   return (
-    <footer className="body-font sticky top-[100vh] text-gray-700">
+    <footer className="body-font text-gray-700 sticky top-[100vh]">
       <div className="container mx-auto mt-4 flex flex-col items-center px-8 py-4 sm:flex-row">
         <div className="container mx-auto flex flex-col items-center space-x-2 sm:flex-row">
-          <p className="mt-4 text-xs text-gray-500 sm:mt-0">
+          <p className="text-gray-500 mt-4 text-xs sm:mt-0">
             <span className="hidden sm:inline">
               {ref() && (
                 <>
@@ -74,7 +74,7 @@ export default function Footer() {
               reserved.
             </span>
           </p>
-          <p className="mt-4 text-xs text-gray-500 sm:mt-0">
+          <p className="text-gray-500 mt-4 text-xs sm:mt-0">
             <span className="hidden sm:inline">
               <a
                 target="_blank"

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -18,10 +18,10 @@ export default function Header(props: HeaderProps) {
   const { session } = useSession();
 
   return (
-    <div className="sticky top-0 z-10 flex h-16 flex-shrink-0 bg-violet-400">
+    <div className="bg-violet-400 sticky top-0 z-10 flex h-16 flex-shrink-0">
       <button
         type="button"
-        className="without-ring px-4 text-white md:hidden"
+        className="without-ring text-white px-4 md:hidden"
         onClick={() => setSidebarOpen(true)}
       >
         <span className="sr-only">Open sidebar</span>
@@ -33,7 +33,7 @@ export default function Header(props: HeaderProps) {
         <div className="ml-4 flex items-center space-x-1.5 md:ml-6">
           {/* read-only mode */}
           {readOnly && (
-            <span className="nightwind-prevent inline-flex items-center gap-x-1.5 rounded-full px-3 py-1 text-xs font-medium text-violet-950 bg-violet-200">
+            <span className="nightwind-prevent bg-violet-200 inline-flex items-center gap-x-1.5 rounded-full px-3 py-1 text-xs font-medium text-violet-950">
               <svg
                 className="h-1.5 w-1.5 fill-orange-400"
                 viewBox="0 0 6 6"

--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -22,7 +22,7 @@ export default function Modal(props: ModalProps) {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-opacity-75 transition-opacity bg-gray-500" />
+          <div className="bg-gray-500 fixed inset-0 bg-opacity-75 transition-opacity" />
         </Transition.Child>
 
         <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -36,7 +36,7 @@ export default function Modal(props: ModalProps) {
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform rounded-lg px-4 pb-4 pt-5 text-left shadow-xl transition-all bg-white sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="bg-white relative transform rounded-lg px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 {props.children}
               </Dialog.Panel>
             </Transition.Child>

--- a/ui/src/components/MoreInfo.tsx
+++ b/ui/src/components/MoreInfo.tsx
@@ -15,10 +15,10 @@ export default function MoreInfo(props: MoreInfoProps) {
         href={href}
         target="_blank"
         rel="noreferrer"
-        className="group inline-flex items-center text-gray-500 hover:text-gray-600"
+        className="group text-gray-500 inline-flex items-center hover:text-gray-600"
       >
         <QuestionMarkCircleIcon
-          className="-ml-1 h-4 w-4 text-gray-300 group-hover:text-gray-400"
+          className="text-gray-300 -ml-1 h-4 w-4 group-hover:text-gray-400"
           aria-hidden="true"
         />
         <span className="ml-1">{children}</span>

--- a/ui/src/components/Nav.tsx
+++ b/ui/src/components/Nav.tsx
@@ -32,7 +32,7 @@ function NavItem(props: NavItemProps) {
       href={to}
       target="_blank"
       rel="noreferrer"
-      className="group flex items-center rounded-md px-2 py-2 text-sm font-medium text-white hover:bg-violet-400 md:text-gray-600 md:hover:bg-gray-50"
+      className="group text-white flex items-center rounded-md px-2 py-2 text-sm font-medium hover:bg-violet-400 md:text-gray-600 md:hover:bg-gray-50"
     >
       <Icon
         className="text-wite mr-3 h-6 w-6 flex-shrink-0 hover:bg-gray-50 md:text-gray-500"

--- a/ui/src/components/Pagination.tsx
+++ b/ui/src/components/Pagination.tsx
@@ -16,7 +16,7 @@ function Page(props: PageProps) {
   // we are using '...' (string) to represent page links that should not be rendered
   if (typeof page === 'string') {
     return (
-      <span className="border-t-2 px-4 pt-4 text-sm font-medium border-transparent text-gray-700">
+      <span className="text-gray-700 border-t-2 border-transparent px-4 pt-4 text-sm font-medium">
         &#8230; {/* ellipsis */}
       </span>
     );
@@ -28,7 +28,7 @@ function Page(props: PageProps) {
       className={classNames(
         page === currentPage
           ? 'text-violet-600 border-violet-500'
-          : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+          : 'text-gray-500 border-transparent hover:text-gray-700 hover:border-gray-300',
         'inline-flex items-center border-t-2 px-4 pt-4 text-sm font-medium'
       )}
       aria-current={page === currentPage ? 'page' : undefined}
@@ -78,20 +78,20 @@ export default function Pagination(props: PaginationProps) {
 
   return (
     <nav
-      className={`${className} flex items-center justify-between border-t px-4 border-gray-200 sm:px-0`}
+      className={`${className} border-gray-200 flex items-center justify-between border-t px-4 sm:px-0`}
     >
       <div className="flex w-0 flex-1">
         {currentPage > 1 && (
           <a
             href="#"
-            className="inline-flex items-center border-t-2 pr-1 pt-4 text-sm font-medium border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            className="text-gray-500 inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium hover:text-gray-700 hover:border-gray-300"
             onClick={(e) => {
               e.preventDefault();
               onPreviousPage();
             }}
           >
             <ArrowLongLeftIcon
-              className="mr-3 h-5 w-5 text-gray-400"
+              className="text-gray-400 mr-3 h-5 w-5"
               aria-hidden="true"
             />
             Previous
@@ -112,7 +112,7 @@ export default function Pagination(props: PaginationProps) {
         {currentPage < lastPage && (
           <a
             href="#"
-            className="inline-flex items-center border-t-2 pl-1 pt-4 text-sm font-medium border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300"
+            className="text-gray-500 inline-flex items-center border-t-2 border-transparent pl-1 pt-4 text-sm font-medium hover:text-gray-700 hover:border-gray-300"
             onClick={(e) => {
               e.preventDefault();
               onNextPage();
@@ -120,7 +120,7 @@ export default function Pagination(props: PaginationProps) {
           >
             Next
             <ArrowLongRightIcon
-              className="ml-3 h-5 w-5 text-gray-400"
+              className="text-gray-400 ml-3 h-5 w-5"
               aria-hidden="true"
             />
           </a>

--- a/ui/src/components/Searchbox.tsx
+++ b/ui/src/components/Searchbox.tsx
@@ -40,14 +40,14 @@ export default function Searchbox(props: SearchboxProps) {
         <div className="relative">
           <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
             <MagnifyingGlassIcon
-              className="h-5 w-5 text-gray-400"
+              className="text-gray-400 h-5 w-5"
               aria-hidden="true"
             />
           </div>
           <input
             id="search"
             name="search"
-            className="block w-full rounded-md border py-2 pl-10 pr-3 leading-5 placeholder-gray-500 shadow-sm bg-white border-gray-300 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-violet-400 focus:border-violet-400 sm:text-sm"
+            className="bg-white border-gray-300 block w-full rounded-md border py-2 pl-10 pr-3 leading-5 placeholder-gray-500 shadow-sm focus:border-violet-400 focus:placeholder-gray-400 focus:outline-none focus:ring-1 focus:ring-violet-400 sm:text-sm"
             placeholder="Search"
             type="search"
             value={value}

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ export default function Sidebar(props: SidebarProps) {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="fixed inset-0 bg-opacity-75 bg-gray-300" />
+            <div className="bg-gray-300 fixed inset-0 bg-opacity-75" />
           </Transition.Child>
 
           <div className="fixed inset-0 z-40 flex">
@@ -43,7 +43,7 @@ export default function Sidebar(props: SidebarProps) {
               leaveFrom="translate-x-0"
               leaveTo="-translate-x-full"
             >
-              <Dialog.Panel className="relative flex w-full max-w-xs flex-1 flex-col pb-4 pt-5 bg-violet-300">
+              <Dialog.Panel className="bg-violet-300 relative flex w-full max-w-xs flex-1 flex-col pb-4 pt-5">
                 <Transition.Child
                   as={Fragment}
                   enter="ease-in-out duration-300"
@@ -61,7 +61,7 @@ export default function Sidebar(props: SidebarProps) {
                     >
                       <span className="sr-only">Close sidebar</span>
                       <XMarkIcon
-                        className="h-6 w-6 text-white"
+                        className="text-white h-6 w-6"
                         aria-hidden="true"
                       />
                     </button>
@@ -93,8 +93,8 @@ export default function Sidebar(props: SidebarProps) {
 
       {/* Static sidebar for desktop */}
       <div className="hidden md:fixed md:inset-y-0 md:flex md:w-64 md:flex-col">
-        <div className="flex min-h-0 flex-1 flex-col bg-gray-200">
-          <div className="relative flex h-16 flex-shrink-0 items-center px-4 pt-2 bg-violet-400">
+        <div className="bg-gray-200 flex min-h-0 flex-1 flex-col">
+          <div className="bg-violet-400 relative flex h-16 flex-shrink-0 items-center px-4 pt-2">
             <Link to="/">
               <img
                 src={logoLight}

--- a/ui/src/components/TabBar.tsx
+++ b/ui/src/components/TabBar.tsx
@@ -16,13 +16,13 @@ export default function TabBar(props: TabBarProps) {
 
   return (
     <div className="mt-3 flex flex-row sm:mt-5">
-      <div className="border-b-2 border-gray-200">
+      <div className="border-gray-200 border-b-2">
         <nav className="-mb-px flex space-x-8">
           {tabs.map((tab) =>
             tab.disabled ? (
               <a
                 key={tab.name}
-                className="cursor-not-allowed whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium text-gray-500"
+                className="text-gray-500 cursor-not-allowed whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium"
               >
                 {tab.name}
               </a>
@@ -35,7 +35,7 @@ export default function TabBar(props: TabBarProps) {
                   classNames(
                     isActive
                       ? 'text-violet-600 border-violet-500'
-                      : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300',
+                      : 'text-gray-500 border-transparent hover:text-gray-700 hover:border-gray-300',
                     'whitespace-nowrap border-b-2 px-1 py-3 text-sm font-medium'
                   )
                 }

--- a/ui/src/components/Well.tsx
+++ b/ui/src/components/Well.tsx
@@ -7,7 +7,7 @@ export default function Well(props: WellProps) {
   const { children, className } = props;
 
   return (
-    <div className={`overflow-hidden rounded-lg bg-gray-50 ${className}`}>
+    <div className={`bg-gray-50 overflow-hidden rounded-lg ${className}`}>
       <div className="px-4 py-5 sm:p-8">{children}</div>
     </div>
   );

--- a/ui/src/components/flags/FlagForm.tsx
+++ b/ui/src/components/flags/FlagForm.tsx
@@ -110,7 +110,7 @@ export default function FlagForm(props: FlagFormProps) {
                 <div className="col-span-2">
                   <label
                     htmlFor="name"
-                    className="block text-sm font-medium text-gray-700"
+                    className="text-gray-700 block text-sm font-medium"
                   >
                     Name
                   </label>
@@ -139,7 +139,7 @@ export default function FlagForm(props: FlagFormProps) {
                 <div className="col-span-2">
                   <label
                     htmlFor="key"
-                    className="block text-sm font-medium text-gray-700"
+                    className="text-gray-700 block text-sm font-medium"
                   >
                     Key
                   </label>
@@ -157,7 +157,7 @@ export default function FlagForm(props: FlagFormProps) {
                 <div className="col-span-3">
                   <label
                     htmlFor="type"
-                    className="block text-sm font-medium text-gray-700"
+                    className="text-gray-700 block text-sm font-medium"
                   >
                     Type
                   </label>
@@ -175,7 +175,7 @@ export default function FlagForm(props: FlagFormProps) {
                               name="type"
                               type="radio"
                               disabled={!isNew}
-                              className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                              className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
                               onChange={() => {
                                 formik.setFieldValue('type', type.id);
                               }}
@@ -186,7 +186,7 @@ export default function FlagForm(props: FlagFormProps) {
                           <div className="ml-3 text-sm">
                             <label
                               htmlFor={type.id}
-                              className="font-medium text-gray-700"
+                              className="text-gray-700 font-medium"
                             >
                               {type.name}
                             </label>
@@ -200,12 +200,12 @@ export default function FlagForm(props: FlagFormProps) {
                   <div className="flex justify-between">
                     <label
                       htmlFor="description"
-                      className="block text-sm font-medium text-gray-700"
+                      className="text-gray-700 block text-sm font-medium"
                     >
                       Description
                     </label>
                     <span
-                      className="text-xs text-gray-500"
+                      className="text-gray-500 text-xs"
                       id="description-optional"
                     >
                       Optional

--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -163,7 +163,7 @@ export default function FlagTable(props: FlagTableProps) {
                   <th
                     key={header.id}
                     scope="col"
-                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    className="text-gray-900 px-3 py-3.5 text-left text-sm font-semibold"
                   >
                     <div
                       className="group inline-flex cursor-pointer"
@@ -175,7 +175,7 @@ export default function FlagTable(props: FlagTableProps) {
                             header.column.columnDef.header,
                             header.getContext()
                           )}
-                      <span className="ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible">
+                      <span className="text-gray-400 ml-2 flex-none rounded group-hover:visible group-focus:visible">
                         {{
                           asc: (
                             <ChevronUpIcon
@@ -197,7 +197,7 @@ export default function FlagTable(props: FlagTableProps) {
                   <th
                     key={header.id}
                     scope="col"
-                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    className="text-gray-900 px-3 py-3.5 text-left text-sm font-semibold"
                   >
                     {header.isPlaceholder
                       ? null

--- a/ui/src/components/flags/VariantForm.tsx
+++ b/ui/src/components/flags/VariantForm.tsx
@@ -73,12 +73,12 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
       })}
     >
       {(formik) => (
-        <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+        <Form className="bg-white flex h-full flex-col overflow-y-scroll shadow-xl">
           <div className="flex-1">
-            <div className="px-4 py-6 bg-gray-50 sm:px-6">
+            <div className="bg-gray-50 px-4 py-6 sm:px-6">
               <div className="flex items-start justify-between space-x-3">
                 <div className="space-y-1">
-                  <Dialog.Title className="text-lg font-medium text-gray-900">
+                  <Dialog.Title className="text-gray-900 text-lg font-medium">
                     {title}
                   </Dialog.Title>
                   <MoreInfo href="https://www.flipt.io/docs/concepts#variants">
@@ -102,7 +102,7 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="key"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Key
                   </label>
@@ -115,11 +115,11 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="name"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Name
                   </label>
-                  <span className="text-xs text-gray-400" id="name-optional">
+                  <span className="text-gray-400 text-xs" id="name-optional">
                     Optional
                   </span>
                 </div>
@@ -131,12 +131,12 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="description"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Description
                   </label>
                   <span
-                    className="text-xs text-gray-400"
+                    className="text-gray-400 text-xs"
                     id="description-optional"
                   >
                     Optional
@@ -150,12 +150,12 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="attachment"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Attachment
                   </label>
                   <span
-                    className="text-xs text-gray-400"
+                    className="text-gray-400 text-xs"
                     id="attachment-optional"
                   >
                     Optional
@@ -167,7 +167,7 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
               </div>
             </div>
           </div>
-          <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+          <div className="border-gray-200 flex-shrink-0 border-t px-4 py-5 sm:px-6">
             <div className="flex justify-end space-x-3">
               <Button onClick={() => setOpen(false)}>Cancel</Button>
               <Button

--- a/ui/src/components/forms/Combobox.tsx
+++ b/ui/src/components/forms/Combobox.tsx
@@ -51,7 +51,7 @@ export default function Combobox<T extends IFilterable>(
       <div className="relative flex w-full flex-row">
         <C.Input
           id={id}
-          className="w-full rounded-md border py-2 pl-3 pr-10 shadow-sm bg-gray-50 border-gray-300 focus:outline-none focus:ring-1 focus:ring-violet-500 focus:border-violet-500 sm:text-sm"
+          className="bg-gray-50 border-gray-300 w-full rounded-md border py-2 pl-3 pr-10 shadow-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500 sm:text-sm"
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             setQuery(e.target.value);
           }}
@@ -63,13 +63,13 @@ export default function Combobox<T extends IFilterable>(
           id={`${id}-select-button`}
         >
           <ChevronUpDownIcon
-            className="h-5 w-5 text-gray-400"
+            className="text-gray-400 h-5 w-5"
             aria-hidden="true"
           />
         </C.Button>
       </div>
       <C.Options
-        className="z-10 mt-1 flex max-h-60 w-full flex-col overflow-auto rounded-md py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 bg-white focus:outline-none sm:text-sm"
+        className="bg-white z-10 mt-1 flex max-h-60 w-full flex-col overflow-auto rounded-md py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
         id={`${id}-select-options`}
       >
         {filteredValues &&
@@ -79,7 +79,7 @@ export default function Combobox<T extends IFilterable>(
               value={v}
               className={({ active }) =>
                 classNames(
-                  'relative w-full cursor-default select-none py-2 pl-3 pr-9 text-gray-900',
+                  'text-gray-900 relative w-full cursor-default select-none py-2 pl-3 pr-9',
                   active ? 'bg-violet-100' : ''
                 )
               }
@@ -104,7 +104,7 @@ export default function Combobox<T extends IFilterable>(
                     >
                       {v?.filterValue}
                     </span>
-                    <span className="ml-2 truncate text-gray-500">
+                    <span className="text-gray-500 ml-2 truncate">
                       {v?.displayValue}
                     </span>
                   </div>
@@ -124,7 +124,7 @@ export default function Combobox<T extends IFilterable>(
             </C.Option>
           ))}
         {!filteredValues?.length && (
-          <div className="w-full py-2 text-center text-gray-500">
+          <div className="text-gray-500 w-full py-2 text-center">
             No results found
           </div>
         )}

--- a/ui/src/components/forms/Dropdown.tsx
+++ b/ui/src/components/forms/Dropdown.tsx
@@ -26,10 +26,10 @@ export default function Dropdown(props: DropdownProps) {
   return (
     <Menu as="div" className="relative inline-block text-left">
       <div>
-        <Menu.Button className="inline-flex w-full justify-center gap-x-1.5 rounded-md px-3 py-2 text-sm font-semibold shadow-sm ring-2 ring-inset ring-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-violet-300">
+        <Menu.Button className="bg-white text-gray-700 inline-flex w-full justify-center gap-x-1.5 rounded-md px-3 py-2 text-sm font-semibold shadow-sm ring-2 ring-inset ring-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-violet-300">
           {label}
           <ChevronDownIcon
-            className="-mr-1 h-5 w-5 text-gray-400"
+            className="text-gray-400 -mr-1 h-5 w-5"
             aria-hidden="true"
           />
         </Menu.Button>
@@ -44,7 +44,7 @@ export default function Dropdown(props: DropdownProps) {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 bg-white focus:outline-none">
+        <Menu.Items className="bg-white absolute right-0 mt-2 w-56 origin-top-right divide-y divide-gray-100 rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
           {actions.map((action) => (
             <div className="py-1" key={action.id}>
               {!action.disabled && (
@@ -66,7 +66,7 @@ export default function Dropdown(props: DropdownProps) {
                     >
                       {action.icon && (
                         <action.icon
-                          className="mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500"
+                          className="text-gray-400 mr-3 h-5 w-5 group-hover:text-gray-500"
                           aria-hidden="true"
                         />
                       )}
@@ -89,7 +89,7 @@ export default function Dropdown(props: DropdownProps) {
                     >
                       {action.icon && (
                         <action.icon
-                          className="mr-3 h-5 w-5 text-gray-300 group-hover:text-gray-400"
+                          className="text-gray-300 mr-3 h-5 w-5 group-hover:text-gray-400"
                           aria-hidden="true"
                         />
                       )}

--- a/ui/src/components/forms/Input.tsx
+++ b/ui/src/components/forms/Input.tsx
@@ -31,7 +31,7 @@ export default function Input(props: InputProps) {
         ref={forwardRef}
         className={classNames(
           hasError ? 'border-red-400' : 'border-gray-300',
-          `${className} block w-full rounded-md shadow-sm text-gray-900 bg-gray-50 focus:ring-violet-300 focus:border-violet-300 disabled:cursor-not-allowed disabled:text-gray-500 disabled:bg-gray-100 disabled:border-gray-200 sm:text-sm`
+          `${className} text-gray-900 bg-gray-50 block w-full rounded-md shadow-sm focus:border-violet-300 disabled:text-gray-500 disabled:bg-gray-100 disabled:border-gray-200 focus:ring-violet-300 disabled:cursor-not-allowed sm:text-sm`
         )}
         id={id}
         type={type}
@@ -44,7 +44,7 @@ export default function Input(props: InputProps) {
         {...rest}
       />
       {meta.touched && meta.error ? (
-        <div className="mt-1 text-sm text-red-500">{meta.error}</div>
+        <div className="text-red-500 mt-1 text-sm">{meta.error}</div>
       ) : null}
     </>
   );

--- a/ui/src/components/forms/Listbox.tsx
+++ b/ui/src/components/forms/Listbox.tsx
@@ -37,19 +37,19 @@ export default function Listbox<T extends ISelectable>(props: ListBoxProps<T>) {
               className={classNames(
                 disabled
                   ? 'bg-gray-100'
-                  : 'shadow-sm ring-1 ring-inset ring-gray-300 bg-gray-50 focus:ring-1 focus:ring-violet-600',
-                'relative w-full cursor-default rounded-md px-2 py-2 pl-3 pr-10 text-left text-gray-900 focus:outline-none sm:text-sm sm:leading-6'
+                  : 'bg-gray-50 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-1 focus:ring-violet-600',
+                'text-gray-900 relative w-full cursor-default rounded-md px-2 py-2 pl-3 pr-10 text-left focus:outline-none sm:text-sm sm:leading-6'
               )}
               id={`${id}-select-button`}
             >
               <div className="flex items-center">
-                <span className="block truncate font-medium text-gray-600">
+                <span className="text-gray-600 block truncate font-medium">
                   {selected?.displayValue}
                 </span>
                 {!disabled && (
                   <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
                     <ChevronUpDownIcon
-                      className="h-5 w-5 text-gray-400"
+                      className="text-gray-400 h-5 w-5"
                       aria-hidden="true"
                     />
                   </span>
@@ -65,7 +65,7 @@ export default function Listbox<T extends ISelectable>(props: ListBoxProps<T>) {
               leaveTo="opacity-0"
             >
               <L.Options
-                className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 bg-gray-50 focus:outline-none sm:text-sm"
+                className="bg-gray-50 absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm"
                 id={`${id}-select-options`}
               >
                 {values?.map((v) => (

--- a/ui/src/components/forms/Select.tsx
+++ b/ui/src/components/forms/Select.tsx
@@ -23,7 +23,7 @@ export default function Select(props: SelectProps) {
       {...field}
       id={id}
       name={name}
-      className={`block rounded-md py-2 pl-3 pr-10 text-base text-gray-900 bg-gray-50 border-gray-300 focus:outline-none focus:ring-violet-300 focus:border-violet-300 sm:text-sm ${className}`}
+      className={`text-gray-900 bg-gray-50 border-gray-300 block rounded-md py-2 pl-3 pr-10 text-base focus:border-violet-300 focus:outline-none focus:ring-violet-300 sm:text-sm ${className}`}
       value={value}
       onChange={onChange || field.onChange}
     >

--- a/ui/src/components/forms/TextArea.tsx
+++ b/ui/src/components/forms/TextArea.tsx
@@ -22,14 +22,14 @@ export default function TextArea(props: TextAreaProps) {
         rows={rows}
         className={classNames(
           hasError ? 'border-red-400' : 'border-gray-300',
-          `${className} block w-full rounded-md shadow-sm text-gray-900 bg-gray-50 focus:ring-violet-500 focus:border-violet-500 sm:text-sm`
+          `${className} text-gray-900 bg-gray-50 block w-full rounded-md shadow-sm focus:border-violet-500 focus:ring-violet-500 sm:text-sm`
         )}
         placeholder={placeholder}
         autoComplete={autocomplete ? 'on' : 'off'}
         {...field}
       />
       {meta.touched && meta.error ? (
-        <div className="mt-1 text-sm text-red-500">{meta.error}</div>
+        <div className="text-red-500 mt-1 text-sm">{meta.error}</div>
       ) : null}
     </>
   );

--- a/ui/src/components/forms/Toggle.tsx
+++ b/ui/src/components/forms/Toggle.tsx
@@ -21,13 +21,13 @@ export default function Toggle(props: ToggleProps) {
       <span className="flex flex-grow flex-col">
         <Switch.Label
           as="span"
-          className="text-sm font-medium text-gray-900"
+          className="text-gray-900 text-sm font-medium"
           passive
         >
           {label}
         </Switch.Label>
         {description && (
-          <Switch.Description as="span" className="text-sm text-gray-500">
+          <Switch.Description as="span" className="text-gray-500 text-sm">
             {description}
           </Switch.Description>
         )}
@@ -50,7 +50,7 @@ export default function Toggle(props: ToggleProps) {
         <span
           className={classNames(
             checked ? 'translate-x-6' : 'translate-x-1',
-            'inline-block h-4 w-4 transform rounded-full ring-0 transition bg-white'
+            'bg-white inline-block h-4 w-4 transform rounded-full ring-0 transition'
           )}
         />
       </Switch>

--- a/ui/src/components/forms/buttons/Button.tsx
+++ b/ui/src/components/forms/buttons/Button.tsx
@@ -29,7 +29,7 @@ export default function Button(props: ButtonProps) {
       }}
       className={classNames(
         primary
-          ? 'border-transparent text-white bg-violet-300 enabled:bg-violet-400 enabled:hover:bg-violet-600 enabled:focus:ring-violet-500'
+          ? 'text-white bg-violet-300 border-transparent enabled:bg-violet-400 enabled:hover:bg-violet-600 enabled:focus:ring-violet-500'
           : 'bg-white text-gray-500 border-violet-300 enabled:hover:bg-gray-50 enabled:focus:ring-gray-500',
         disabled ? 'cursor-not-allowed' : 'cursor-hand',
         `mb-1 inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium shadow-sm focus:outline-none focus:ring-1 focus:ring-offset-1 ${className}`

--- a/ui/src/components/forms/buttons/DeleteButton.tsx
+++ b/ui/src/components/forms/buttons/DeleteButton.tsx
@@ -13,7 +13,7 @@ export function DeleteButton(props: DeleteButtonProps) {
       type="button"
       className={classNames(
         disabled ? 'cursor-not-allowed' : 'cursor-hand',
-        'mb-1 mt-5 inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium text-red-400 border-red-200 focus:outline-none enabled:hover:bg-red-50 sm:mt-0'
+        'text-red-400 border-red-200 mb-1 mt-5 inline-flex items-center justify-center rounded-md border px-4 py-2 text-sm font-medium enabled:hover:bg-red-50 focus:outline-none sm:mt-0'
       )}
       onClick={() => {
         !disabled && onClick && onClick();

--- a/ui/src/components/forms/buttons/TextButton.tsx
+++ b/ui/src/components/forms/buttons/TextButton.tsx
@@ -27,9 +27,9 @@ export default function TextButton(props: ButtonProps) {
       }}
       className={classNames(
         disabled ? 'cursor-not-allowed' : 'cursor-hand',
-        `mb-1 inline-flex items-center justify-center rounded-md border-0 text-sm font-medium text-gray-300 
-        focus:outline-none
-        enabled:text-gray-500 enabled:hover:text-gray-600 ${className}`
+        `text-gray-300 mb-1 inline-flex items-center justify-center rounded-md border-0 text-sm font-medium 
+        enabled:text-gray-500
+        enabled:hover:text-gray-600 focus:outline-none ${className}`
       )}
       disabled={disabled}
       title={title}

--- a/ui/src/components/header/Notifications.tsx
+++ b/ui/src/components/header/Notifications.tsx
@@ -35,20 +35,20 @@ export function Notification(props: NotificationProps) {
             leaveFrom="opacity-100"
             leaveTo="opacity-0"
           >
-            <div className="pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 bg-white">
+            <div className="bg-white pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
               <div className="p-4">
                 <div className="flex items-start">
                   <div className="flex-shrink-0">
                     <MegaphoneIcon
-                      className="h-6 w-6 text-gray-400"
+                      className="text-gray-400 h-6 w-6"
                       aria-hidden="true"
                     />
                   </div>
                   <div className="ml-3 w-0 flex-1 pt-0.5">
-                    <p className="text-sm font-medium text-gray-900">
+                    <p className="text-gray-900 text-sm font-medium">
                       Update Available
                     </p>
-                    <p className="mt-1 text-sm text-gray-500">
+                    <p className="text-gray-500 mt-1 text-sm">
                       A new version of Flipt is available!
                     </p>
                     <div className="mt-3 flex space-x-7 hover:cursor-pointer">
@@ -56,12 +56,12 @@ export function Notification(props: NotificationProps) {
                         href={info.latestVersionURL}
                         target="_blank"
                         rel="noreferrer"
-                        className="rounded-md text-sm font-medium bg-white text-violet-600 hover:text-violet-500 focus:outline-none"
+                        className="bg-white text-violet-600 rounded-md text-sm font-medium hover:text-violet-500 focus:outline-none"
                       >
                         Check It Out
                       </a>
                       <a
-                        className="rounded-md text-sm font-medium bg-white text-gray-700 hover:text-gray-500 focus:outline-none"
+                        className="bg-white text-gray-700 rounded-md text-sm font-medium hover:text-gray-500 focus:outline-none"
                         onClick={(e) => {
                           e.preventDefault();
                           setShow(false);
@@ -75,7 +75,7 @@ export function Notification(props: NotificationProps) {
                   <div className="ml-4 flex flex-shrink-0">
                     <button
                       type="button"
-                      className="inline-flex rounded-md bg-white text-gray-400 hover:text-gray-500 focus:outline-none"
+                      className="bg-white text-gray-400 inline-flex rounded-md hover:text-gray-500 focus:outline-none"
                       onClick={() => {
                         setShow(false);
                         markSeen();
@@ -119,12 +119,12 @@ export default function Notifications(props: NotificationsProps) {
 
       <button
         type="button"
-        className="without-ring relative rounded-full text-violet-100"
+        className="without-ring text-violet-100 relative rounded-full"
       >
         {newNotifications && (
           <span className="absolute right-0 top-0 flex h-2 w-2">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 bg-white"></span>
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-violet-100"></span>
+            <span className="bg-white absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"></span>
+            <span className="bg-violet-100 relative inline-flex h-2 w-2 rounded-full"></span>
           </span>
         )}
         <span className="sr-only">View notifications</span>

--- a/ui/src/components/header/UserProfile.tsx
+++ b/ui/src/components/header/UserProfile.tsx
@@ -31,7 +31,7 @@ export default function UserProfile(props: UserProfileProps) {
   return (
     <Menu as="div" className="relative ml-3">
       <div>
-        <Menu.Button className="nightwind-prevent flex max-w-xs items-center rounded-full text-sm bg-white hover:ring-2 hover:ring-white/80 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2">
+        <Menu.Button className="nightwind-prevent bg-white flex max-w-xs items-center rounded-full text-sm hover:ring-2 hover:ring-white/80 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-offset-2">
           <span className="sr-only">Open user menu</span>
           {imgURL && (
             <img
@@ -44,7 +44,7 @@ export default function UserProfile(props: UserProfileProps) {
           )}
           {!imgURL && (
             <UserCircleIcon
-              className="h-8 w-8 rounded-full text-violet-300"
+              className="text-violet-300 h-8 w-8 rounded-full"
               aria-hidden="true"
             />
           )}
@@ -59,7 +59,7 @@ export default function UserProfile(props: UserProfileProps) {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md py-1 shadow-lg ring-1 ring-black ring-opacity-5 bg-white focus:outline-none">
+        <Menu.Items className="bg-white absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
           <Menu.Item key="logout">
             {({ active }) => (
               <a
@@ -70,7 +70,7 @@ export default function UserProfile(props: UserProfileProps) {
                 }}
                 className={classNames(
                   active ? 'bg-gray-100' : '',
-                  'block px-4 py-2 text-sm text-gray-700'
+                  'text-gray-700 block px-4 py-2 text-sm'
                 )}
               >
                 Logout

--- a/ui/src/components/namespaces/NamespaceForm.tsx
+++ b/ui/src/components/namespaces/NamespaceForm.tsx
@@ -75,12 +75,12 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
       })}
     >
       {(formik) => (
-        <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+        <Form className="bg-white flex h-full flex-col overflow-y-scroll shadow-xl">
           <div className="flex-1">
-            <div className="px-4 py-6 bg-gray-50 sm:px-6">
+            <div className="bg-gray-50 px-4 py-6 sm:px-6">
               <div className="flex items-start justify-between space-x-3">
                 <div className="space-y-1">
-                  <Dialog.Title className="text-lg font-medium text-gray-900">
+                  <Dialog.Title className="text-gray-900 text-lg font-medium">
                     {title}
                   </Dialog.Title>
                   <MoreInfo href="https://www.flipt.io/docs/concepts#namespaces">
@@ -104,7 +104,7 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="name"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Name
                   </label>
@@ -137,7 +137,7 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="key"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Key
                   </label>
@@ -158,12 +158,12 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="description"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Description
                   </label>
                   <span
-                    className="text-xs text-gray-400"
+                    className="text-gray-400 text-xs"
                     id="description-optional"
                   >
                     Optional
@@ -175,7 +175,7 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
               </div>
             </div>
           </div>
-          <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+          <div className="border-gray-200 flex-shrink-0 border-t px-4 py-5 sm:px-6">
             <div className="flex justify-end space-x-3">
               <Button onClick={() => setOpen(false)}>Cancel</Button>
               <Button

--- a/ui/src/components/namespaces/NamespaceTable.tsx
+++ b/ui/src/components/namespaces/NamespaceTable.tsx
@@ -212,7 +212,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
                         <th
                           key={header.id}
                           scope="col"
-                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                          className="text-gray-900 px-3 py-3.5 text-left text-sm font-semibold"
                         >
                           <div
                             className="group inline-flex cursor-pointer"
@@ -224,7 +224,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
                                   header.column.columnDef.header,
                                   header.getContext()
                                 )}
-                            <span className="ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible">
+                            <span className="text-gray-400 ml-2 flex-none rounded group-hover:visible group-focus:visible">
                               {{
                                 asc: (
                                   <ChevronUpIcon
@@ -246,7 +246,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
                         <th
                           key={header.id}
                           scope="col"
-                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                          className="text-gray-900 px-3 py-3.5 text-left text-sm font-semibold"
                         >
                           {header.isPlaceholder
                             ? null
@@ -260,7 +260,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
                   </tr>
                 ))}
               </thead>
-              <tbody className="divide-y divide-gray-200 bg-white">
+              <tbody className="bg-white divide-y divide-gray-200">
                 {table.getRowModel().rows.map((row) => (
                   <tr key={row.id}>
                     {row.getVisibleCells().map((cell) => (

--- a/ui/src/components/notifications/ErrorNotification.tsx
+++ b/ui/src/components/notifications/ErrorNotification.tsx
@@ -9,20 +9,20 @@ export default function ErrorNotification() {
     <Transition show={error !== null}>
       <div className="max-w-s fixed bottom-0 right-2 z-50 m-4">
         <div
-          className="rounded-md border p-4 shadow bg-red-50 border-red-100"
+          className="bg-red-50 border-red-100 rounded-md border p-4 shadow"
           role="alert"
         >
           <div className="flex">
             <div className="flex-shrink-0">
               <XCircleIcon
-                className="h-5 w-5 text-red-400"
+                className="text-red-400 h-5 w-5"
                 aria-hidden="true"
               />
             </div>
             <div className="ml-3">
-              <h3 className="text-sm font-medium text-red-800">Error</h3>
+              <h3 className="text-red-800 text-sm font-medium">Error</h3>
               {error && error.message && (
-                <div className="mt-2 text-sm text-red-700">{error.message}</div>
+                <div className="text-red-700 mt-2 text-sm">{error.message}</div>
               )}
             </div>
             <div className="ml-auto pl-10">
@@ -32,7 +32,7 @@ export default function ErrorNotification() {
                   onClick={() => {
                     clearError();
                   }}
-                  className="inline-flex rounded-md p-1.5 text-red-500 bg-red-50 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2 focus:ring-offset-green-50"
+                  className="text-red-500 bg-red-50 inline-flex rounded-md p-1.5 hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2 focus:ring-offset-green-50"
                 >
                   <span className="sr-only">Dismiss</span>
                   <XMarkIcon className="h-4 w-4" aria-hidden="true" />

--- a/ui/src/components/notifications/SuccessNotification.tsx
+++ b/ui/src/components/notifications/SuccessNotification.tsx
@@ -16,23 +16,23 @@ export default function SuccessNotification() {
   return (
     <Transition show={success !== null}>
       <div className="max-w-s fixed bottom-0 right-2 z-10 m-4">
-        <div className="rounded-md p-4 bg-green-50">
+        <div className="bg-green-50 rounded-md p-4">
           <div className="flex">
             <div className="flex-shrink-0">
               <CheckCircleIcon
-                className="h-5 w-5 text-green-400"
+                className="text-green-400 h-5 w-5"
                 aria-hidden="true"
               />
             </div>
             <div className="ml-3">
-              <p className="text-sm font-medium text-green-800">{success}</p>
+              <p className="text-green-800 text-sm font-medium">{success}</p>
             </div>
             <div className="ml-auto pl-3">
               <div className="-mx-1.5 -my-1.5">
                 <button
                   type="button"
                   onClick={() => clearSuccess()}
-                  className="inline-flex rounded-md p-1.5 text-green-500 bg-green-50 hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2 focus:ring-offset-green-50"
+                  className="text-green-500 bg-green-50 inline-flex rounded-md p-1.5 hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2 focus:ring-offset-green-50"
                 >
                   <span className="sr-only">Dismiss</span>
                   <XMarkIcon className="h-5 w-5" aria-hidden="true" />

--- a/ui/src/components/panels/CopyToNamespacePanel.tsx
+++ b/ui/src/components/panels/CopyToNamespacePanel.tsx
@@ -44,21 +44,21 @@ export default function CopyToNamespacePanel(props: CopyToNamespacePanelProps) {
   return (
     <>
       <div className="sm:flex sm:items-start">
-        <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-violet-100 sm:mx-0 sm:h-10 sm:w-10">
+        <div className="bg-violet-100 mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full sm:mx-0 sm:h-10 sm:w-10">
           <DocumentDuplicateIcon
-            className="h-6 w-6 text-violet-500"
+            className="text-violet-500 h-6 w-6"
             aria-hidden="true"
           />
         </div>
         <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
           <Dialog.Title
             as="h3"
-            className="text-lg font-medium leading-6 text-gray-900"
+            className="text-gray-900 text-lg font-medium leading-6"
           >
             Copy {panelType}
           </Dialog.Title>
           <div className="mt-2">
-            <p className="text-sm text-gray-500">{panelMessage}</p>
+            <p className="text-gray-500 text-sm">{panelMessage}</p>
           </div>
           <div className="mt-4">
             <Listbox<SelectableNamespace>

--- a/ui/src/components/panels/DeletePanel.tsx
+++ b/ui/src/components/panels/DeletePanel.tsx
@@ -22,21 +22,21 @@ export default function DeletePanel(props: DeletePanelProps) {
   return (
     <>
       <div className="sm:flex sm:items-start">
-        <div className="mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+        <div className="bg-red-100 mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full sm:mx-0 sm:h-10 sm:w-10">
           <ExclamationTriangleIcon
-            className="h-6 w-6 text-red-600"
+            className="text-red-600 h-6 w-6"
             aria-hidden="true"
           />
         </div>
         <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
           <Dialog.Title
             as="h3"
-            className="text-lg font-medium leading-6 text-gray-900"
+            className="text-gray-900 text-lg font-medium leading-6"
           >
             Delete {panelType}
           </Dialog.Title>
           <div className="mt-2">
-            <p className="text-sm text-gray-500">{panelMessage}</p>
+            <p className="text-gray-500 text-sm">{panelMessage}</p>
           </div>
         </div>
       </div>

--- a/ui/src/components/rollouts/Rollout.tsx
+++ b/ui/src/components/rollouts/Rollout.tsx
@@ -39,15 +39,15 @@ const Rollout = forwardRef(
       key={rollout.id}
       ref={ref}
       style={style}
-      className={`${className} w-full items-center space-y-2 rounded-md border shadow-md shadow-violet-100 bg-white border-violet-300 hover:shadow-violet-200 sm:flex sm:flex-col lg:px-6 lg:py-2`}
+      className={`${className} bg-white border-violet-300 w-full items-center space-y-2 rounded-md border shadow-md shadow-violet-100 hover:shadow-violet-200 sm:flex sm:flex-col lg:px-6 lg:py-2`}
     >
-      <div className="w-full border-b p-2 bg-white border-gray-200 ">
+      <div className="bg-white border-gray-200 w-full border-b p-2 ">
         <div className="flex w-full flex-wrap items-center justify-between sm:flex-nowrap">
           <span
             key={rollout.id}
             className={classNames(
               readOnly ? 'hover:cursor-not-allowed' : 'hover:cursor-move',
-              'hidden h-4 w-4 justify-start text-gray-400 hover:text-violet-300 sm:flex'
+              'text-gray-400 hidden h-4 w-4 justify-start hover:text-violet-300 sm:flex'
             )}
             {...rest}
           >
@@ -56,14 +56,14 @@ const Rollout = forwardRef(
           <h3
             className={classNames(
               readOnly ? 'hover:cursor-not-allowed' : 'hover:cursor-move',
-              'text-sm font-normal leading-6 text-gray-700'
+              'text-gray-700 text-sm font-normal leading-6'
             )}
             {...rest}
           >
             {rolloutTypeToLabel(rollout.type)} Rollout
           </h3>
           <Menu as="div" className="hidden sm:flex">
-            <Menu.Button className="ml-4 block text-gray-600 hover:text-gray-900">
+            <Menu.Button className="text-gray-600 ml-4 block hover:text-gray-900">
               <EllipsisVerticalIcon className="h-5 w-5" aria-hidden="true" />
             </Menu.Button>
             {!readOnly && (
@@ -76,7 +76,7 @@ const Rollout = forwardRef(
                 leaveFrom="transform opacity-100 scale-100"
                 leaveTo="transform opacity-0 scale-95"
               >
-                <Menu.Items className="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md py-2 shadow-lg ring-1 ring-gray-900/5 bg-white focus:outline-none">
+                <Menu.Items className="bg-white absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md py-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none">
                   <Menu.Item>
                     {({ active }) => (
                       <a
@@ -87,7 +87,7 @@ const Rollout = forwardRef(
                         }}
                         className={classNames(
                           active ? 'bg-gray-50' : '',
-                          'block px-3 py-1 text-sm leading-6 text-gray-900'
+                          'text-gray-900 block px-3 py-1 text-sm leading-6'
                         )}
                       >
                         Edit
@@ -104,7 +104,7 @@ const Rollout = forwardRef(
                         }}
                         className={classNames(
                           active ? 'bg-gray-50' : '',
-                          'block px-3 py-1 text-sm leading-6 text-gray-900'
+                          'text-gray-900 block px-3 py-1 text-sm leading-6'
                         )}
                       >
                         Delete

--- a/ui/src/components/rollouts/forms/EditRolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/EditRolloutForm.tsx
@@ -139,12 +139,12 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
       }}
     >
       {(formik) => (
-        <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+        <Form className="bg-white flex h-full flex-col overflow-y-scroll shadow-xl">
           <div className="flex-1">
-            <div className="px-4 py-6 bg-gray-50 sm:px-6">
+            <div className="bg-gray-50 px-4 py-6 sm:px-6">
               <div className="flex items-start justify-between space-x-3">
                 <div className="space-y-1">
-                  <Dialog.Title className="text-lg font-medium text-gray-900">
+                  <Dialog.Title className="text-gray-900 text-lg font-medium">
                     Edit Rollout
                   </Dialog.Title>
                   <MoreInfo href="https://www.flipt.io/docs/concepts#rollouts">
@@ -168,7 +168,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                 <div>
                   <label
                     htmlFor="type"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Type
                   </label>
@@ -188,7 +188,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                               aria-describedby={`${rolloutRule.id}-description`}
                               name="type"
                               type="radio"
-                              className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                              className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
                               disabled={true}
                               checked={rolloutRule.id === rollout.type}
                               value={rolloutRule.id}
@@ -197,7 +197,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                           <div className="ml-3 text-sm">
                             <label
                               htmlFor={rolloutRule.id}
-                              className="font-medium text-gray-700"
+                              className="text-gray-700 font-medium"
                             >
                               {rolloutRule.name}
                             </label>
@@ -218,7 +218,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                 <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                   <label
                     htmlFor="percentage"
-                    className="mb-2 block text-sm font-medium text-gray-900"
+                    className="text-gray-900 mb-2 block text-sm font-medium"
                   >
                     Percentage
                   </label>
@@ -226,7 +226,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                     id="percentage-slider"
                     name="percentage"
                     type="range"
-                    className="h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle bg-gray-200 dark:bg-gray-700"
+                    className="bg-gray-200 h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle dark:bg-gray-700"
                   />
                   <Input
                     type="number"
@@ -243,7 +243,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                   <div>
                     <label
                       htmlFor="segmentKey"
-                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                     >
                       Segment
                     </label>
@@ -267,7 +267,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                 <label
                   htmlFor="value"
-                  className="mb-2 block text-sm font-medium text-gray-900"
+                  className="text-gray-900 mb-2 block text-sm font-medium"
                 >
                   Value
                 </label>
@@ -286,12 +286,12 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                 <div>
                   <label
                     htmlFor="description"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Description
                   </label>
                   <span
-                    className="text-xs text-gray-400"
+                    className="text-gray-400 text-xs"
                     id="description-optional"
                   >
                     Optional
@@ -303,7 +303,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
               </div>
             </div>
           </div>
-          <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+          <div className="border-gray-200 flex-shrink-0 border-t px-4 py-5 sm:px-6">
             <div className="flex justify-end space-x-3">
               <Button onClick={() => setOpen(false)}>Cancel</Button>
               <Button

--- a/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
@@ -118,14 +118,14 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
       }}
     >
       {(formik) => (
-        <Form className="flex h-full w-full flex-col overflow-y-scroll bg-white">
+        <Form className="bg-white flex h-full w-full flex-col overflow-y-scroll">
           <div className="w-full flex-1">
             <div className="space-y-6 py-6 sm:space-y-0 sm:py-0">
               {rollout.type === RolloutType.THRESHOLD ? (
                 <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:p-2">
                   <label
                     htmlFor="percentage"
-                    className="mb-2 block text-sm font-medium text-gray-900"
+                    className="text-gray-900 mb-2 block text-sm font-medium"
                   >
                     Percentage
                   </label>
@@ -133,7 +133,7 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
                     id="percentage-slider"
                     name="percentage"
                     type="range"
-                    className="hidden h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle bg-gray-200 dark:bg-gray-700 sm:block"
+                    className="bg-gray-200 hidden h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle dark:bg-gray-700 sm:block"
                   />
                   <div className="relative">
                     <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
@@ -154,7 +154,7 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
                   <div>
                     <label
                       htmlFor="segmentKey"
-                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                     >
                       Segment
                     </label>
@@ -178,7 +178,7 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:p-2">
                 <label
                   htmlFor="value"
-                  className="mb-2 block text-sm font-medium text-gray-900"
+                  className="text-gray-900 mb-2 block text-sm font-medium"
                 >
                   Value
                 </label>

--- a/ui/src/components/rollouts/forms/RolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/RolloutForm.tsx
@@ -117,12 +117,12 @@ export default function RolloutForm(props: RolloutFormProps) {
       }}
     >
       {(formik) => (
-        <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+        <Form className="bg-white flex h-full flex-col overflow-y-scroll shadow-xl">
           <div className="flex-1">
-            <div className="px-4 py-6 bg-gray-50 sm:px-6">
+            <div className="bg-gray-50 px-4 py-6 sm:px-6">
               <div className="flex items-start justify-between space-x-3">
                 <div className="space-y-1">
-                  <Dialog.Title className="text-lg font-medium text-gray-900">
+                  <Dialog.Title className="text-gray-900 text-lg font-medium">
                     New Rollout
                   </Dialog.Title>
                   <MoreInfo href="https://www.flipt.io/docs/concepts#rollouts">
@@ -146,7 +146,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                 <div>
                   <label
                     htmlFor="type"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Type
                   </label>
@@ -166,7 +166,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                               aria-describedby={`${rolloutRule.id}-description`}
                               name="type"
                               type="radio"
-                              className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                              className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
                               onChange={() => {
                                 setRolloutRuleType(rolloutRule.id);
                               }}
@@ -177,7 +177,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                           <div className="ml-3 text-sm">
                             <label
                               htmlFor={rolloutRule.id}
-                              className="font-medium text-gray-700"
+                              className="text-gray-700 font-medium"
                             >
                               {rolloutRule.name}
                             </label>
@@ -198,7 +198,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                 <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                   <label
                     htmlFor="percentage"
-                    className="mb-2 block text-sm font-medium text-gray-900"
+                    className="text-gray-900 mb-2 block text-sm font-medium"
                   >
                     Percentage
                   </label>
@@ -206,7 +206,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                     id="percentage-slider"
                     name="percentage"
                     type="range"
-                    className="h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle bg-gray-200 dark:bg-gray-700"
+                    className="bg-gray-200 h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle dark:bg-gray-700"
                   />
                   <Input
                     type="number"
@@ -223,7 +223,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                   <div>
                     <label
                       htmlFor="segmentKey"
-                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                     >
                       Segment
                     </label>
@@ -247,7 +247,7 @@ export default function RolloutForm(props: RolloutFormProps) {
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                 <label
                   htmlFor="value"
-                  className="mb-2 block text-sm font-medium text-gray-900"
+                  className="text-gray-900 mb-2 block text-sm font-medium"
                 >
                   Value
                 </label>
@@ -265,12 +265,12 @@ export default function RolloutForm(props: RolloutFormProps) {
                 <div>
                   <label
                     htmlFor="description"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Description
                   </label>
                   <span
-                    className="text-xs text-gray-400"
+                    className="text-gray-400 text-xs"
                     id="description-optional"
                   >
                     Optional
@@ -282,7 +282,7 @@ export default function RolloutForm(props: RolloutFormProps) {
               </div>
             </div>
           </div>
-          <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+          <div className="border-gray-200 flex-shrink-0 border-t px-4 py-5 sm:px-6">
             <div className="flex justify-end space-x-3">
               <Button onClick={() => setOpen(false)}>Cancel</Button>
               <Button

--- a/ui/src/components/rules/Rule.tsx
+++ b/ui/src/components/rules/Rule.tsx
@@ -37,15 +37,15 @@ const Rule = forwardRef(
       key={rule.id}
       ref={ref}
       style={style}
-      className={`${className} w-full items-center space-y-2 rounded-md border shadow-md shadow-violet-100 bg-white border-violet-300 hover:shadow-violet-200 sm:flex sm:flex-col lg:px-4 lg:py-2`}
+      className={`${className} bg-white border-violet-300 w-full items-center space-y-2 rounded-md border shadow-md shadow-violet-100 hover:shadow-violet-200 sm:flex sm:flex-col lg:px-4 lg:py-2`}
     >
-      <div className="w-full border-b p-2 bg-white border-gray-200 ">
+      <div className="bg-white border-gray-200 w-full border-b p-2 ">
         <div className="flex w-full flex-wrap items-center justify-between sm:flex-nowrap">
           <span
             key={rule.id}
             className={classNames(
               readOnly ? 'hover:cursor-not-allowed' : 'hover:cursor-move',
-              'hidden h-4 w-4 justify-start text-gray-400 hover:text-violet-300 sm:flex'
+              'text-gray-400 hidden h-4 w-4 justify-start hover:text-violet-300 sm:flex'
             )}
             {...rest}
           >
@@ -54,14 +54,14 @@ const Rule = forwardRef(
           <h3
             className={classNames(
               readOnly ? 'hover:cursor-not-allowed' : 'hover:cursor-move',
-              'text-sm font-normal leading-6 text-gray-700'
+              'text-gray-700 text-sm font-normal leading-6'
             )}
             {...rest}
           >
             Rule
           </h3>
           <Menu as="div" className="hidden sm:flex">
-            <Menu.Button className="ml-4 block text-gray-600 hover:text-gray-900">
+            <Menu.Button className="text-gray-600 ml-4 block hover:text-gray-900">
               <EllipsisVerticalIcon className="h-5 w-5" aria-hidden="true" />
             </Menu.Button>
             {!readOnly && (
@@ -74,7 +74,7 @@ const Rule = forwardRef(
                 leaveFrom="transform opacity-100 scale-100"
                 leaveTo="transform opacity-0 scale-95"
               >
-                <Menu.Items className="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md py-2 shadow-lg ring-1 ring-gray-900/5 bg-white focus:outline-none">
+                <Menu.Items className="bg-white absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md py-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none">
                   <Menu.Item>
                     {({ active }) => (
                       <a
@@ -85,7 +85,7 @@ const Rule = forwardRef(
                         }}
                         className={classNames(
                           active ? 'bg-gray-50' : '',
-                          'block px-3 py-1 text-sm leading-6 text-gray-900'
+                          'text-gray-900 block px-3 py-1 text-sm leading-6'
                         )}
                       >
                         Delete

--- a/ui/src/components/rules/forms/MultiDistributionForm.tsx
+++ b/ui/src/components/rules/forms/MultiDistributionForm.tsx
@@ -16,7 +16,7 @@ export default function MultiDistributionFormInputs(
         <div>
           <label
             htmlFor="variantKey"
-            className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+            className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
           >
             Variants
           </label>
@@ -30,7 +30,7 @@ export default function MultiDistributionFormInputs(
           <div>
             <label
               htmlFor={dist.variantKey}
-              className="block truncate text-right text-sm text-gray-600 sm:mt-px sm:pr-2 sm:pt-2"
+              className="text-gray-600 block truncate text-right text-sm sm:mt-px sm:pr-2 sm:pt-2"
             >
               {dist.variantKey}
             </label>
@@ -38,7 +38,7 @@ export default function MultiDistributionFormInputs(
           <div className="relative sm:col-span-1">
             <input
               type="number"
-              className="block w-full rounded-md pl-7 pr-12 shadow-sm border-gray-300 focus:ring-violet-300 focus:border-violet-300 sm:text-sm"
+              className="border-gray-300 block w-full rounded-md pl-7 pr-12 shadow-sm focus:border-violet-300 focus:ring-violet-300 sm:text-sm"
               value={dist.rollout}
               name={dist.variantKey}
               // eslint-disable-next-line react/no-unknown-property

--- a/ui/src/components/rules/forms/QuickEditRuleForm.tsx
+++ b/ui/src/components/rules/forms/QuickEditRuleForm.tsx
@@ -178,14 +178,14 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
     >
       {(formik) => {
         return (
-          <Form className="flex h-full w-full flex-col overflow-y-scroll bg-white">
+          <Form className="bg-white flex h-full w-full flex-col overflow-y-scroll">
             <div className="w-full flex-1">
               <div className="space-y-6 py-6 sm:space-y-0 sm:py-0">
                 <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-2">
                   <div>
                     <label
                       htmlFor="segmentKey"
-                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                     >
                       Segment
                     </label>
@@ -209,7 +209,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                   <div>
                     <label
                       htmlFor="ruleType"
-                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                     >
                       Type
                     </label>
@@ -228,7 +228,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                               <div className="text-sm">
                                 <label
                                   htmlFor={dist.id}
-                                  className="font-medium text-gray-700"
+                                  className="text-gray-700 font-medium"
                                 >
                                   {dist.name}
                                 </label>
@@ -253,7 +253,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                       <div>
                         <label
                           htmlFor="variantKey"
-                          className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                          className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                         >
                           Variant
                         </label>
@@ -281,7 +281,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                       <div>
                         <label
                           htmlFor="variantKey"
-                          className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                          className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                         >
                           Variants
                         </label>
@@ -300,7 +300,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                                     <div>
                                       <label
                                         htmlFor={`rollouts.[${index}].distribution.rollout`}
-                                        className="block truncate text-right text-sm text-gray-600 sm:mt-px sm:pr-2 sm:pt-2"
+                                        className="text-gray-600 block truncate text-right text-sm sm:mt-px sm:pr-2 sm:pt-2"
                                       >
                                         {dist.variant.key}
                                       </label>
@@ -309,7 +309,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                                       <Field
                                         key={index}
                                         type="number"
-                                        className="block w-full rounded-md pl-7 pr-12 shadow-sm border-gray-300 focus:ring-violet-300 focus:border-violet-300 sm:text-sm"
+                                        className="border-gray-300 block w-full rounded-md pl-7 pr-12 shadow-sm focus:border-violet-300 focus:ring-violet-300 sm:text-sm"
                                         value={dist.distribution.rollout}
                                         name={`rollouts.[${index}].distribution.rollout`}
                                         // eslint-disable-next-line react/no-unknown-property
@@ -332,7 +332,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                       )}
                     />
                     {formik.touched.rollouts && formik.errors.rollouts && (
-                      <p className="mt-1 px-4 text-center text-sm text-gray-500 sm:px-6 sm:py-5">
+                      <p className="text-gray-500 mt-1 px-4 text-center text-sm sm:px-6 sm:py-5">
                         Multi-variant rules must have distributions that add up
                         to 100% or less.
                       </p>

--- a/ui/src/components/rules/forms/RuleForm.tsx
+++ b/ui/src/components/rules/forms/RuleForm.tsx
@@ -165,12 +165,12 @@ export default function RuleForm(props: RuleFormProps) {
     >
       {(formik) => {
         return (
-          <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+          <Form className="bg-white flex h-full flex-col overflow-y-scroll shadow-xl">
             <div className="flex-1">
-              <div className="px-4 py-6 bg-gray-50 sm:px-6">
+              <div className="bg-gray-50 px-4 py-6 sm:px-6">
                 <div className="flex items-start justify-between space-x-3">
                   <div className="space-y-1">
-                    <Dialog.Title className="text-lg font-medium text-gray-900">
+                    <Dialog.Title className="text-gray-900 text-lg font-medium">
                       New Rule
                     </Dialog.Title>
                     <MoreInfo href="https://www.flipt.io/docs/concepts#rules">
@@ -194,7 +194,7 @@ export default function RuleForm(props: RuleFormProps) {
                   <div>
                     <label
                       htmlFor="segmentKey"
-                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                     >
                       Segment
                     </label>
@@ -218,7 +218,7 @@ export default function RuleForm(props: RuleFormProps) {
                   <div>
                     <label
                       htmlFor="ruleType"
-                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                     >
                       Type
                     </label>
@@ -238,7 +238,7 @@ export default function RuleForm(props: RuleFormProps) {
                                 aria-describedby={`${dist.id}-description`}
                                 name="ruleType"
                                 type="radio"
-                                className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                                className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
                                 onChange={() => {
                                   setRuleType(dist.id);
                                 }}
@@ -253,7 +253,7 @@ export default function RuleForm(props: RuleFormProps) {
                             <div className="ml-3 text-sm">
                               <label
                                 htmlFor={dist.id}
-                                className="font-medium text-gray-700"
+                                className="text-gray-700 font-medium"
                               >
                                 {dist.name}
                               </label>
@@ -288,13 +288,13 @@ export default function RuleForm(props: RuleFormProps) {
                     />
                   )}
                 {!distributionsValid && ruleType === DistributionType.Multi && (
-                  <p className="mt-1 px-4 text-center text-sm text-gray-500 sm:px-6 sm:py-5">
+                  <p className="text-gray-500 mt-1 px-4 text-center text-sm sm:px-6 sm:py-5">
                     Multi-variant rules must have distributions that add up to
                     100% or less.
                   </p>
                 )}
                 {(!flag.variants || flag.variants?.length == 0) && (
-                  <p className="mt-1 px-4 text-center text-sm text-gray-500 sm:px-6 sm:py-5">
+                  <p className="text-gray-500 mt-1 px-4 text-center text-sm sm:px-6 sm:py-5">
                     Flag{' '}
                     <Link to=".." className="text-violet-500">
                       {truncateKey(flag.key)}
@@ -305,7 +305,7 @@ export default function RuleForm(props: RuleFormProps) {
                 )}
               </div>
             </div>
-            <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+            <div className="border-gray-200 flex-shrink-0 border-t px-4 py-5 sm:px-6">
               <div className="flex justify-end space-x-3">
                 <Button onClick={() => setOpen(false)}>Cancel</Button>
                 <Button

--- a/ui/src/components/rules/forms/SingleDistributionForm.tsx
+++ b/ui/src/components/rules/forms/SingleDistributionForm.tsx
@@ -16,7 +16,7 @@ export default function SingleDistributionFormInput(
       <div>
         <label
           htmlFor="variantKey"
-          className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+          className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
         >
           Variant
         </label>

--- a/ui/src/components/segments/ConstraintForm.tsx
+++ b/ui/src/components/segments/ConstraintForm.tsx
@@ -106,7 +106,7 @@ function ConstraintValueInput(props: ConstraintInputProps) {
       <div>
         <label
           htmlFor="value"
-          className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+          className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
         >
           Value
         </label>
@@ -166,17 +166,17 @@ function ConstraintValueDateTimeInput(props: ConstraintInputProps) {
       <div>
         <label
           htmlFor="value"
-          className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+          className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
         >
           Value
         </label>
-        <span className="text-xs text-gray-400" id="value-tz">
+        <span className="text-gray-400 text-xs" id="value-tz">
           <Link
             to="/settings"
-            className="group inline-flex items-center text-gray-400 hover:text-gray-500"
+            className="group text-gray-400 inline-flex items-center hover:text-gray-500"
           >
             <QuestionMarkCircleIcon
-              className="-ml-1 h-4 w-4 text-gray-300 group-hover:text-gray-400"
+              className="text-gray-300 -ml-1 h-4 w-4 group-hover:text-gray-400"
               aria-hidden="true"
             />
             <span className="ml-1">{timezone}</span>
@@ -276,12 +276,12 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
       })}
     >
       {(formik) => (
-        <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+        <Form className="bg-white flex h-full flex-col overflow-y-scroll shadow-xl">
           <div className="flex-1">
-            <div className="px-4 py-6 bg-gray-50 sm:px-6">
+            <div className="bg-gray-50 px-4 py-6 sm:px-6">
               <div className="flex items-start justify-between space-x-3">
                 <div className="space-y-1">
-                  <Dialog.Title className="text-lg font-medium text-gray-900">
+                  <Dialog.Title className="text-gray-900 text-lg font-medium">
                     {title}
                   </Dialog.Title>
                   <MoreInfo href="https://www.flipt.io/docs/concepts#constraints">
@@ -307,7 +307,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="property"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Property
                   </label>
@@ -320,7 +320,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="type"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Type
                   </label>
@@ -352,7 +352,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="operator"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Operator
                   </label>
@@ -379,12 +379,12 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="description"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Description
                   </label>
                   <span
-                    className="text-xs text-gray-400"
+                    className="text-gray-400 text-xs"
                     id="description-optional"
                   >
                     Optional
@@ -396,7 +396,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
               </div>
             </div>
           </div>
-          <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+          <div className="border-gray-200 flex-shrink-0 border-t px-4 py-5 sm:px-6">
             <div className="flex justify-end space-x-3">
               <Button
                 onClick={() => {

--- a/ui/src/components/segments/SegmentForm.tsx
+++ b/ui/src/components/segments/SegmentForm.tsx
@@ -96,7 +96,7 @@ export default function SegmentForm(props: SegmentFormProps) {
               <div className="col-span-2">
                 <label
                   htmlFor="name"
-                  className="block text-sm font-medium text-gray-700"
+                  className="text-gray-700 block text-sm font-medium"
                 >
                   Name
                 </label>
@@ -121,7 +121,7 @@ export default function SegmentForm(props: SegmentFormProps) {
               <div className="col-span-2">
                 <label
                   htmlFor="key"
-                  className="block text-sm font-medium text-gray-700"
+                  className="text-gray-700 block text-sm font-medium"
                 >
                   Key
                 </label>
@@ -139,7 +139,7 @@ export default function SegmentForm(props: SegmentFormProps) {
               <div className="col-span-3">
                 <label
                   htmlFor="matchType"
-                  className="block text-sm font-medium text-gray-700"
+                  className="text-gray-700 block text-sm font-medium"
                 >
                   Match Type
                 </label>
@@ -157,7 +157,7 @@ export default function SegmentForm(props: SegmentFormProps) {
                             aria-describedby={`${matchType.id}-description`}
                             name="matchType"
                             type="radio"
-                            className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                            className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
                             onChange={() => {
                               formik.setFieldValue('matchType', matchType.id);
                             }}
@@ -168,7 +168,7 @@ export default function SegmentForm(props: SegmentFormProps) {
                         <div className="ml-3 text-sm">
                           <label
                             htmlFor={matchType.id}
-                            className="font-medium text-gray-700"
+                            className="text-gray-700 font-medium"
                           >
                             {matchType.name}
                           </label>
@@ -188,12 +188,12 @@ export default function SegmentForm(props: SegmentFormProps) {
                 <div className="flex justify-between">
                   <label
                     htmlFor="description"
-                    className="block text-sm font-medium text-gray-700"
+                    className="text-gray-700 block text-sm font-medium"
                   >
                     Description
                   </label>
                   <span
-                    className="text-xs text-gray-500"
+                    className="text-gray-500 text-xs"
                     id="description-optional"
                   >
                     Optional

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -146,7 +146,7 @@ export default function SegmentTable(props: SegmentTableProps) {
                   <th
                     key={header.id}
                     scope="col"
-                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    className="text-gray-900 px-3 py-3.5 text-left text-sm font-semibold"
                   >
                     <div
                       className="group inline-flex cursor-pointer"
@@ -158,7 +158,7 @@ export default function SegmentTable(props: SegmentTableProps) {
                             header.column.columnDef.header,
                             header.getContext()
                           )}
-                      <span className="ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible">
+                      <span className="text-gray-400 ml-2 flex-none rounded group-hover:visible group-focus:visible">
                         {{
                           asc: (
                             <ChevronUpIcon
@@ -180,7 +180,7 @@ export default function SegmentTable(props: SegmentTableProps) {
                   <th
                     key={header.id}
                     scope="col"
-                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                    className="text-gray-900 px-3 py-3.5 text-left text-sm font-semibold"
                   >
                     {header.isPlaceholder
                       ? null

--- a/ui/src/components/tokens/ShowTokenPanel.tsx
+++ b/ui/src/components/tokens/ShowTokenPanel.tsx
@@ -35,21 +35,21 @@ export default function ShowTokenPanel(props: ShowTokenPanelProps) {
   return (
     <>
       <div>
-        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
-          <CheckIcon className="h-6 w-6 text-green-600" aria-hidden="true" />
+        <div className="bg-green-100 mx-auto flex h-12 w-12 items-center justify-center rounded-full">
+          <CheckIcon className="text-green-600 h-6 w-6" aria-hidden="true" />
         </div>
         <div className="mt-3 text-center sm:mt-5">
           <Dialog.Title
             as="h3"
-            className="text-lg font-medium leading-6 text-gray-900"
+            className="text-gray-900 text-lg font-medium leading-6"
           >
             Created Token
           </Dialog.Title>
           <div className="mt-2">
-            <p className="text-sm text-gray-500">
+            <p className="text-gray-500 text-sm">
               Please copy the token below and store it in a secure location.
             </p>
-            <p className="mt-2 text-sm text-gray-700">
+            <p className="text-gray-700 mt-2 text-sm">
               You will not be able to view it again
             </p>
           </div>
@@ -74,13 +74,13 @@ export default function ShowTokenPanel(props: ShowTokenPanelProps) {
                 >
                   <CheckIcon
                     className={classNames(
-                      'absolute m-auto h-6 w-6 justify-center align-middle transition-opacity duration-300 ease-in-out text-green-400 hover:text-white',
+                      'text-green-400 absolute m-auto h-6 w-6 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-white',
                       copied ? 'visible opacity-100' : 'invisible opacity-0'
                     )}
                   />
                   <ClipboardDocumentIcon
                     className={classNames(
-                      'm-auto h-6 w-6 justify-center align-middle transition-opacity duration-300 ease-in-out text-gray-400 hover:text-white',
+                      'text-gray-400 m-auto h-6 w-6 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-white',
                       copied ? 'invisible opacity-0' : 'visible opacity-100'
                     )}
                   />

--- a/ui/src/components/tokens/TokenForm.tsx
+++ b/ui/src/components/tokens/TokenForm.tsx
@@ -66,12 +66,12 @@ const TokenForm = forwardRef((props: TokenFormProps, ref: any) => {
       }}
     >
       {(formik) => (
-        <Form className="flex h-full flex-col overflow-y-scroll shadow-xl bg-white">
+        <Form className="bg-white flex h-full flex-col overflow-y-scroll shadow-xl">
           <div className="flex-1">
-            <div className="px-4 py-6 bg-gray-50 sm:px-6">
+            <div className="bg-gray-50 px-4 py-6 sm:px-6">
               <div className="flex items-start justify-between space-x-3">
                 <div className="space-y-1">
-                  <Dialog.Title className="text-lg font-medium text-gray-900">
+                  <Dialog.Title className="text-gray-900 text-lg font-medium">
                     New Token
                   </Dialog.Title>
                   <MoreInfo href="https://www.flipt.io/docs/authentication/methods#static-token">
@@ -97,7 +97,7 @@ const TokenForm = forwardRef((props: TokenFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="name"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Name
                   </label>
@@ -110,7 +110,7 @@ const TokenForm = forwardRef((props: TokenFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="description"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Description
                   </label>
@@ -123,11 +123,11 @@ const TokenForm = forwardRef((props: TokenFormProps, ref: any) => {
                 <div>
                   <label
                     htmlFor="expires"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
                   >
                     Expires On
                   </label>
-                  <span className="text-xs text-gray-400" id="expires-optional">
+                  <span className="text-gray-400 text-xs" id="expires-optional">
                     Optional
                   </span>
                 </div>
@@ -142,7 +142,7 @@ const TokenForm = forwardRef((props: TokenFormProps, ref: any) => {
               </div>
             </div>
           </div>
-          <div className="flex-shrink-0 border-t px-4 py-5 border-gray-200 sm:px-6">
+          <div className="border-gray-200 flex-shrink-0 border-t px-4 py-5 sm:px-6">
             <div className="flex justify-end space-x-3">
               <Button
                 onClick={() => {

--- a/ui/src/components/tokens/TokenTable.tsx
+++ b/ui/src/components/tokens/TokenTable.tsx
@@ -145,7 +145,7 @@ export default function TokenTable(props: TokenTableProps) {
                         <th
                           key={header.id}
                           scope="col"
-                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                          className="text-gray-900 px-3 py-3.5 text-left text-sm font-semibold"
                         >
                           <div
                             className="group inline-flex cursor-pointer"
@@ -157,7 +157,7 @@ export default function TokenTable(props: TokenTableProps) {
                                   header.column.columnDef.header,
                                   header.getContext()
                                 )}
-                            <span className="ml-2 flex-none rounded text-gray-400 group-hover:visible group-focus:visible">
+                            <span className="text-gray-400 ml-2 flex-none rounded group-hover:visible group-focus:visible">
                               {{
                                 asc: (
                                   <ChevronUpIcon
@@ -179,7 +179,7 @@ export default function TokenTable(props: TokenTableProps) {
                         <th
                           key={header.id}
                           scope="col"
-                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+                          className="text-gray-900 px-3 py-3.5 text-left text-sm font-semibold"
                         >
                           {header.isPlaceholder
                             ? null
@@ -193,7 +193,7 @@ export default function TokenTable(props: TokenTableProps) {
                   </tr>
                 ))}
               </thead>
-              <tbody className="divide-y divide-gray-200 bg-white">
+              <tbody className="bg-white divide-y divide-gray-200">
                 {table.getRowModel().rows.map((row) => (
                   <tr key={row.id}>
                     {row.getVisibleCells().map((cell) => (


### PR DESCRIPTION
apparently the tailwindcss order plugin for prettier changed the 'preferred' order for CSS classes again..

this change was entirely automated ie: `cd ui && npx prettier -w .`