### PR TITLE
feat(config/flipt.schema.*): add oidc provider scopes property

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -81,6 +81,7 @@ import "strings"
 			client_id?:        string
 			client_secret?:    string
 			redirect_address?: string
+			scopes?:           [...string]
 		}
 	}
 

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -220,7 +220,8 @@
             "issuer_url": { "type": "string" },
             "client_id": { "type": "string" },
             "client_secret": { "type": "string" },
-            "redirect_address": { "type": "string" }
+            "redirect_address": { "type": "string" },
+            "scopes": { "type": "array", "items": { "type": "string" } }
           },
           "additionalProperties": false
         }


### PR DESCRIPTION
## Description
This PR adds an optional string array field definition for the `authentication.methods.oidc.providers.[provider].scopes` option to the JSON and CUE schemas for the flipt configuration file.

## Notes
I wasn't sure if it was preferable to just use a loose string type, or if a specific enum with the standard OIDC claims of `email`, `profile` would be more correct. Let me know if you'd prefer it as an enum instead and I can update.

## On CUE
I have no experience with CUE schemas or idea of how to go about validating my change. I read up on the docs and this seemed like the right change there. Apologies if this is making more work than it's resolving 😆. 

Thanks for the warm response!

## Related Issue
Fixes #1944 