### PR TITLE
fix: dont clear all localstorage on 401

### DIFF
--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -13,6 +13,7 @@ const authURL = '/auth/v1';
 const evaluateURL = '/evaluate/v1';
 const metaURL = '/meta';
 const csrfTokenHeaderKey = 'x-csrf-token';
+const sessionKey = 'session';
 
 export class APIError extends Error {
   status: number;
@@ -47,7 +48,8 @@ export async function request(method: string, uri: string, body?: any) {
   const res = await fetch(uri, req);
   if (!res.ok) {
     if (res.status === 401) {
-      window.localStorage.clear();
+      window.localStorage.removeItem(csrfTokenHeaderKey);
+      window.localStorage.removeItem(sessionKey);
       window.location.reload();
     }
 


### PR DESCRIPTION
Fixes: #1933 

Previously we were clearing the entire browser localStorage for our app on 401/logout. This was also causing user prefs like 'theme' to be cleared.

This fixes it to only clear the session related values on 401

![2023-08-04 11 40 14](https://github.com/flipt-io/flipt/assets/209477/7bdd1413-8f05-40bc-87fc-329ffe7a61a1)
