### PR TITLE
feat(rules/rollouts): hide or and and based on segment keys length, and UX around adding segments

### DIFF
--- a/ui/src/components/forms/SegmentsPicker.tsx
+++ b/ui/src/components/forms/SegmentsPicker.tsx
@@ -1,5 +1,5 @@
 import { MinusSmallIcon, PlusSmallIcon } from '@heroicons/react/24/outline';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 import Combobox from '~/components/forms/Combobox';
 import { FilterableSegment, ISegment } from '~/types/Segment';
@@ -7,7 +7,6 @@ import { truncateKey } from '~/utils/helpers';
 
 type SegmentPickerProps = {
   readonly?: boolean;
-  editMode?: boolean;
   segments: ISegment[];
   selectedSegments: FilterableSegment[];
   segmentAdd: (segment: FilterableSegment) => void;
@@ -17,7 +16,6 @@ type SegmentPickerProps = {
 
 export default function SegmentsPicker({
   readonly = false,
-  editMode = false,
   segments,
   selectedSegments: parentSegments,
   segmentAdd,
@@ -28,7 +26,11 @@ export default function SegmentsPicker({
     new Set<string>(parentSegments.map((s) => s.key))
   );
 
-  const [editing, setEditing] = useState<boolean>(editMode);
+  const [editing, setEditing] = useState<boolean>(true);
+
+  useEffect(() => {
+    setEditing(true);
+  }, [parentSegments]);
 
   const handleSegmentRemove = (index: number) => {
     const filterableSegment = parentSegments[index];
@@ -37,7 +39,7 @@ export default function SegmentsPicker({
     segmentsSet.current!.delete(filterableSegment.key);
     segmentRemove(index);
 
-    if (editMode && parentSegments.length == 1) {
+    if (editing && parentSegments.length == 1) {
       setEditing(true);
     }
   };

--- a/ui/src/components/rollouts/forms/EditRolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/EditRolloutForm.tsx
@@ -287,7 +287,6 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                         render={(arrayHelpers) => (
                           <SegmentsPicker
                             readonly={readOnly}
-                            editMode
                             segments={segments}
                             segmentAdd={(segment: FilterableSegment) =>
                               arrayHelpers.push(segment)
@@ -305,49 +304,50 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                       />
                     </div>
                     <div className="mt-6 flex space-x-8">
-                      {segmentOperators.map((segmentOperator, index) => (
-                        <div className="flex space-x-2" key={index}>
-                          <div>
-                            <input
-                              id={segmentOperator.id}
-                              name="operator"
-                              type="radio"
-                              className={twMerge(
-                                `text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400 ${
-                                  readOnly ? 'cursor-not-allowed' : undefined
-                                }`
-                              )}
-                              onChange={() => {
-                                formik.setFieldValue(
-                                  'operator',
-                                  segmentOperator.id
-                                );
-                              }}
-                              checked={
-                                segmentOperator.id === formik.values.operator
-                              }
-                              value={segmentOperator.id}
-                              disabled={readOnly}
-                              title={
-                                readOnly
-                                  ? 'Not allowed in Read-Only mode'
-                                  : undefined
-                              }
-                            />
+                      {formik.values.segmentKeys.length > 1 &&
+                        segmentOperators.map((segmentOperator, index) => (
+                          <div className="flex space-x-2" key={index}>
+                            <div>
+                              <input
+                                id={segmentOperator.id}
+                                name="operator"
+                                type="radio"
+                                className={twMerge(
+                                  `text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400 ${
+                                    readOnly ? 'cursor-not-allowed' : undefined
+                                  }`
+                                )}
+                                onChange={() => {
+                                  formik.setFieldValue(
+                                    'operator',
+                                    segmentOperator.id
+                                  );
+                                }}
+                                checked={
+                                  segmentOperator.id === formik.values.operator
+                                }
+                                value={segmentOperator.id}
+                                disabled={readOnly}
+                                title={
+                                  readOnly
+                                    ? 'Not allowed in Read-Only mode'
+                                    : undefined
+                                }
+                              />
+                            </div>
+                            <div>
+                              <label
+                                htmlFor={segmentOperator.id}
+                                className="text-gray-700 block text-sm"
+                              >
+                                {segmentOperator.name}{' '}
+                                <span className="font-light">
+                                  {segmentOperator.meta}
+                                </span>
+                              </label>
+                            </div>
                           </div>
-                          <div>
-                            <label
-                              htmlFor={segmentOperator.id}
-                              className="text-gray-700 block text-sm"
-                            >
-                              {segmentOperator.name}{' '}
-                              <span className="font-light">
-                                {segmentOperator.meta}
-                              </span>
-                            </label>
-                          </div>
-                        </div>
-                      ))}
+                        ))}
                     </div>
                   </div>
                 </div>

--- a/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
@@ -193,7 +193,6 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
                         render={(arrayHelpers) => (
                           <SegmentsPicker
                             readonly={readOnly}
-                            editMode
                             segments={segments}
                             segmentAdd={(segment: FilterableSegment) =>
                               arrayHelpers.push(segment)
@@ -211,49 +210,50 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
                       />
                     </div>
                     <div className="mt-6 flex space-x-8">
-                      {segmentOperators.map((segmentOperator, index) => (
-                        <div className="flex space-x-2" key={index}>
-                          <div>
-                            <input
-                              id={segmentOperator.id}
-                              name="operator"
-                              type="radio"
-                              className={twMerge(
-                                `text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400 ${
-                                  readOnly ? 'cursor-not-allowed' : undefined
-                                }`
-                              )}
-                              onChange={() => {
-                                formik.setFieldValue(
-                                  'operator',
-                                  segmentOperator.id
-                                );
-                              }}
-                              checked={
-                                segmentOperator.id === formik.values.operator
-                              }
-                              value={segmentOperator.id}
-                              disabled={readOnly}
-                              title={
-                                readOnly
-                                  ? 'Not allowed in Read-Only mode'
-                                  : undefined
-                              }
-                            />
+                      {formik.values.segmentKeys.length > 1 &&
+                        segmentOperators.map((segmentOperator, index) => (
+                          <div className="flex space-x-2" key={index}>
+                            <div>
+                              <input
+                                id={segmentOperator.id}
+                                name="operator"
+                                type="radio"
+                                className={twMerge(
+                                  `text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400 ${
+                                    readOnly ? 'cursor-not-allowed' : undefined
+                                  }`
+                                )}
+                                onChange={() => {
+                                  formik.setFieldValue(
+                                    'operator',
+                                    segmentOperator.id
+                                  );
+                                }}
+                                checked={
+                                  segmentOperator.id === formik.values.operator
+                                }
+                                value={segmentOperator.id}
+                                disabled={readOnly}
+                                title={
+                                  readOnly
+                                    ? 'Not allowed in Read-Only mode'
+                                    : undefined
+                                }
+                              />
+                            </div>
+                            <div>
+                              <label
+                                htmlFor={segmentOperator.id}
+                                className="text-gray-700 block text-sm"
+                              >
+                                {segmentOperator.name}{' '}
+                                <span className="font-light">
+                                  {segmentOperator.meta}
+                                </span>
+                              </label>
+                            </div>
                           </div>
-                          <div>
-                            <label
-                              htmlFor={segmentOperator.id}
-                              className="text-gray-700 block text-sm"
-                            >
-                              {segmentOperator.name}{' '}
-                              <span className="font-light">
-                                {segmentOperator.meta}
-                              </span>
-                            </label>
-                          </div>
-                        </div>
-                      ))}
+                        ))}
                     </div>
                   </div>
                 </div>

--- a/ui/src/components/rollouts/forms/RolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/RolloutForm.tsx
@@ -276,53 +276,58 @@ export default function RolloutForm(props: RolloutFormProps) {
                       )}
                     />
                   </div>
-                  <div>
-                    <label
-                      htmlFor="operator"
-                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
-                    >
-                      Operator
-                    </label>
-                  </div>
-                  <div>
-                    <div className="sm:col-span-2">
-                      <div className="w-48 space-y-4">
-                        {segmentOperators.map((segmentOperator, index) => (
-                          <div className="flex space-x-4" key={index}>
-                            <div>
-                              <input
-                                id={segmentOperator.id}
-                                name="operator"
-                                type="radio"
-                                className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
-                                onChange={() => {
-                                  formik.setFieldValue(
-                                    'operator',
-                                    segmentOperator.id
-                                  );
-                                }}
-                                checked={
-                                  segmentOperator.id === formik.values.operator
-                                }
-                                value={segmentOperator.id}
-                              />
-                            </div>
-                            <div className="mt-1">
-                              <label
-                                htmlFor={segmentOperator.id}
-                                className="text-gray-700 block text-sm"
-                              >
-                                {segmentOperator.name}{' '}
-                                <span className="font-light">
-                                  {segmentOperator.meta}
-                                </span>
-                              </label>
-                            </div>
-                          </div>
-                        ))}
+                  {formik.values.segmentKeys.length > 1 && (
+                    <>
+                      <div>
+                        <label
+                          htmlFor="operator"
+                          className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
+                        >
+                          Operator
+                        </label>
                       </div>
-                    </div>
-                  </div>
+                      <div>
+                        <div className="sm:col-span-2">
+                          <div className="w-48 space-y-4">
+                            {segmentOperators.map((segmentOperator, index) => (
+                              <div className="flex space-x-4" key={index}>
+                                <div>
+                                  <input
+                                    id={segmentOperator.id}
+                                    name="operator"
+                                    type="radio"
+                                    className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
+                                    onChange={() => {
+                                      formik.setFieldValue(
+                                        'operator',
+                                        segmentOperator.id
+                                      );
+                                    }}
+                                    checked={
+                                      segmentOperator.id ===
+                                      formik.values.operator
+                                    }
+                                    value={segmentOperator.id}
+                                  />
+                                </div>
+                                <div className="mt-1">
+                                  <label
+                                    htmlFor={segmentOperator.id}
+                                    className="text-gray-700 block text-sm"
+                                  >
+                                    {segmentOperator.name}{' '}
+                                    <span className="font-light">
+                                      {segmentOperator.meta}
+                                    </span>
+                                  </label>
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    </>
+                  )}
                 </div>
               )}
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">

--- a/ui/src/components/rules/forms/QuickEditRuleForm.tsx
+++ b/ui/src/components/rules/forms/QuickEditRuleForm.tsx
@@ -173,6 +173,9 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
         if (!validRollout(values.rollouts)) {
           errors.rollouts = 'Rollouts must add up to 100%';
         }
+        if (values.segmentKeys.length <= 0) {
+          errors.segmentKeys = 'Segments length must be greater than 0';
+        }
         return errors;
       }}
       onSubmit={(values, { setSubmitting }) => {
@@ -211,7 +214,6 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                         render={(arrayHelpers) => (
                           <SegmentsPicker
                             readonly={readOnly}
-                            editMode
                             segments={segments}
                             segmentAdd={(segment: FilterableSegment) =>
                               arrayHelpers.push(segment)
@@ -229,49 +231,50 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                       />
                     </div>
                     <div className="mt-6 flex space-x-8">
-                      {segmentOperators.map((segmentOperator, index) => (
-                        <div className="flex space-x-2" key={index}>
-                          <div>
-                            <input
-                              id={segmentOperator.id}
-                              name="operator"
-                              type="radio"
-                              className={twMerge(
-                                `text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400 ${
-                                  readOnly ? 'cursor-not-allowed' : undefined
-                                }`
-                              )}
-                              onChange={() => {
-                                formik.setFieldValue(
-                                  'operator',
-                                  segmentOperator.id
-                                );
-                              }}
-                              checked={
-                                segmentOperator.id === formik.values.operator
-                              }
-                              value={segmentOperator.id}
-                              disabled={readOnly}
-                              title={
-                                readOnly
-                                  ? 'Not allowed in Read-Only mode'
-                                  : undefined
-                              }
-                            />
+                      {formik.values.segmentKeys.length > 1 &&
+                        segmentOperators.map((segmentOperator, index) => (
+                          <div className="flex space-x-2" key={index}>
+                            <div>
+                              <input
+                                id={segmentOperator.id}
+                                name="operator"
+                                type="radio"
+                                className={twMerge(
+                                  `text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400 ${
+                                    readOnly ? 'cursor-not-allowed' : undefined
+                                  }`
+                                )}
+                                onChange={() => {
+                                  formik.setFieldValue(
+                                    'operator',
+                                    segmentOperator.id
+                                  );
+                                }}
+                                checked={
+                                  segmentOperator.id === formik.values.operator
+                                }
+                                value={segmentOperator.id}
+                                disabled={readOnly}
+                                title={
+                                  readOnly
+                                    ? 'Not allowed in Read-Only mode'
+                                    : undefined
+                                }
+                              />
+                            </div>
+                            <div>
+                              <label
+                                htmlFor={segmentOperator.id}
+                                className="text-gray-700 block text-sm"
+                              >
+                                {segmentOperator.name}{' '}
+                                <span className="font-light">
+                                  {segmentOperator.meta}
+                                </span>
+                              </label>
+                            </div>
                           </div>
-                          <div>
-                            <label
-                              htmlFor={segmentOperator.id}
-                              className="text-gray-700 block text-sm"
-                            >
-                              {segmentOperator.name}{' '}
-                              <span className="font-light">
-                                {segmentOperator.meta}
-                              </span>
-                            </label>
-                          </div>
-                        </div>
-                      ))}
+                        ))}
                     </div>
                   </div>
                 </div>

--- a/ui/src/components/rules/forms/RuleForm.tsx
+++ b/ui/src/components/rules/forms/RuleForm.tsx
@@ -239,53 +239,59 @@ export default function RuleForm(props: RuleFormProps) {
                       )}
                     />
                   </div>
-                  <div>
-                    <label
-                      htmlFor="operator"
-                      className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
-                    >
-                      Operator
-                    </label>
-                  </div>
-                  <div>
-                    <div className="sm:col-span-2">
-                      <div className="w-48 space-y-4">
-                        {segmentOperators.map((segmentOperator, index) => (
-                          <div className="flex space-x-4" key={index}>
-                            <div>
-                              <input
-                                id={segmentOperator.id}
-                                name="operator"
-                                type="radio"
-                                className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
-                                onChange={() => {
-                                  formik.setFieldValue(
-                                    'operator',
-                                    segmentOperator.id
-                                  );
-                                }}
-                                checked={
-                                  segmentOperator.id === formik.values.operator
-                                }
-                                value={segmentOperator.id}
-                              />
-                            </div>
-                            <div className="mt-1">
-                              <label
-                                htmlFor={segmentOperator.id}
-                                className="text-gray-700 block text-sm"
-                              >
-                                {segmentOperator.name}{' '}
-                                <span className="font-light">
-                                  {segmentOperator.meta}
-                                </span>
-                              </label>
-                            </div>
-                          </div>
-                        ))}
+                  {formik.values.segmentKeys.length > 1 && (
+                    <>
+                      <div>
+                        <label
+                          htmlFor="operator"
+                          className="text-gray-900 block text-sm font-medium sm:mt-px sm:pt-2"
+                        >
+                          Operator
+                        </label>
                       </div>
-                    </div>
-                  </div>
+                      <div>
+                        <div className="sm:col-span-2">
+                          <div className="w-48 space-y-4">
+                            {formik.values.segmentKeys.length > 1 &&
+                              segmentOperators.map((segmentOperator, index) => (
+                                <div className="flex space-x-4" key={index}>
+                                  <div>
+                                    <input
+                                      id={segmentOperator.id}
+                                      name="operator"
+                                      type="radio"
+                                      className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
+                                      onChange={() => {
+                                        formik.setFieldValue(
+                                          'operator',
+                                          segmentOperator.id
+                                        );
+                                      }}
+                                      checked={
+                                        segmentOperator.id ===
+                                        formik.values.operator
+                                      }
+                                      value={segmentOperator.id}
+                                    />
+                                  </div>
+                                  <div className="mt-1">
+                                    <label
+                                      htmlFor={segmentOperator.id}
+                                      className="text-gray-700 block text-sm"
+                                    >
+                                      {segmentOperator.name}{' '}
+                                      <span className="font-light">
+                                        {segmentOperator.meta}
+                                      </span>
+                                    </label>
+                                  </div>
+                                </div>
+                              ))}
+                          </div>
+                        </div>
+                      </div>
+                    </>
+                  )}
                 </div>
                 <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                   <div>

--- a/ui/tests/rules.spec.ts
+++ b/ui/tests/rules.spec.ts
@@ -42,7 +42,6 @@ test.describe('Rules', () => {
       await page.getByRole('button', { name: 'New Rule' }).click();
       await page.locator('#segmentKey-0-select-button').click();
       await page.getByLabel('New Rule').getByText('Test Rule').click();
-      await page.getByLabel('AND (ALL Segments)').check();
       await page.getByLabel('Multi-Variate').check();
       await page.getByRole('button', { name: 'Create' }).click();
       await expect(page.getByText('Successfully created rule')).toBeVisible();
@@ -52,8 +51,6 @@ test.describe('Rules', () => {
   test('can update rule', async ({ page }) => {
     await page.getByRole('link', { name: 'test-rule' }).click();
     await page.getByRole('link', { name: 'Evaluation' }).click();
-
-    await page.getByLabel('AND (ALL Segments)').check();
     await page
       .locator('input[name="rollouts\\.\\[0\\]\\.distribution\\.rollout"]')
       .click();


### PR DESCRIPTION
This PR addresses the two issues:
- Change UX around adding segments to always add the plus button whenever a segment is chosen
- Only show `AND` and `OR` radio buttons when you choose multiple segments


![rollout_update](https://github.com/flipt-io/flipt/assets/13950726/ec39e8fd-d61c-4608-a88e-bcd127bd60c9)
![rule-update](https://github.com/flipt-io/flipt/assets/13950726/8aca7c73-ced3-4644-a041-b377613fa20b)


Completes FLI-545
Completes FLI-546