### PR TITLE
chore: fix release-grpc-dotnet workflow

### DIFF
--- a/.github/workflows/release-clients.yml
+++ b/.github/workflows/release-clients.yml
@@ -39,4 +39,4 @@ jobs:
           tag=$(echo $GITHUB_REF_NAME)
           gh workflow run proto-upgrade.yml -R flipt-io/flipt-grpc-go -f tag="${tag}"
           gh workflow run proto-upgrade.yml -R flipt-io/flipt-grpc-ruby -f tag="${tag}"
-          gh workflow run proto-upgrade.yml -R flipt-io/flipt-grpc-dotnet -f tag="${{ inputs.tag }}"
+          gh workflow run proto-upgrade.yml -R flipt-io/flipt-grpc-dotnet -f tag="${tag}"


### PR DESCRIPTION
pass tag correctly to dotnet grpc release workflow