### PR TITLE
chore: disallow rollouts eval UI

### DIFF
--- a/build/testing/integration/readonly/testdata/default.yaml
+++ b/build/testing/integration/readonly/testdata/default.yaml
@@ -16243,3 +16243,4 @@ segments:
 - key: segment_no_constraints
   name: SEGMENT_NO_CONSTRAINTS
   description: Some Segment Description
+  match_type: ALL_MATCH_TYPE

--- a/build/testing/integration/readonly/testdata/production.yaml
+++ b/build/testing/integration/readonly/testdata/production.yaml
@@ -16244,3 +16244,4 @@ segments:
 - key: segment_no_constraints
   name: SEGMENT_NO_CONSTRAINTS
   description: Some Segment Description
+  match_type: ALL_MATCH_TYPE

--- a/ui/src/app/auth/Login.tsx
+++ b/ui/src/app/auth/Login.tsx
@@ -56,7 +56,7 @@ export default function Login() {
     });
 
     if (!res.ok || res.status !== 200) {
-      setError(new Error('Unable to authenticate: ' + res.text()));
+      setError('Unable to authenticate: ' + res.text());
       return;
     }
 
@@ -91,7 +91,7 @@ export default function Login() {
         );
         setProviders(loginProviders);
       } catch (err) {
-        setError(err instanceof Error ? err : Error(String(err)));
+        setError(err);
       }
     };
 

--- a/ui/src/app/flags/Evaluation.tsx
+++ b/ui/src/app/flags/Evaluation.tsx
@@ -16,7 +16,7 @@ import {
 import { InformationCircleIcon, PlusIcon } from '@heroicons/react/24/outline';
 import { useCallback, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useOutletContext } from 'react-router-dom';
+import { useNavigate, useOutletContext } from 'react-router-dom';
 import { selectReadonly } from '~/app/meta/metaSlice';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import EmptyState from '~/components/EmptyState';
@@ -32,6 +32,7 @@ import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
 import { IDistribution } from '~/types/Distribution';
 import { IEvaluatable } from '~/types/Evaluatable';
+import { FlagType } from '~/types/Flag';
 import { IRule, IRuleList } from '~/types/Rule';
 import { ISegment, ISegmentList } from '~/types/Segment';
 import { IVariant } from '~/types/Variant';
@@ -54,6 +55,8 @@ export default function Evaluation() {
 
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
+
+  const navigate = useNavigate();
 
   const namespace = useSelector(selectCurrentNamespace);
   const readOnly = useSelector(selectReadonly);
@@ -165,6 +168,13 @@ export default function Evaluation() {
   useEffect(() => {
     loadData();
   }, [loadData, rulesVersion]);
+
+  useEffect(() => {
+    if (flag.type === FlagType.BOOLEAN) {
+      setError('Boolean flags do not support evaluation rules');
+      navigate(`/namespaces/${namespace.key}/flags/${flag.key}`);
+    }
+  }, [flag.type, navigate, setError, namespace.key, flag.key]);
 
   return (
     <>

--- a/ui/src/components/NotificationProvider.tsx
+++ b/ui/src/components/NotificationProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useState } from 'react';
+import { getErrorMessage } from '~/utils/helpers';
 
 type ErrorContext = {
   error: string | null;
@@ -28,13 +29,12 @@ export function NotificationProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [error, setIError] = useState<string | null>(null);
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const [error, setError_] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
 
   const setError = (error: unknown) => {
-    if (error === null) setIError(null);
-    else if (error instanceof Error) setIError(error.message);
-    else setIError(String(error));
+    setError_(getErrorMessage(error));
   };
 
   return (

--- a/ui/src/components/NotificationProvider.tsx
+++ b/ui/src/components/NotificationProvider.tsx
@@ -34,6 +34,10 @@ export function NotificationProvider({
   const [success, setSuccess] = useState<string | null>(null);
 
   const setError = (error: unknown) => {
+    if (error === null) {
+      setError_(null);
+      return;
+    }
     setError_(getErrorMessage(error));
   };
 

--- a/ui/src/components/NotificationProvider.tsx
+++ b/ui/src/components/NotificationProvider.tsx
@@ -1,8 +1,8 @@
 import { createContext, useState } from 'react';
 
 type ErrorContext = {
-  error: Error | null;
-  setError(_error: Error | null): void;
+  error: string | null;
+  setError(_error: unknown): void;
   clearError(): void;
 };
 
@@ -14,8 +14,8 @@ type SuccessContext = {
 
 export const NotificationContext = createContext<ErrorContext & SuccessContext>(
   {
-    error: null as Error | null,
-    setError(_error: Error | null) {},
+    error: null as string | null,
+    setError(_error: unknown) {},
     clearError() {},
     success: null as string | null,
     setSuccess(_success: string | null) {},
@@ -28,8 +28,14 @@ export function NotificationProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [error, setError] = useState<Error | null>(null);
+  const [error, setIError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+
+  const setError = (error: unknown) => {
+    if (error === null) setIError(null);
+    else if (error instanceof Error) setIError(error.message);
+    else setIError(String(error));
+  };
 
   return (
     <NotificationContext.Provider

--- a/ui/src/components/notifications/ErrorNotification.tsx
+++ b/ui/src/components/notifications/ErrorNotification.tsx
@@ -21,8 +21,8 @@ export default function ErrorNotification() {
             </div>
             <div className="ml-3">
               <h3 className="text-red-800 text-sm font-medium">Error</h3>
-              {error && error.message && (
-                <div className="text-red-700 mt-2 text-sm">{error.message}</div>
+              {error && (
+                <div className="text-red-700 mt-2 text-sm">{error}</div>
               )}
             </div>
             <div className="ml-auto pl-10">

--- a/ui/src/utils/helpers.ts
+++ b/ui/src/utils/helpers.ts
@@ -36,3 +36,32 @@ export function addNamespaceToPath(path: string, key: string): string {
   }
   return `${namespaces}${key}${path}`;
 }
+
+type ErrorWithMessage = {
+  message: string;
+};
+
+function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as Record<string, unknown>).message === 'string'
+  );
+}
+
+function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
+  if (isErrorWithMessage(maybeError)) return maybeError;
+
+  try {
+    return new Error(JSON.stringify(maybeError));
+  } catch {
+    // fallback in case there's an error stringifying the maybeError
+    // like with circular references for example.
+    return new Error(String(maybeError));
+  }
+}
+
+export function getErrorMessage(error: unknown) {
+  return toErrorWithMessage(error).message;
+}


### PR DESCRIPTION
Fixes: FLI-509

- don't allow navigating to `/flag/evaluation` for boolean flags
- also redoes our ErrorNotification/context so that it can accept either `Error` or `string`s and display the string message

![2023-07-28 09 47 51](https://github.com/flipt-io/flipt/assets/209477/ce852357-4bce-4125-b5cc-fd39c2993503)
