### PR TITLE
chore: fix segment adding for rollouts

### DIFF
--- a/ui/screenshot/concepts/distributions.js
+++ b/ui/screenshot/concepts/distributions.js
@@ -3,6 +3,6 @@ const { capture } = require('../../screenshot.js');
 (async () => {
   await capture('concepts', 'distributions', async (page) => {
     await page.getByRole('link', { name: 'colorscheme' }).click();
-    await page.getByRole('link', { name: 'Evaluation' }).click(); 
+    await page.getByRole('link', { name: 'Evaluation' }).click();
   });
 })();

--- a/ui/screenshot/concepts/evaluation.js
+++ b/ui/screenshot/concepts/evaluation.js
@@ -4,9 +4,13 @@ const { capture } = require('../../screenshot.js');
   await capture('concepts', 'evaluation', async (page) => {
     await page.getByRole('link', { name: 'Console' }).click();
     await page.locator('#flagKey-select-button').click();
-    await page.getByRole('option', { name: 'colorscheme Color Scheme' }).click();
+    await page
+      .getByRole('option', { name: 'colorscheme Color Scheme' })
+      .click();
     await page.getByPlaceholder('{}').click();
-    await page.getByPlaceholder('{}').fill('{\n\t"finished_onboarding":"false"\n}');
+    await page
+      .getByPlaceholder('{}')
+      .fill('{\n\t"finished_onboarding":"false"\n}');
     await page.getByRole('button', { name: 'Evaluate', exact: true }).click();
   });
 })();

--- a/ui/screenshot/concepts/rules.js
+++ b/ui/screenshot/concepts/rules.js
@@ -3,6 +3,6 @@ const { capture } = require('../../screenshot.js');
 (async () => {
   await capture('concepts', 'rules', async (page) => {
     await page.getByRole('link', { name: 'colorscheme' }).click();
-    await page.getByRole('link', { name: 'Evaluation' }).click(); 
+    await page.getByRole('link', { name: 'Evaluation' }).click();
   });
 })();

--- a/ui/screenshot/extra/darkmode.js
+++ b/ui/screenshot/extra/darkmode.js
@@ -4,7 +4,9 @@ const { capture } = require('../../screenshot.js');
   await capture('extra', 'darkmode', async (page) => {
     await page.getByRole('link', { name: 'Settings' }).click();
     await page.getByLabel('Theme').selectOption('dark');
-    await page.getByLabel('UTC TimezoneDisplay dates and times in UTC timezone').click();
+    await page
+      .getByLabel('UTC TimezoneDisplay dates and times in UTC timezone')
+      .click();
     await page.getByRole('link', { name: 'Flags' }).click();
   });
 })();

--- a/ui/src/components/rollouts/forms/RolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/RolloutForm.tsx
@@ -184,6 +184,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                               className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
                               onChange={() => {
                                 setRolloutRuleType(rolloutRule.id);
+                                formik.setFieldValue('type', rolloutRule.id);
                               }}
                               checked={rolloutRule.id === rolloutRuleType}
                               value={rolloutRule.id}


### PR DESCRIPTION
Fixes disabling the button when you choose `Segment` rollout type and there are no segments chosen. Also ran:
```
$ npm run format
```