### PR TITLE
chore: update mage action to latest action which allows install

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -34,10 +34,13 @@ jobs:
           cd /usr/local
           curl -L https://dl.dagger.io/dagger/install.sh | sh
 
-      - uses: GeorgeMac/mage-action@gm/tools-add-path-debug
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: dagger:run test:cli
+          install-only: true
+
+      - name: Run CLI Tests
+        run: mage dagger:run test:cli
 
   test:
     name: Integration Tests
@@ -62,10 +65,13 @@ jobs:
           cd /usr/local
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${DAGGER_VERSION} sh
 
-      - uses: GeorgeMac/mage-action@gm/tools-add-path-debug
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: dagger:run "test:integration ${{ matrix.test }}"
+          install-only: true
+
+      - name: Run Integration Tests
+        run: mage dagger:run "test:integration ${{ matrix.test }}"
 
       - name: Upload Flipt Service Logs
         uses: actions/upload-artifact@v3
@@ -94,7 +100,10 @@ jobs:
           cd /usr/local
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${DAGGER_VERSION} sh
 
-      - uses: GeorgeMac/mage-action@gm/tools-add-path-debug
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: dagger:run test:ui
+          install-only: true
+
+      - name: Run UI Tests
+        run: mage dagger:run test:ui

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,10 +53,13 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin
           echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
-      - uses: magefile/mage-action@v2
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: prep
+          install-only: true
+
+      - name: Prep Build
+        run: mage prep
 
       - name: GoReleaser (Nightly) Build
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/release-tag-latest.yml
+++ b/.github/workflows/release-tag-latest.yml
@@ -49,10 +49,10 @@ jobs:
           username: "${{ github.repository_owner }}"
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: GeorgeMac/mage-action@gm/tools-add-path-debug
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: prep
+          install-only: true
 
       - name: Tag and Push latest
         env:
@@ -70,4 +70,3 @@ jobs:
             docker pull ghcr.io/flipt-io/flipt:$TAG
             skopeo copy --all docker://ghcr.io/flipt-io/flipt:$TAG docker://ghcr.io/flipt-io/flipt:latest
           fi
- 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,13 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin
           echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
-      - uses: magefile/mage-action@v2
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: prep
+          install-only: true
+
+      - name: Prep Build
+        run: mage prep
 
       - name: GoReleaser Build
         uses: goreleaser/goreleaser-action@v4
@@ -126,11 +129,6 @@ jobs:
           username: "${{ github.repository_owner }}"
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: GeorgeMac/mage-action@gm/tools-add-path-debug
-        with:
-          version: latest
-          args: prep
-
       - name: Generate token
         id: generate_token
         uses: tibdex/github-app-token@v1
@@ -152,6 +150,13 @@ jobs:
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
 
+      - name: Install Mage
+        uses: magefile/mage-action@v2
+        with:
+          install-only: true
+
+        # TODO: see if we can wire up the `release-tag-latest` workflow to run
+        # after release with the same tag
       - name: Tag and Push latest
         env:
           TAG: ${{ github.ref_name }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -47,10 +47,13 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/quill/main/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin
           echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
-      - uses: magefile/mage-action@v2
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: prep
+          install-only: true
+
+      - name: Prep Build
+        run: mage prep
 
       - name: GoReleaser (Snapshot) Build
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,13 @@ jobs:
           cd /usr/local
           curl -L https://dl.dagger.io/dagger/install.sh | sh
 
-      - name: Unit Test ${{ matrix.database }}
-        uses: GeorgeMac/mage-action@gm/tools-add-path-debug
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: dagger:run "test:database ${{ matrix.database }}"
+          install-only: true
+
+      - name: Unit Test ${{ matrix.database }}
+        run: mage dagger:run "test:database ${{ matrix.database }}"
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3.1.4
@@ -79,10 +81,10 @@ jobs:
           cd /usr/local
           curl -L https://dl.dagger.io/dagger/install.sh | DAGGER_VERSION=${DAGGER_VERSION} sh
 
-      - uses: GeorgeMac/mage-action@gm/tools-add-path-debug
+      - name: Install Mage
+        uses: magefile/mage-action@v2
         with:
-          version: latest
-          args: dagger:run test:migration
+          install-only: true
 
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v3.1.4
+      - name: Run UI Tests
+        run: mage dagger:run test:migration


### PR DESCRIPTION
https://github.com/magefile/mage-action/pull/293 added the ability to do `install-only`

this updates all our workflows to make use of it so mage is available for all later steps