### PR TITLE
chore: fix scrollToBottom for screenshots

### DIFF
--- a/ui/screenshot.js
+++ b/ui/screenshot.js
@@ -8,6 +8,13 @@ const screenshot = async (page, name) => {
   await page.screenshot({ path: 'screenshots/' + name });
 };
 
+const scrollToBottom = async (page) => {
+  await sleep(1000);
+  await page.evaluate(() => {
+    window.scrollTo(0, document.body.scrollHeight);
+  });
+};
+
 const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));
 
 const capture = async function (folder, name, fn, opts = {}) {
@@ -43,7 +50,7 @@ const capture = async function (folder, name, fn, opts = {}) {
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
     viewport: { width: 1440, height: 900 },
-    deviceScaleFactor: 3,
+    deviceScaleFactor: 3
   });
   const page = await context.newPage();
 
@@ -56,4 +63,4 @@ const capture = async function (folder, name, fn, opts = {}) {
   await browser.close();
 };
 
-module.exports = { capture, sleep, screenshot };
+module.exports = { capture, sleep, screenshot, scrollToBottom };

--- a/ui/screenshot.js
+++ b/ui/screenshot.js
@@ -56,7 +56,7 @@ const capture = async function (folder, name, fn, opts = {}) {
 
   await page.goto(fliptAddr);
   await fn(page);
-  await sleep(3000);
+  await sleep(4000);
   await screenshot(page, `${folder}/${name}.png`);
 
   await context.close();

--- a/ui/screenshot/concepts/constraints.js
+++ b/ui/screenshot/concepts/constraints.js
@@ -1,12 +1,9 @@
-const { capture } = require('../../screenshot.js');
+const { capture, scrollToBottom } = require('../../screenshot.js');
 
 (async () => {
   await capture('concepts', 'constraints', async (page) => {
     await page.getByRole('link', { name: 'Segments' }).click();
     await page.getByRole('link', { name: 'new-users' }).click();
-    await page.evaluate(() =>
-      // scroll to bottom of page to show all constraints
-      window.scrollTo(0, document.documentElement.scrollHeight)
-    );
+    await scrollToBottom(page);
   });
 })();

--- a/ui/screenshot/concepts/rollouts.js
+++ b/ui/screenshot/concepts/rollouts.js
@@ -1,11 +1,8 @@
-const { capture } = require('../../screenshot.js');
+const { capture, scrollToBottom } = require('../../screenshot.js');
 
 (async () => {
   await capture('concepts', 'rollouts', async (page) => {
     await page.getByRole('link', { name: 'new-contact-page' }).click();
-    await page.evaluate(() =>
-      // scroll to bottom of page to show all rollouts
-      window.scrollTo(0, document.documentElement.scrollHeight)
-    );
+    await scrollToBottom(page);
   });
 })();

--- a/ui/screenshot/concepts/variants.js
+++ b/ui/screenshot/concepts/variants.js
@@ -1,11 +1,8 @@
-const { capture } = require('../../screenshot.js');
+const { capture, scrollToBottom } = require('../../screenshot.js');
 
 (async () => {
   await capture('concepts', 'variants', async (page) => {
     await page.getByRole('link', { name: 'colorscheme' }).click();
-    await page.evaluate(() =>
-      // scroll to bottom of page to show all variants
-      window.scrollTo(0, document.documentElement.scrollHeight)
-    );
+    await scrollToBottom(page);
   });
 })();


### PR DESCRIPTION
previously the screenshots were not always reliably scrolling to the bottom of the page when requested, sometimes the screenshot would happen mid-scroll.

This effectively fixes that

![rollouts](https://github.com/flipt-io/flipt/assets/209477/0d9fff7a-d996-454e-989a-51ad306f661c)
