### PR TITLE
fix: validate rollout submit

### DIFF
--- a/ui/src/components/forms/Input.tsx
+++ b/ui/src/components/forms/Input.tsx
@@ -43,7 +43,7 @@ export default function Input(props: InputProps) {
         autoComplete={autoComplete ? 'on' : 'off'}
         {...rest}
       />
-      {meta.touched && meta.error ? (
+      {hasError && meta.error?.length && meta.error.length > 0 ? (
         <div className="text-red-500 mt-1 text-sm">{meta.error}</div>
       ) : null}
     </>

--- a/ui/src/components/rollouts/forms/EditRolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/EditRolloutForm.tsx
@@ -114,6 +114,24 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
         percentage: rollout.threshold?.percentage,
         value: initialValue
       }}
+      validate={(values) => {
+        if (values.type === RolloutType.SEGMENT) {
+          if (!values.segmentKey) {
+            return {
+              segmentKey: true
+            };
+          }
+        } else if (values.type === RolloutType.THRESHOLD) {
+          if (
+            values.percentage &&
+            (values.percentage < 0 || values.percentage > 100)
+          ) {
+            return {
+              percentage: true
+            };
+          }
+        }
+      }}
       onSubmit={(values, { setSubmitting }) => {
         let handleSubmit = async (_values: RolloutFormValues) => {};
 
@@ -228,14 +246,19 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                     type="range"
                     className="bg-gray-200 h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle dark:bg-gray-700"
                   />
-                  <Input
-                    type="number"
-                    id="percentage"
-                    max={100}
-                    min={0}
-                    name="percentage"
-                    className="text-center"
-                  />
+                  <div className="relative">
+                    <div className="text-black pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                      %
+                    </div>
+                    <Input
+                      type="number"
+                      id="percentage"
+                      max={100}
+                      min={0}
+                      name="percentage"
+                      className="text-center"
+                    />
+                  </div>
                 </div>
               )}
               {rollout.type === RolloutType.SEGMENT && (

--- a/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
@@ -94,6 +94,24 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
         percentage: rollout.threshold?.percentage,
         value: initialValue
       }}
+      validate={(values) => {
+        if (values.type === RolloutType.SEGMENT) {
+          if (!values.segmentKey) {
+            return {
+              segmentKey: true
+            };
+          }
+        } else if (values.type === RolloutType.THRESHOLD) {
+          if (
+            values.percentage &&
+            (values.percentage < 0 || values.percentage > 100)
+          ) {
+            return {
+              percentage: true
+            };
+          }
+        }
+      }}
       onSubmit={(values, { setSubmitting }) => {
         let handleSubmit = async (_values: RolloutFormValues) => {};
 
@@ -136,7 +154,7 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
                     className="bg-gray-200 hidden h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle dark:bg-gray-700 sm:block"
                   />
                   <div className="relative">
-                    <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                    <div className="text-black pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
                       %
                     </div>
                     <Input
@@ -145,7 +163,7 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
                       max={100}
                       min={0}
                       name="percentage"
-                      className="pl-10 text-center"
+                      className="text-center"
                     />
                   </div>
                 </div>

--- a/ui/src/components/rollouts/forms/RolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/RolloutForm.tsx
@@ -92,6 +92,21 @@ export default function RolloutForm(props: RolloutFormProps) {
         percentage: 50, // TODO: make this 0?
         value: 'true'
       }}
+      validate={(values) => {
+        if (values.type === RolloutType.SEGMENT) {
+          if (!values.segmentKey) {
+            return {
+              segmentKey: true
+            };
+          }
+        } else if (values.type === RolloutType.THRESHOLD) {
+          if (values.percentage < 0 || values.percentage > 100) {
+            return {
+              percentage: true
+            };
+          }
+        }
+      }}
       onSubmit={(values, { setSubmitting }) => {
         let handleSubmit = async (_values: RolloutFormValues) => {};
 
@@ -208,14 +223,19 @@ export default function RolloutForm(props: RolloutFormProps) {
                     type="range"
                     className="bg-gray-200 h-2 w-full cursor-pointer appearance-none self-center rounded-lg align-middle dark:bg-gray-700"
                   />
-                  <Input
-                    type="number"
-                    id="percentage"
-                    max={100}
-                    min={0}
-                    name="percentage"
-                    className="text-center"
-                  />
+                  <div className="relative">
+                    <div className="text-black pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                      %
+                    </div>
+                    <Input
+                      type="number"
+                      id="percentage"
+                      max={100}
+                      min={0}
+                      name="percentage"
+                      className="text-center"
+                    />
+                  </div>
                 </div>
               )}
               {rolloutRuleType === RolloutType.SEGMENT && (


### PR DESCRIPTION
Fixes: FLI-510

- disables submit button in UI if invalid rollout values are entered
- adds % indicator on all threshold inputs
- fixes % for darkmode

<img width="577" alt="CleanShot 2023-07-18 at 16 05 26@2x" src="https://github.com/flipt-io/flipt/assets/209477/1b8beb3a-9e26-4577-ae5d-0dcae8c470e5">
<img width="879" alt="CleanShot 2023-07-18 at 16 05 16@2x" src="https://github.com/flipt-io/flipt/assets/209477/0e432a03-c02a-469b-a288-1e5b52d55a85">
