### PR TITLE
feat(hackweek): add support page instead of link to docs

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -278,6 +278,28 @@ func (u UI) Run() error {
 	return cmd.Run()
 }
 
+// Formats UI code
+func (u UI) Fmt() error {
+	fmt.Println("Formatting UI...")
+
+	cmd := exec.Command("npm", "run", "format")
+	cmd.Dir = "ui"
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// Runs the UI linters
+func (u UI) Lint() error {
+	fmt.Println("Linting UI...")
+
+	cmd := exec.Command("npm", "run", "lint")
+	cmd.Dir = "ui"
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 // Builds all UI assets for release distribution
 func (u UI) Build() error {
 	mg.Deps(u.Deps)

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,6 +23,7 @@ const Segments = loadable(() => import('./app/segments/Segments'));
 const Console = loadable(() => import('./app/console/Console'));
 const Login = loadable(() => import('./app/auth/Login'));
 const Settings = loadable(() => import('./app/Settings'));
+const Support = loadable(() => import('./app/Support'));
 const Preferences = loadable(() => import('./app/preferences/Preferences'));
 const Namespaces = loadable(() => import('./app/namespaces/Namespaces'));
 const Tokens = loadable(() => import('./app/tokens/Tokens'));
@@ -116,6 +117,10 @@ const router = createHashRouter([
             element: <Tokens />
           }
         ]
+      },
+      {
+        path: 'support',
+        element: <Support />
       },
       ...namespacesRoutes
     ]

--- a/ui/src/app/Support.tsx
+++ b/ui/src/app/Support.tsx
@@ -21,7 +21,7 @@ export default function Support() {
           <a
             className="text-white bg-violet-500 mb-1 inline-flex items-center justify-center rounded-md border border-transparent px-4 py-2 text-sm font-medium shadow-sm hover:bg-violet-600 hover:cursor-pointer focus:outline-none focus:ring-1 focus:ring-violet-500 focus:ring-offset-1"
             target="_blank"
-            rel="noopener"
+            rel="noreferrer"
             href="https://www.flipt.io/docs/"
           >
             <span>Documentation</span>

--- a/ui/src/app/Support.tsx
+++ b/ui/src/app/Support.tsx
@@ -1,0 +1,112 @@
+import {
+  ArrowUpRightIcon,
+  ChatBubbleBottomCenterIcon,
+  EnvelopeIcon,
+  ExclamationCircleIcon
+} from '@heroicons/react/24/outline';
+
+export default function Support() {
+  return (
+    <>
+      <div className="flex-row justify-between pb-5 sm:flex sm:items-center">
+        <div className="flex flex-col">
+          <h1 className="text-gray-900 text-2xl font-bold leading-7 sm:truncate sm:text-3xl">
+            Support
+          </h1>
+          <p className="text-gray-500 mt-2 text-sm">
+            How to get help with Flipt
+          </p>
+        </div>
+        <div className="mt-4">
+          <a
+            className="text-white bg-violet-500 mb-1 inline-flex items-center justify-center rounded-md border border-transparent px-4 py-2 text-sm font-medium shadow-sm hover:bg-violet-600 hover:cursor-pointer focus:outline-none focus:ring-1 focus:ring-violet-500 focus:ring-offset-1"
+            target="_blank"
+            rel="noopener"
+            href="https://www.flipt.io/docs/"
+          >
+            <span>Documentation</span>
+            <ArrowUpRightIcon
+              className="text-white -mr-1.5 ml-1 h-3 w-3"
+              aria-hidden="true"
+            />
+          </a>
+        </div>
+      </div>
+      <div className="my-8">
+        <div className="sm:flex sm:items-center">
+          <div className="sm:flex-auto">
+            <div className="flex h-72 flex-col space-y-4 sm:flex-row sm:space-x-4 sm:space-y-0 lg:h-48">
+              <div className="border-gray-200 flex h-full w-full flex-col items-stretch rounded-md border p-6 sm:w-1/3">
+                <div className="sm:shrink-0">
+                  <div className="flex items-center space-x-2">
+                    <ExclamationCircleIcon className="text-gray-400 h-6 w-6" />
+                    <h3 className="text-gray-900 text-base font-semibold">
+                      File an Issue
+                    </h3>
+                  </div>
+                  <p className="text-gray-500 pt-1 text-sm leading-5">
+                    Get support from the entire community
+                  </p>
+                </div>
+                <div className="mt-4 flex grow items-end sm:mt-0">
+                  <a
+                    className="border-gray-200 rounded-md border px-2 py-1 hover:border-gray-300 hover:shadow-sm hover:shadow-gray-400 sm:px-3 sm:py-2"
+                    href="https://github.com/flipt-io/flipt/issues/new/choose"
+                  >
+                    <span className="text-gray-700 text-sm">
+                      Create GitHub Issue
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div className="border-gray-200 flex h-full w-full flex-col items-stretch rounded-md border p-6 sm:w-1/3">
+                <div className="sm:shrink-0">
+                  <div className="flex items-center space-x-2">
+                    <ChatBubbleBottomCenterIcon className="text-gray-400 h-6 w-6" />
+                    <h3 className="text-gray-900 text-base font-semibold">
+                      Slack Connect
+                    </h3>
+                  </div>
+                  <p className="text-gray-500 pt-1 text-sm leading-5">
+                    Invite your team to collaborate in a shared Slack channel
+                  </p>
+                </div>
+                <div className="mt-4 flex grow items-end sm:mt-0">
+                  <a
+                    className="border-gray-200 rounded-md border px-2 py-1 hover:border-gray-300 hover:shadow-sm hover:shadow-gray-400 sm:px-3 sm:py-2"
+                    href="mailto:info@flipt.io?subject=Slack Connect Request&body=Hi there! I'd like to request a Slack Connect channel for our team."
+                  >
+                    <span className="text-gray-700 text-sm">
+                      Request Invite
+                    </span>
+                  </a>
+                </div>
+              </div>
+              <div className="border-gray-200 flex h-full w-full flex-col items-stretch rounded-md border p-6 sm:w-1/3">
+                <div className="sm:shrink-0">
+                  <div className="flex items-center space-x-2">
+                    <EnvelopeIcon className="text-gray-400 h-6 w-6" />
+                    <h3 className="text-gray-900 text-base font-semibold">
+                      Email
+                    </h3>
+                  </div>
+                  <p className="text-gray-500 pt-1 text-sm leading-5">
+                    Send an email to our shared inbox
+                  </p>
+                </div>
+                <div className="mt-4 flex grow items-end sm:mt-0">
+                  <a
+                    className="border-gray-200 rounded-md border px-2 py-1 hover:border-gray-300 hover:shadow-sm hover:shadow-gray-400 sm:px-3 sm:py-2"
+                    href="mailto:info@flipt.io?subject=Support Inquiry"
+                  >
+                    <span className="text-gray-700 text-sm">Send Email</span>
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/ui/src/app/namespaces/Namespaces.tsx
+++ b/ui/src/app/namespaces/Namespaces.tsx
@@ -80,7 +80,7 @@ export default function Namespaces() {
       <div className="my-10">
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">
-            <h1 className="text-gray-700 text-xl font-semibold">Namespaces</h1>
+            <h3 className="text-gray-700 text-xl font-semibold">Namespaces</h3>
             <p className="text-gray-500 mt-2 text-sm">
               Namespaces allow you to group your flags, segments and rules under
               a single name

--- a/ui/src/app/preferences/Preferences.tsx
+++ b/ui/src/app/preferences/Preferences.tsx
@@ -27,7 +27,7 @@ export default function Preferences() {
     <Formik initialValues={initialValues} onSubmit={() => {}}>
       <div className="my-10 divide-y divide-gray-200">
         <div className="space-y-1">
-          <h1 className="text-gray-700 text-xl font-semibold">Preferences</h1>
+          <h3 className="text-gray-700 text-xl font-semibold">Preferences</h3>
           <p className="text-gray-500 mt-2 text-sm">
             Manage how information is displayed in the UI
           </p>

--- a/ui/src/app/tokens/Tokens.tsx
+++ b/ui/src/app/tokens/Tokens.tsx
@@ -160,9 +160,9 @@ export default function Tokens() {
       <div className="my-10">
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">
-            <h1 className="text-gray-700 text-xl font-semibold">
+            <h3 className="text-gray-700 text-xl font-semibold">
               Static Tokens
-            </h1>
+            </h3>
             <p className="text-gray-500 mt-2 text-sm">
               Static tokens are used to authenticate with the API
             </p>

--- a/ui/src/components/Nav.tsx
+++ b/ui/src/components/Nav.tsx
@@ -1,8 +1,8 @@
 import {
-  BookOpenIcon,
   CodeBracketIcon,
   Cog6ToothIcon,
   FlagIcon,
+  QuestionMarkCircleIcon,
   UsersIcon
 } from '@heroicons/react/24/outline';
 import { useSelector } from 'react-redux';
@@ -19,28 +19,13 @@ type NavItemProps = {
   to: string;
   name: string;
   Icon: Icon;
-  external?: boolean;
   onClick?: () => void;
 };
 
 function NavItem(props: NavItemProps) {
-  const { to, name, Icon, external, onClick } = props;
+  const { to, name, Icon, onClick } = props;
 
-  return external ? (
-    <a
-      key={name}
-      href={to}
-      target="_blank"
-      rel="noreferrer"
-      className="group text-white flex items-center rounded-md px-2 py-2 text-sm font-medium hover:bg-violet-400 md:text-gray-600 md:hover:bg-gray-50"
-    >
-      <Icon
-        className="text-wite mr-3 h-6 w-6 flex-shrink-0 hover:bg-gray-50 md:text-gray-500"
-        aria-hidden="true"
-      />
-      {name}
-    </a>
-  ) : (
+  return (
     <NavLink
       key={name}
       to={to}
@@ -114,10 +99,9 @@ export default function Nav(props: NavProps) {
       Icon: Cog6ToothIcon
     },
     {
-      name: 'Documentation',
-      to: 'https://flipt.io/docs?utm_source=app',
-      Icon: BookOpenIcon,
-      external: true
+      name: 'Support',
+      to: 'support',
+      Icon: QuestionMarkCircleIcon
     }
   ];
 


### PR DESCRIPTION
Removes link to docs to instead link to a dedicated support page with links to:

- File a GitHub issue
- Send an email requesting slack connect invite
- Send a general support email

Also includes links to our docs still in top right

### Light
![localhost_8080_(Desktop) (28)](https://github.com/flipt-io/flipt/assets/209477/89f9aecd-be87-4a14-9e0e-3f88d58eb82d)

### Dark
![localhost_8080_(Desktop) (27)](https://github.com/flipt-io/flipt/assets/209477/bc1ac87d-0db9-47fb-adfb-2ac65d8a129a)
