### PR TITLE
feat(segments): introduce cue validation for new segment definitions

### DIFF
--- a/internal/cue/flipt.cue
+++ b/internal/cue/flipt.cue
@@ -28,14 +28,19 @@ close({
 }
 
 #Variant: {
-	key:        string & =~"^.+$"
-	name:       string & =~"^.+$"
+	key:          string & =~"^.+$"
+	name:         string & =~"^.+$"
 	description?: string
-	attachment: {...} | *null
+	attachment:   {...} | *null
+}
+
+#RuleSegment: {
+	keys: [...string]
+	operator: "OR_SEGMENT_OPERATOR" | "AND_SEGMENT_OPERATOR" | *null
 }
 
 #Rule: {
-	segment: string & =~"^.+$"
+	segment: string & =~"^[-_,A-Za-z0-9]+$" | #RuleSegment
 	rank?:   int
 	distributions: [...#Distribution]
 }
@@ -45,10 +50,13 @@ close({
 	rollout: >=0 & <=100
 }
 
+#RolloutSegment: {key: string & =~"^[-_,A-Za-z0-9]+$"} | {keys: [...string]}
+
 #Rollout: {
 	segment: {
-		key:   string
-		value: bool
+		#RolloutSegment
+		operator: "OR_SEGMENT_OPERATOR" | "AND_SEGMENT_OPERATOR" | *null
+		value:    bool
 	}
 } | {
 	threshold: {

--- a/internal/cue/testdata/valid_segments_v2.yaml
+++ b/internal/cue/testdata/valid_segments_v2.yaml
@@ -1,0 +1,55 @@
+namespace: default
+flags:
+- key: flipt
+  name: flipt
+  description: flipt
+  enabled: false
+  variants:
+  - key: flipt
+    name: flipt
+  - key: flipt
+    name: flipt
+    description: I'm a description.
+  rules:
+  - segment:
+      keys:
+      - internal-users
+      - all-users
+      operator: AND_SEGMENT_OPERATOR
+    distributions:
+    - variant: fromFlipt
+      rollout: 100
+  - segment: all-users
+    distributions:
+    - variant: fromFlipt2
+      rollout: 100
+- key: boolean
+  name: Boolean
+  description: Boolean flag
+  enabled: false
+  rollouts:
+  - description: enabled for internal users
+    segment:
+      keys:
+      - internal-users
+      - all-users
+      operator: AND_SEGMENT_OPERATOR
+      value: true
+  - description: enabled for 50%
+    threshold:
+      percentage: 50.0
+      value: true
+segments:
+- key: all-users
+  name: All Users
+  description: All Users
+  match_type: ALL_MATCH_TYPE
+- key: internal-users
+  name: Internal Users
+  description: All internal users at flipt.
+  constraints:
+  - type: STRING_COMPARISON_TYPE
+    property: organization
+    operator: eq
+    value: flipt
+  match_type: ALL_MATCH_TYPE

--- a/internal/cue/validate_test.go
+++ b/internal/cue/validate_test.go
@@ -36,6 +36,18 @@ func TestValidate_Latest_Success(t *testing.T) {
 	assert.Empty(t, res.Errors)
 }
 
+func TestValidate_Latest_Segments_V2(t *testing.T) {
+	b, err := os.ReadFile("testdata/valid_segments_v2.yaml")
+	require.NoError(t, err)
+
+	v, err := NewFeaturesValidator()
+	require.NoError(t, err)
+
+	res, err := v.Validate("testdata/valid_segments_v2.yaml", b)
+	assert.NoError(t, err)
+	assert.Empty(t, res.Errors)
+}
+
 func TestValidate_Failure(t *testing.T) {
 	b, err := os.ReadFile("testdata/invalid.yaml")
 	require.NoError(t, err)


### PR DESCRIPTION
Introduce new cue definitions for rule and rollout segment definitions. Also, add new tests to validate the new behavior of the updated cue file.

Completes FLI-548