### PR TITLE
fix: Fix cache shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.25.1](https://github.com/flipt-io/flipt/releases/tag/v1.25.1) - 2023-08-18
+
+### Fixed
+
+- cache shadow var when setting up middleware (#2017)
+
 ## [v1.25.0](https://github.com/flipt-io/flipt/releases/tag/v1.25.0) - 2023-08-16
 
 ### Added

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -245,7 +245,12 @@ func NewGRPCServer(
 
 	var cacher cache.Cacher
 	if cfg.Cache.Enabled {
-		cacher, cacheShutdown, err := getCache(ctx, cfg)
+		var (
+			cacheShutdown errFunc
+			err           error
+		)
+
+		cacher, cacheShutdown, err = getCache(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fix issue where cacher was still getting set to nil because of shadowing rules, resulting in the middleware for caching not getting activated because of a later nil check: https://github.com/flipt-io/flipt/blob/f6f01890f6017b6cebb2f70c2052c4d2e6591d29/internal/cmd/grpc.go#L317