### PR TITLE
fix(auth/middleware): only enforce email matches on OIDC method tokens 

### DIFF
--- a/internal/server/auth/middleware.go
+++ b/internal/server/auth/middleware.go
@@ -148,6 +148,11 @@ func EmailMatchingInterceptor(logger *zap.Logger, rgxs []*regexp.Regexp) grpc.Un
 			return handler(ctx, req)
 		}
 
+		// this mechanism only applies to authentications created using OIDC
+		if auth.Method != authrpc.Method_METHOD_OIDC {
+			return handler(ctx, req)
+		}
+
 		email, ok := auth.Metadata["io.flipt.auth.oidc.email"]
 		if !ok {
 			logger.Debug("no email provided but required for auth")

--- a/internal/server/auth/middleware_test.go
+++ b/internal/server/auth/middleware_test.go
@@ -150,7 +150,7 @@ func TestEmailMatchingInterceptor(t *testing.T) {
 	clientToken, storedAuth, err := authenticator.CreateAuthentication(
 		context.TODO(),
 		&auth.CreateAuthenticationRequest{
-			Method: authrpc.Method_METHOD_TOKEN,
+			Method: authrpc.Method_METHOD_OIDC,
 			Metadata: map[string]string{
 				"io.flipt.auth.oidc.email": "foo@flipt.io",
 			},
@@ -161,7 +161,17 @@ func TestEmailMatchingInterceptor(t *testing.T) {
 	nonEmailClientToken, nonEmailStoredAuth, err := authenticator.CreateAuthentication(
 		context.TODO(),
 		&auth.CreateAuthenticationRequest{
-			Method: authrpc.Method_METHOD_TOKEN,
+			Method:   authrpc.Method_METHOD_OIDC,
+			Metadata: map[string]string{},
+		},
+	)
+	require.NoError(t, err)
+
+	staticClientToken, staticStoreAuth, err := authenticator.CreateAuthentication(
+		context.TODO(),
+		&auth.CreateAuthenticationRequest{
+			Method:   authrpc.Method_METHOD_TOKEN,
+			Metadata: map[string]string{},
 		},
 	)
 	require.NoError(t, err)
@@ -193,6 +203,16 @@ func TestEmailMatchingInterceptor(t *testing.T) {
 				"^.*@flipt.io$",
 			},
 			auth: storedAuth,
+		},
+		{
+			name: "successful token was not generated via OIDC method",
+			metadata: metadata.MD{
+				"Authorization": []string{"Bearer " + staticClientToken},
+			},
+			emailMatches: []string{
+				"foo@flipt.io",
+			},
+			auth: staticStoreAuth,
 		},
 		{
 			name: "email does not match (regular string)",


### PR DESCRIPTION
Fixes an issue where when OIDC is used in conjunction with other authentication methods (Token, Kubernetes etc.) with the new email matches feature, we end up inadvertantly rejecting all non-OIDC method generated tokens.

The email matches feature should only be enforced on authentication tokens generated with the OIDC method.

From the newly added test around this behaviour:
```
    --- FAIL: TestEmailMatchingInterceptor/successful_token_was_not_generated_via_OIDC_method (0.00s)
        logger.go:130: 2023-08-01T14:41:44.690Z	DEBUG	no email provided but required for auth
        middleware_test.go:281: 
            	Error Trace:	/src/internal/server/auth/middleware_test.go:281
            	Error:      	Not equal: 
            	            	expected: <nil>(<nil>)
            	            	actual  : *status.Error(&status.Error{s:(*status.Status)(0xc0000143d8)})
            	Test:       	TestEmailMatchingInterceptor/successful_token_was_not_generated_via_OIDC_method
```
This is a authentication token created as a static token failing because of email matches which only should apply to client token generated with the OIDC method.