### PR TITLE
fix: store namespace in localstorage

### DIFF
--- a/ui/src/app/Layout.tsx
+++ b/ui/src/app/Layout.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Navigate, Outlet } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import {
+  Navigate,
+  Outlet,
+  useLocation,
+  useNavigate,
+  useParams
+} from 'react-router-dom';
 import Footer from '~/components/Footer';
 import Header from '~/components/Header';
 import { NotificationProvider } from '~/components/NotificationProvider';
@@ -9,13 +16,36 @@ import Sidebar from '~/components/Sidebar';
 import { useSession } from '~/data/hooks/session';
 import { useAppDispatch } from '~/data/hooks/store';
 import { fetchConfigAsync, fetchInfoAsync } from './meta/metaSlice';
-import { fetchNamespacesAsync } from './namespaces/namespacesSlice';
+import {
+  currentNamespaceChanged,
+  fetchNamespacesAsync,
+  selectCurrentNamespace
+} from './namespaces/namespacesSlice';
 
 function InnerLayout() {
   const { session } = useSession();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const dispatch = useAppDispatch();
+
+  const { namespaceKey } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const currentNamespace = useSelector(selectCurrentNamespace);
+
+  useEffect(() => {
+    if (!namespaceKey) {
+      return;
+    }
+
+    // if the namespaceKey in the url is not the same as the currentNamespace, then
+    // dispatch the currentNamespaceChanged action to update the currentNamespace in the store
+    // this allows the namespace to be changed by the url and not just the namespace dropdown,
+    // which is required for 'deep' linking
+    if (currentNamespace?.key !== namespaceKey) {
+      dispatch(currentNamespaceChanged({ key: namespaceKey }));
+    }
+  }, [namespaceKey, currentNamespace, dispatch, navigate, location.pathname]);
 
   useEffect(() => {
     dispatch(fetchNamespacesAsync());

--- a/ui/src/app/flags/Flag.tsx
+++ b/ui/src/app/flags/Flag.tsx
@@ -53,6 +53,7 @@ export default function Flag() {
     getFlag(namespace.key, flagKey)
       .then((flag: IFlag) => {
         setFlag(flag);
+        clearError();
       })
       .catch((err) => {
         setError(err);

--- a/ui/src/app/namespaces/namespacesSlice.ts
+++ b/ui/src/app/namespaces/namespacesSlice.ts
@@ -14,6 +14,8 @@ import { RootState } from '~/store';
 import { LoadingStatus } from '~/types/Meta';
 import { INamespace, INamespaceBase } from '~/types/Namespace';
 
+const namespaceKey = 'namespace';
+
 interface INamespacesState {
   namespaces: { [key: string]: INamespace };
   status: LoadingStatus;
@@ -24,7 +26,7 @@ interface INamespacesState {
 const initialState: INamespacesState = {
   namespaces: {},
   status: LoadingStatus.IDLE,
-  currentNamespace: 'default',
+  currentNamespace: localStorage.getItem(namespaceKey) || 'default',
   error: undefined
 };
 
@@ -85,7 +87,7 @@ export const selectNamespaces = createSelector(
 export const selectCurrentNamespace = createSelector(
   [
     (state: RootState) => {
-      if (state.namespaces.status === LoadingStatus.SUCCEEDED) {
+      if (state.namespaces.namespaces[state.namespaces.currentNamespace]) {
         return state.namespaces.namespaces[state.namespaces.currentNamespace];
       }
       return { key: 'default', name: 'Default', description: '' } as INamespace;

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -78,6 +78,7 @@ export default function Segment() {
     getSegment(namespace.key, segmentKey)
       .then((segment: ISegment) => {
         setSegment(segment);
+        clearError();
       })
       .catch((err) => {
         setError(err);

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -7,10 +7,12 @@ import {
 import { metaSlice } from './app/meta/metaSlice';
 import { namespacesSlice } from './app/namespaces/namespacesSlice';
 import { preferencesSlice } from './app/preferences/preferencesSlice';
+import { LoadingStatus } from './types/Meta';
 
 const listenerMiddleware = createListenerMiddleware();
 
 const preferencesKey = 'preferences';
+const namespaceKey = 'namespace';
 
 listenerMiddleware.startListening({
   matcher: isAnyOf(
@@ -26,13 +28,32 @@ listenerMiddleware.startListening({
   }
 });
 
+listenerMiddleware.startListening({
+  matcher: isAnyOf(namespacesSlice.actions.currentNamespaceChanged),
+  effect: (_action, api) => {
+    // save to local storage
+    localStorage.setItem(
+      namespaceKey,
+      (api.getState() as RootState).namespaces.currentNamespace
+    );
+  }
+});
+
 const preferencesState = JSON.parse(
   localStorage.getItem(preferencesKey) || '{}'
 );
 
+const currentNamespace = localStorage.getItem(namespaceKey) || 'default';
+
 export const store = configureStore({
   preloadedState: {
-    preferences: preferencesState
+    preferences: preferencesState,
+    namespaces: {
+      namespaces: {},
+      status: LoadingStatus.IDLE,
+      currentNamespace,
+      error: undefined
+    }
   },
   reducer: {
     namespaces: namespacesSlice.reducer,


### PR DESCRIPTION
Fixes: #1942 

- persists current namespace in browser localStorage so its consistent across tabs
- also allows sharing direct URLs as now the namespace is loaded from URL if it does not match what is in the store (and then updates the value in the store also)

![2023-08-04 10 55 42](https://github.com/flipt-io/flipt/assets/209477/6afdd6d8-a441-4093-ae9b-32e9dc196d98)
