### PR TITLE
chore(rollouts): account for segments without constraints

### DIFF
--- a/build/testing/integration/readonly/readonly_test.go
+++ b/build/testing/integration/readonly/readonly_test.go
@@ -101,7 +101,7 @@ func TestReadOnly(t *testing.T) {
 				NamespaceKey: namespace,
 			})
 			require.NoError(t, err)
-			require.Len(t, flags.Flags, 52)
+			require.Len(t, flags.Flags, 53)
 
 			flag := flags.Flags[0]
 			assert.Equal(t, namespace, flag.NamespaceKey)
@@ -128,8 +128,8 @@ func TestReadOnly(t *testing.T) {
 					require.NoError(t, err)
 
 					if flags.NextPageToken == "" {
-						// ensure last page contains 2 entries (boolean and disabled)
-						assert.Len(t, flags.Flags, 2)
+						// ensure last page contains 3 entries (boolean and disabled)
+						assert.Len(t, flags.Flags, 3)
 
 						found = append(found, flags.Flags...)
 
@@ -144,7 +144,7 @@ func TestReadOnly(t *testing.T) {
 					nextPage = flags.NextPageToken
 				}
 
-				require.Len(t, found, 52)
+				require.Len(t, found, 53)
 			})
 		})
 
@@ -189,7 +189,7 @@ func TestReadOnly(t *testing.T) {
 			})
 
 			require.NoError(t, err)
-			require.Len(t, segments.Segments, 50)
+			require.Len(t, segments.Segments, 51)
 
 			t.Run("Paginated (page size 10)", func(t *testing.T) {
 				var (
@@ -205,18 +205,20 @@ func TestReadOnly(t *testing.T) {
 					require.NoError(t, err)
 
 					// ensure each page is of length 10
-					assert.Len(t, segments.Segments, 10)
 
 					found = append(found, segments.Segments...)
 
 					if segments.NextPageToken == "" {
+						assert.Len(t, segments.Segments, 1)
 						break
 					}
+
+					assert.Len(t, segments.Segments, 10)
 
 					nextPage = segments.NextPageToken
 				}
 
-				require.Len(t, found, 50)
+				require.Len(t, found, 51)
 			})
 		})
 
@@ -523,6 +525,18 @@ func TestReadOnly(t *testing.T) {
 						Context: map[string]string{
 							"in_segment": "segment_001",
 						},
+					})
+
+					require.NoError(t, err)
+
+					assert.Equal(t, evaluation.EvaluationReason_MATCH_EVALUATION_REASON, result.Reason)
+					assert.True(t, result.Enabled, "segment evaluation value should be true")
+				})
+
+				t.Run("segment with no constraints", func(t *testing.T) {
+					result, err := sdk.Evaluation().Boolean(ctx, &evaluation.EvaluationRequest{
+						NamespaceKey: namespace,
+						FlagKey:      "flag_boolean_no_constraints",
 					})
 
 					require.NoError(t, err)

--- a/build/testing/integration/readonly/testdata/default.yaml
+++ b/build/testing/integration/readonly/testdata/default.yaml
@@ -15579,6 +15579,16 @@ flags:
   type: VARIANT_FLAG_TYPE
   description: Disabled Flag Description
   enabled: false
+- key: flag_boolean_no_constraints
+  name: FLAG_NO_CONSTRAINTS
+  type: BOOLEAN_FLAG_TYPE
+  description: Flag Boolean no segment constraints
+  enabled: false
+  rollouts:
+  - description: enabled for segment_no_constraints
+    segment:
+      key: segment_no_constraints
+      value: true
 segments:
 - key: segment_001
   name: SEGMENT_001
@@ -16230,3 +16240,6 @@ segments:
     operator: eq
     value: segment_050
   match_type: ALL_MATCH_TYPE
+- key: segment_no_constraints
+  name: SEGMENT_NO_CONSTRAINTS
+  description: Some Segment Description

--- a/build/testing/integration/readonly/testdata/production.yaml
+++ b/build/testing/integration/readonly/testdata/production.yaml
@@ -15580,6 +15580,16 @@ flags:
   type: VARIANT_FLAG_TYPE
   description: Disabled Flag Description
   enabled: false
+- key: flag_boolean_no_constraints
+  name: FLAG_NO_CONSTRAINTS
+  type: BOOLEAN_FLAG_TYPE
+  description: Flag Boolean no segment constraints
+  enabled: false
+  rollouts:
+  - description: enabled for segment_no_constraints
+    segment:
+      key: segment_no_constraints
+      value: true
 segments:
 - key: segment_001
   name: SEGMENT_001
@@ -16231,3 +16241,6 @@ segments:
     operator: eq
     value: segment_050
   match_type: ALL_MATCH_TYPE
+- key: segment_no_constraints
+  name: SEGMENT_NO_CONSTRAINTS
+  description: Some Segment Description

--- a/internal/storage/sql/evaluation_test.go
+++ b/internal/storage/sql/evaluation_test.go
@@ -639,16 +639,6 @@ func (s *DBTestSuite) TestGetEvaluationRollouts() {
 
 	require.NoError(t, err)
 
-	_, err = s.store.CreateConstraint(context.TODO(), &flipt.CreateConstraintRequest{
-		SegmentKey: segment.Key,
-		Type:       flipt.ComparisonType_STRING_COMPARISON_TYPE,
-		Property:   "foo",
-		Operator:   "EQ",
-		Value:      "bar",
-	})
-
-	require.NoError(t, err)
-
 	_, err = s.store.CreateRollout(context.TODO(), &flipt.CreateRolloutRequest{
 		FlagKey: flag.Key,
 		Rank:    1,


### PR DESCRIPTION
Add logic to account for segments without constraints. For rules, segments without constraints result in a match during evaluation. This PR does the following:

- Uses a `LEFT JOIN` instead of a `JOIN` in the query to get segments that do not have constraints out of the db
- Writes unit/integration tests to validate that the behavior is working