### PR TITLE
feat(oidc): Add parameters for pkce flow

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -79,7 +79,8 @@ import "strings"
 			client_id?:        string
 			client_secret?:    string
 			redirect_address?: string
-			scopes?:           [...string]
+			scopes?: [...string]
+			pkce?: bool
 		}
 	}
 
@@ -131,10 +132,10 @@ import "strings"
 		object?: {
 			type: "s3" | *""
 			s3?: {
-				region: string
-				bucket: string
-				prefix?: string
-				endpoint?: string
+				region:         string
+				bucket:         string
+				prefix?:        string
+				endpoint?:      string
 				poll_interval?: =~#duration | *"1m"
 			}
 		}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -221,7 +221,8 @@
             "client_id": { "type": "string" },
             "client_secret": { "type": "string" },
             "redirect_address": { "type": "string" },
-            "scopes": { "type": "array", "items": { "type": "string" } }
+            "scopes": { "type": "array", "items": { "type": "string" } },
+            "pkce": { "type": "boolean", "default": false }
           },
           "additionalProperties": false
         }

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -368,6 +368,7 @@ type AuthenticationMethodOIDCProvider struct {
 	ClientSecret    string   `json:"clientSecret,omitempty" mapstructure:"client_secret"`
 	RedirectAddress string   `json:"redirectAddress,omitempty" mapstructure:"redirect_address"`
 	Scopes          []string `json:"scopes,omitempty" mapstructure:"scopes"`
+	PKCE            bool     `json:"pkce,omitempty" mapstructure:"pkce"`
 }
 
 // AuthenticationCleanupSchedule is used to configure a cleanup goroutine.

--- a/internal/server/auth/method/oidc/server_test.go
+++ b/internal/server/auth/method/oidc/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/flipt/internal/config"
+	authoidc "go.flipt.io/flipt/internal/server/auth/method/oidc"
 	oidctesting "go.flipt.io/flipt/internal/server/auth/method/oidc/testing"
 	"go.flipt.io/flipt/rpc/flipt/auth"
 	"go.uber.org/zap/zaptest"
@@ -29,7 +30,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-func Test_Server(t *testing.T) {
+func Test_Server_ImplicitFlow(t *testing.T) {
 	var (
 		router = chi.NewRouter()
 		// httpServer is the test server used for hosting
@@ -133,7 +134,116 @@ func Test_Server(t *testing.T) {
 		Jar: jar,
 	}
 
+	testOIDCFlow(t, ctx, tp.Addr(), clientAddress, client, server)
+}
+
+func Test_Server_PKCE(t *testing.T) {
+	var (
+		router        = chi.NewRouter()
+		httpServer    = httptest.NewServer(router)
+		clientAddress = strings.Replace(httpServer.URL, "127.0.0.1", "localhost", 1)
+
+		id, secret = "client_id", "client_secret"
+
+		logger = zaptest.NewLogger(t)
+		ctx    = context.Background()
+	)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n\n", err)
+		return
+	}
+
+	tp := oidc.StartTestProvider(t, oidc.WithNoTLS(), oidc.WithTestDefaults(&oidc.TestProviderDefaults{
+		CustomClaims: map[string]interface{}{},
+		SubjectInfo: map[string]*oidc.TestSubject{
+			"mark": {
+				Password: "phelps",
+				UserInfo: map[string]interface{}{
+					"email": "mark@flipt.io",
+					"name":  "Mark Phelps",
+				},
+				CustomClaims: map[string]interface{}{
+					"email": "mark@flipt.io",
+					"name":  "Mark Phelps",
+				},
+			},
+			"george": {
+				Password: "macrorie",
+				UserInfo: map[string]interface{}{
+					"email": "george@flipt.io",
+					"name":  "George MacRorie",
+				},
+				CustomClaims: map[string]interface{}{
+					"email": "george@flipt.io",
+					"name":  "George MacRorie",
+				},
+			},
+		},
+		SigningKey: &oidc.TestSigningKey{
+			PrivKey: priv,
+			PubKey:  priv.Public(),
+			Alg:     oidc.RS256,
+		},
+		AllowedRedirectURIs: []string{
+			fmt.Sprintf("%s/auth/v1/method/oidc/google/callback", clientAddress),
+		},
+		ClientID:     &id,
+		ClientSecret: &secret,
+		PKCEVerifier: authoidc.PKCEVerifier,
+	}))
+
+	defer tp.Stop()
+
+	var (
+		authConfig = config.AuthenticationConfig{
+			Session: config.AuthenticationSession{
+				Domain:        "localhost",
+				Secure:        false,
+				TokenLifetime: 1 * time.Hour,
+				StateLifetime: 10 * time.Minute,
+			},
+			Methods: config.AuthenticationMethods{
+				OIDC: config.AuthenticationMethod[config.AuthenticationMethodOIDCConfig]{
+					Enabled: true,
+					Method: config.AuthenticationMethodOIDCConfig{
+						Providers: map[string]config.AuthenticationMethodOIDCProvider{
+							"google": {
+								IssuerURL:       tp.Addr(),
+								ClientID:        id,
+								ClientSecret:    secret,
+								RedirectAddress: clientAddress,
+								PKCE:            true,
+							},
+						},
+					},
+				},
+			},
+		}
+		server = oidctesting.StartHTTPServer(t, ctx, logger, authConfig, router)
+	)
+
+	t.Cleanup(func() { _ = server.Stop() })
+
+	jar, err := cookiejar.New(&cookiejar.Options{})
+	require.NoError(t, err)
+
+	client := &http.Client{
+		// skip redirects
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		// establish a cookie jar
+		Jar: jar,
+	}
+
+	testOIDCFlow(t, ctx, tp.Addr(), clientAddress, client, server)
+}
+
+func testOIDCFlow(t *testing.T, ctx context.Context, tpAddr, clientAddress string, client *http.Client, server *oidctesting.HTTPServer) {
 	var authURL *url.URL
+
 	t.Run("AuthorizeURL", func(t *testing.T) {
 		authorizeURL := clientAddress + "/auth/v1/method/oidc/google/authorize"
 
@@ -175,7 +285,7 @@ func Test_Server(t *testing.T) {
 		values.Set("uname", "mark")
 		values.Set("psw", "phelps")
 
-		req, err = http.NewRequestWithContext(ctx, http.MethodPost, tp.Addr()+"/login", strings.NewReader(values.Encode()))
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, tpAddr+"/login", strings.NewReader(values.Encode()))
 		require.NoError(t, err)
 
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")


### PR DESCRIPTION
This PR provides an implementation of completing PKCE flow with an OIDC provider. It does the following:
1. Introduces authentication parameters for enabling PKCE for all legs of the flow
2. Tests for PKCE enabled on server side

Completes FLI-567