### PR TITLE
feat: Force readonly

### DIFF
--- a/config/local.yml
+++ b/config/local.yml
@@ -31,5 +31,12 @@ cors:
 #   http_port: 8080
 #   grpc_port: 9000
 
+experimental:
+  filesystem_storage:
+    enabled: true
+
+storage:
+  readOnly: true
+
 db:
   url: file:flipt.db

--- a/config/local.yml
+++ b/config/local.yml
@@ -31,12 +31,5 @@ cors:
 #   http_port: 8080
 #   grpc_port: 9000
 
-experimental:
-  filesystem_storage:
-    enabled: true
-
-storage:
-  readOnly: true
-
 db:
   url: file:flipt.db

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -39,11 +39,11 @@ func authenticationGRPC(
 		return nil
 	}
 
-	// NOTE: we skip attempting to connect to any database in the situation that either the git or local
+	// NOTE: we skip attempting to connect to any database in the situation that either the git, local, or object
 	// FS backends are configured.
 	// All that is required to establish a connection for authentication is to either make auth required
 	// or configure at-least one authentication method (e.g. enable token method).
-	if !cfg.Authentication.Enabled() && (cfg.Storage.Type == config.GitStorageType || cfg.Storage.Type == config.LocalStorageType) {
+	if !cfg.Authentication.Enabled() && (cfg.Storage.Type != config.DatabaseStorageType) {
 		return grpcRegisterers{
 			public.NewServer(logger, cfg.Authentication),
 			auth.NewServer(logger, storageauthmemory.NewStore()),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -691,6 +691,11 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			name:    "storage readonly config invalid",
+			path:    "./testdata/storage/invalid_readonly.yml",
+			wantErr: errors.New("setting read only mode is only supported with database storage"),
+		},
+		{
 			name:    "s3 config invalid",
 			path:    "./testdata/storage/s3_bucket_missing.yml",
 			wantErr: errors.New("s3 bucket must be specified"),

--- a/internal/config/testdata/storage/invalid_readonly.yml
+++ b/internal/config/testdata/storage/invalid_readonly.yml
@@ -1,0 +1,13 @@
+experimental:
+  filesystem_storage:
+    enabled: true
+storage:
+  type: object
+  readOnly: false
+  object:
+    type: s3
+    s3:
+      bucket: "testbucket"
+      prefix: "prefix"
+      region: "region"
+      poll_interval: "5m"

--- a/ui/src/app/meta/metaSlice.ts
+++ b/ui/src/app/meta/metaSlice.ts
@@ -6,7 +6,6 @@ import { IConfig, IInfo, StorageType } from '~/types/Meta';
 interface IMetaSlice {
   info: IInfo;
   config: IConfig;
-  readonly: boolean;
 }
 
 const initialState: IMetaSlice = {
@@ -22,10 +21,10 @@ const initialState: IMetaSlice = {
   },
   config: {
     storage: {
-      type: StorageType.DATABASE
+      type: StorageType.DATABASE,
+      readOnly: false
     }
-  },
-  readonly: false
+  }
 };
 
 export const metaSlice = createSlice({
@@ -39,16 +38,19 @@ export const metaSlice = createSlice({
       })
       .addCase(fetchConfigAsync.fulfilled, (state, action) => {
         state.config = action.payload;
-        state.readonly =
-          action.payload.storage?.type &&
-          action.payload.storage?.type !== StorageType.DATABASE;
+        if (action.payload.storage?.readOnly === undefined) {
+          state.config.storage.readOnly =
+            action.payload.storage?.type &&
+            action.payload.storage?.type !== StorageType.DATABASE;
+        }
       });
   }
 });
 
 export const selectInfo = (state: { meta: IMetaSlice }) => state.meta.info;
+export const selectConfig = (state: { meta: IMetaSlice }) => state.meta.config;
 export const selectReadonly = (state: { meta: IMetaSlice }) =>
-  state.meta.readonly;
+  state.meta.config.storage.readOnly;
 
 export const fetchInfoAsync = createAsyncThunk('meta/fetchInfo', async () => {
   const response = await getInfo();

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -1,7 +1,14 @@
+import {
+  CircleStackIcon,
+  CloudIcon,
+  CodeBracketIcon,
+  DocumentIcon
+} from '@heroicons/react/20/solid';
 import { Bars3BottomLeftIcon } from '@heroicons/react/24/outline';
 import { useSelector } from 'react-redux';
-import { selectInfo, selectReadonly } from '~/app/meta/metaSlice';
+import { selectConfig, selectInfo, selectReadonly } from '~/app/meta/metaSlice';
 import { useSession } from '~/data/hooks/session';
+import { Icon } from '~/types/Icon';
 import Notifications from './header/Notifications';
 import UserProfile from './header/UserProfile';
 
@@ -9,13 +16,25 @@ type HeaderProps = {
   setSidebarOpen: (sidebarOpen: boolean) => void;
 };
 
+const storageTypes: Record<string, Icon> = {
+  local: DocumentIcon,
+  object: CloudIcon,
+  git: CodeBracketIcon,
+  database: CircleStackIcon
+};
+
 export default function Header(props: HeaderProps) {
   const { setSidebarOpen } = props;
 
   const info = useSelector(selectInfo);
+  const config = useSelector(selectConfig);
   const readOnly = useSelector(selectReadonly);
 
   const { session } = useSession();
+
+  const StorageIcon = config.storage?.type
+    ? storageTypes[config.storage?.type]
+    : undefined;
 
   return (
     <div className="bg-violet-400 sticky top-0 z-10 flex h-16 flex-shrink-0">
@@ -33,14 +52,16 @@ export default function Header(props: HeaderProps) {
         <div className="ml-4 flex items-center space-x-1.5 md:ml-6">
           {/* read-only mode */}
           {readOnly && (
-            <span className="nightwind-prevent bg-violet-200 inline-flex items-center gap-x-1.5 rounded-full px-3 py-1 text-xs font-medium text-violet-950">
-              <svg
-                className="h-1.5 w-1.5 fill-orange-400"
-                viewBox="0 0 6 6"
-                aria-hidden="true"
-              >
-                <circle cx={3} cy={3} r={3} />
-              </svg>
+            <span
+              className="nightwind-prevent text-gray-900 bg-violet-200 inline-flex items-center gap-x-1.5 rounded-lg px-3 py-1 text-xs font-medium"
+              title={`Backed by ${config.storage?.type || 'unknown'} storage`}
+            >
+              {StorageIcon && (
+                <StorageIcon
+                  className="h-3 w-3 fill-violet-400"
+                  aria-hidden="true"
+                />
+              )}
               Read-Only
             </span>
           )}

--- a/ui/src/types/Meta.ts
+++ b/ui/src/types/Meta.ts
@@ -11,21 +11,18 @@ export interface IInfo {
 
 export interface IStorage {
   type: StorageType;
+  readOnly?: boolean;
 }
-
-// export interface IAuthentication {
-//   required?: boolean;
-// }
 
 export interface IConfig {
   storage: IStorage;
-  //authentication: IAuthentication;
 }
 
 export enum StorageType {
   DATABASE = 'database',
   GIT = 'git',
-  LOCAL = 'local'
+  LOCAL = 'local',
+  OBJECT = 'object'
 }
 
 export enum LoadingStatus {


### PR DESCRIPTION
Gives us (and operators) to force the UI into read-only mode by setting the following:

```yaml
experimental:
  filesystem_storage:
    enabled: true

storage:
  readOnly: true
```

In this next release we will be 'graduating' filesystem storage, so the `experimental` bit will not be required.

The goal of this feature is two fold:

1. To enable devs to be able to more easily test the UI in readonly mode (without requiring us to configure a readonly storage mode)
2. To allow operators to put Flipt in readonly mode even if backed by a database

For 2., more work will need to be done either at the API or ideally storage layer to reject all write requests, as currently this change only affects the UI so users could still make API requests or modify data via import/export even if `storage: readonly: true`


This also modifies the badge in the UI to show an icon based on what storage mode is in use:

- database
- local
- git
- object

(images in order)

![CleanShot 2023-08-09 at 09 33 04](https://github.com/flipt-io/flipt/assets/209477/b1982365-0be8-4c25-ac94-1ab7f2dd5677)
![CleanShot 2023-08-09 at 09 29 42](https://github.com/flipt-io/flipt/assets/209477/e97dae9d-0b68-46f5-87fc-8ee9baf149f6)
![CleanShot 2023-08-09 at 09 29 26](https://github.com/flipt-io/flipt/assets/209477/89b93424-66e1-454b-9196-713e4c4f68b0)
![CleanShot 2023-08-09 at 09 29 09](https://github.com/flipt-io/flipt/assets/209477/584a7229-6a6d-4e02-8be0-efe8bac890ea)
