### PR TITLE
fix(ui): rule form inputs in darkmode

### DIFF
--- a/ui/src/components/rules/forms/QuickEditRuleForm.tsx
+++ b/ui/src/components/rules/forms/QuickEditRuleForm.tsx
@@ -309,7 +309,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                                       <Field
                                         key={index}
                                         type="number"
-                                        className="border-gray-300 block w-full rounded-md pl-7 pr-12 shadow-sm focus:border-violet-300 focus:ring-violet-300 sm:text-sm"
+                                        className="text-gray-900 bg-gray-50 border-gray-300 block w-full rounded-md pl-7 pr-12 shadow-sm focus:border-violet-300 focus:ring-violet-300 sm:text-sm"
                                         value={dist.distribution.rollout}
                                         name={`rollouts.[${index}].distribution.rollout`}
                                         // eslint-disable-next-line react/no-unknown-property


### PR DESCRIPTION
Fixes: FLI-543

## Before

![CleanShot 2023-08-05 at 20 16 01](https://github.com/flipt-io/flipt/assets/209477/5b02d1b4-5acc-4d64-8ae2-8b9b86c1e5b6)

## After
<img width="541" alt="CleanShot 2023-08-07 at 09 47 57@2x" src="https://github.com/flipt-io/flipt/assets/209477/256a3019-529b-4443-8428-82d35469f495">

