### PR TITLE
feat(rules): Revise query for optimization

### DIFF
--- a/internal/storage/sql/common/evaluation.go
+++ b/internal/storage/sql/common/evaluation.go
@@ -25,6 +25,12 @@ func (s *Store) GetEvaluationRules(ctx context.Context, namespaceKey, flagKey st
 		return nil, err
 	}
 
+	defer func() {
+		if cerr := ruleMetaRows.Close(); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
 	type RuleMeta struct {
 		ID              string
 		Rank            int32
@@ -181,7 +187,7 @@ func (s *Store) GetEvaluationRules(ctx context.Context, namespaceKey, flagKey st
 		}
 	}
 
-	sort.Slice(rules[:], func(i, j int) bool {
+	sort.Slice(rules, func(i, j int) bool {
 		return rules[i].Rank < rules[j].Rank
 	})
 

--- a/internal/storage/sql/common/evaluation.go
+++ b/internal/storage/sql/common/evaluation.go
@@ -19,7 +19,6 @@ func (s *Store) GetEvaluationRules(ctx context.Context, namespaceKey, flagKey st
 		Select("id, rank, segment_operator").
 		From("rules").
 		Where(sq.And{sq.Eq{"flag_key": flagKey}, sq.Eq{"namespace_key": namespaceKey}}).
-		OrderBy(`"rank" ASC`).
 		QueryContext(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/storage/sql/common/evaluation.go
+++ b/internal/storage/sql/common/evaluation.go
@@ -16,7 +16,7 @@ func (s *Store) GetEvaluationRules(ctx context.Context, namespaceKey, flagKey st
 	}
 
 	ruleMetaRows, err := s.builder.
-		Select("id, rank, segment_operator").
+		Select("id, \"rank\", segment_operator").
 		From("rules").
 		Where(sq.And{sq.Eq{"flag_key": flagKey}, sq.Eq{"namespace_key": namespaceKey}}).
 		QueryContext(ctx)


### PR DESCRIPTION
Revise query to collect ruleIDs, and then use those collected IDs in subsequent query for the segments/constraints. We sort the rules at the end via the `rank`, so we can actually just remove the `OrderBy` clause in the first query to optimize.

Before this, the subquery [here](https://github.com/flipt-io/flipt/blob/segment-anding/internal/storage/sql/common/evaluation.go#L33-L44) was not filtering rules based on `flag_key` or `namespace_key`.
