### PR TITLE
chore: skip storing in cache for ui consistency

### DIFF
--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -40,7 +40,8 @@ export async function request(method: string, uri: string, body?: any) {
     method,
     headers: {
       'Content-Type': 'application/json',
-      Accept: 'application/json'
+      Accept: 'application/json',
+      'Cache-Control': 'no-store'
     },
     body: JSON.stringify(body)
   });


### PR DESCRIPTION
Builds on #2014 

Adds `Cache-Control: no-store` header for UI so results are always consistent (updating flag shows immediately instead of waiting on cache expiry)

[no-store from RFC](https://datatracker.ietf.org/doc/html/rfc7234#section-5.2)

```
The "no-store" request directive indicates that a cache MUST NOT store any part of either this request or any response to it.
```

With Cache Enabled:

```
2023-08-18T08:10:54-04:00	DEBUG	get flag	{"server": "grpc", "request": "key:\"flag_001\"  namespace_key:\"default\""}
2023-08-18T08:10:54-04:00	DEBUG	skipping storage cache as 'no-store' was set	{"server": "grpc"}
```