### PR TITLE
chore: setup links to discord in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Join our Discord community 💬
+    url: https://flipt.io/discord
+    about: "Come chat with us! Ask for help, join our software development efforts, or just give us feedback!"


### PR DESCRIPTION
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser

adds option/link to join our discord instead of filing an issue