### PR TITLE
fix: Hover icons

### DIFF
--- a/ui/src/app/console/Console.tsx
+++ b/ui/src/app/console/Console.tsx
@@ -198,7 +198,7 @@ export default function Console() {
                             >
                               <ArrowPathIcon
                                 className={classNames(
-                                  'text-gray-400 m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-white dark:hover:text-gray-500'
+                                  'text-gray-400 m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-gray-500'
                                 )}
                               />
                             </button>

--- a/ui/src/components/flags/FlagForm.tsx
+++ b/ui/src/components/flags/FlagForm.tsx
@@ -179,7 +179,7 @@ export default function FlagForm(props: FlagFormProps) {
                       >
                         <CheckIcon
                           className={classNames(
-                            'nightwind-prevent text-green-400 absolute m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-white',
+                            'nightwind-prevent text-green-400 absolute m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out',
                             keyCopied
                               ? 'visible opacity-100'
                               : 'invisible opacity-0'
@@ -187,7 +187,7 @@ export default function FlagForm(props: FlagFormProps) {
                         />
                         <ClipboardDocumentIcon
                           className={classNames(
-                            'text-gray-400 m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-white dark:hover:text-gray-500',
+                            'text-gray-400 m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-gray-500',
                             keyCopied
                               ? 'invisible opacity-0'
                               : 'visible opacity-100'

--- a/ui/src/components/segments/SegmentForm.tsx
+++ b/ui/src/components/segments/SegmentForm.tsx
@@ -161,7 +161,7 @@ export default function SegmentForm(props: SegmentFormProps) {
                     >
                       <CheckIcon
                         className={classNames(
-                          'nightwind-prevent text-green-400 absolute m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-white',
+                          'nightwind-prevent text-green-400 absolute m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out',
                           keyCopied
                             ? 'visible opacity-100'
                             : 'invisible opacity-0'
@@ -169,7 +169,7 @@ export default function SegmentForm(props: SegmentFormProps) {
                       />
                       <ClipboardDocumentIcon
                         className={classNames(
-                          'text-gray-400 m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-white dark:hover:text-gray-500',
+                          'text-gray-400 m-auto h-5 w-5 justify-center align-middle transition-opacity duration-300 ease-in-out hover:text-gray-500',
                           keyCopied
                             ? 'invisible opacity-0'
                             : 'visible opacity-100'


### PR DESCRIPTION
In light mode some of the icons were hard to see on hover

## Before

![2023-08-28 15 05 23](https://github.com/flipt-io/flipt/assets/209477/6c672c84-91c3-41e4-9ee6-70a6d0772025)

## After

![2023-08-28 15 04 27](https://github.com/flipt-io/flipt/assets/209477/ff099003-936d-4557-bfda-57a4ef691231)
![2023-08-28 15 02 37](https://github.com/flipt-io/flipt/assets/209477/be58fe22-2bda-4a27-85aa-b1428c9596fc)
