### PR TITLE
fix(ui): make flags/segments inputs disabled in readonly mode

### DIFF
--- a/ui/src/components/flags/FlagForm.tsx
+++ b/ui/src/components/flags/FlagForm.tsx
@@ -118,6 +118,7 @@ export default function FlagForm(props: FlagFormProps) {
                     className="mt-1"
                     name="name"
                     id="name"
+                    disabled={readOnly}
                     autoFocus={isNew}
                     onChange={(e) => {
                       // check if the name and key are currently in sync
@@ -147,7 +148,7 @@ export default function FlagForm(props: FlagFormProps) {
                     className="mt-1"
                     name="key"
                     id="key"
-                    disabled={!isNew}
+                    disabled={!isNew || readOnly}
                     onChange={(e) => {
                       const formatted = stringAsKey(e.target.value);
                       formik.setFieldValue('key', formatted);
@@ -174,7 +175,7 @@ export default function FlagForm(props: FlagFormProps) {
                               id={type.id}
                               name="type"
                               type="radio"
-                              disabled={!isNew}
+                              disabled={!isNew || readOnly}
                               className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
                               onChange={() => {
                                 formik.setFieldValue('type', type.id);
@@ -211,7 +212,12 @@ export default function FlagForm(props: FlagFormProps) {
                       Optional
                     </span>
                   </div>
-                  <Input className="mt-1" name="description" id="description" />
+                  <Input
+                    className="mt-1"
+                    name="description"
+                    id="description"
+                    disabled={readOnly}
+                  />
                 </div>
               </div>
               <div className="flex justify-end">

--- a/ui/src/components/segments/SegmentForm.tsx
+++ b/ui/src/components/segments/SegmentForm.tsx
@@ -104,6 +104,7 @@ export default function SegmentForm(props: SegmentFormProps) {
                   className="mt-1"
                   name="name"
                   id="name"
+                  disabled={readOnly}
                   autoFocus={isNew}
                   onChange={(e) => {
                     // check if the name and key are currently in sync
@@ -129,7 +130,7 @@ export default function SegmentForm(props: SegmentFormProps) {
                   className="mt-1"
                   name="key"
                   id="key"
-                  disabled={!isNew}
+                  disabled={!isNew || readOnly}
                   onChange={(e) => {
                     const formatted = stringAsKey(e.target.value);
                     formik.setFieldValue('key', formatted);
@@ -157,6 +158,7 @@ export default function SegmentForm(props: SegmentFormProps) {
                             aria-describedby={`${matchType.id}-description`}
                             name="matchType"
                             type="radio"
+                            disabled={readOnly}
                             className="text-violet-400 border-gray-300 h-4 w-4 focus:ring-violet-400"
                             onChange={() => {
                               formik.setFieldValue('matchType', matchType.id);
@@ -199,7 +201,12 @@ export default function SegmentForm(props: SegmentFormProps) {
                     Optional
                   </span>
                 </div>
-                <Input className="mt-1" name="description" id="description" />
+                <Input
+                  className="mt-1"
+                  name="description"
+                  id="description"
+                  disabled={readOnly}
+                />
               </div>
             </div>
             <div className="flex justify-end">

--- a/ui/tests/flags.spec.ts
+++ b/ui/tests/flags.spec.ts
@@ -154,8 +154,7 @@ test.describe('Flags - Read Only', () => {
 
   test('can not update flag', async ({ page }) => {
     await page.getByRole('link', { name: 'test-flag' }).click();
-    await page.getByLabel('Description').click();
-    await page.getByLabel('Description').fill('Test flag description 2');
+    await expect(page.getByLabel('Description')).toBeDisabled();
     await expect(page.getByRole('switch', { name: 'Enabled' })).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Update' })).toBeDisabled();
   });

--- a/ui/tests/segments.spec.ts
+++ b/ui/tests/segments.spec.ts
@@ -116,8 +116,7 @@ test.describe('Segments - Read Only', () => {
 
   test('can not update segment', async ({ page }) => {
     await page.getByRole('link', { name: 'test-segment' }).click();
-    await page.getByLabel('Description').click();
-    await page.getByLabel('Description').fill("i'm a test 2");
+    await expect(page.getByLabel('Description')).toBeDisabled();
     await expect(page.getByRole('button', { name: 'Update' })).toBeDisabled();
   });
 


### PR DESCRIPTION
Fixes: FLI-556

Makes flag/segment name/desc/flag type inputs disabled when in readonly mode

### Before

![CleanShot 2023-08-12 at 14 07 01](https://github.com/flipt-io/flipt/assets/209477/47a4ca60-20c6-4023-b109-7ef8096672c8)

### After

![CleanShot 2023-08-12 at 14 06 00](https://github.com/flipt-io/flipt/assets/209477/e3fc4e1f-a78b-4057-b1d7-3e3569eddeef)
