### PR TITLE
fix(ext): attempt to import when namespace exists on create namespace

### DIFF
--- a/internal/ext/importer.go
+++ b/internal/ext/importer.go
@@ -104,16 +104,18 @@ func (i *Importer) Import(ctx context.Context, r io.Reader) (err error) {
 			Key: namespace,
 		})
 
-		if status.Code(err) != codes.NotFound && !errors.AsMatch[errors.ErrNotFound](err) {
-			return err
-		}
-
-		_, err = i.creator.CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
-			Key:  namespace,
-			Name: namespace,
-		})
 		if err != nil {
-			return err
+			if status.Code(err) != codes.NotFound && !errors.AsMatch[errors.ErrNotFound](err) {
+				return err
+			}
+
+			_, err = i.creator.CreateNamespace(ctx, &flipt.CreateNamespaceRequest{
+				Key:  namespace,
+				Name: namespace,
+			})
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/ext/importer_test.go
+++ b/internal/ext/importer_test.go
@@ -832,7 +832,7 @@ func TestImport_CreateNamespace(t *testing.T) {
 	creator.getNSErr = nil
 
 	// rewind the file so it can be read again
-	in.Seek(0, io.SeekStart)
+	_, _ = in.Seek(0, io.SeekStart)
 
 	// returns a nil error because namespace exists
 	err = importer.Import(context.Background(), in)

--- a/internal/ext/importer_test.go
+++ b/internal/ext/importer_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ferrors "go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/rpc/flipt"
 )
 
@@ -786,7 +788,6 @@ func TestImport_Namespaces(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-
 			var (
 				creator  = &mockCreator{}
 				importer = NewImporter(creator, WithNamespace(tc.cliNamespace))
@@ -803,7 +804,42 @@ func TestImport_Namespaces(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
 
+func TestImport_CreateNamespace(t *testing.T) {
+	var (
+		creator  = &mockCreator{}
+		importer = NewImporter(creator, WithCreateNamespace())
+	)
+
+	in, err := os.Open("testdata/import_new_namespace.yml")
+	assert.NoError(t, err)
+	defer in.Close()
+
+	// first attempt to create namespace should be met with
+	// a namespace not found and still succeed, by attempting
+	// to create it
+	creator.getNSErr = ferrors.ErrNotFoundf("namespace not found")
+
+	err = importer.Import(context.Background(), in)
+	require.NoError(t, err)
+
+	// namespace was created
+	assert.Len(t, creator.createNSReqs, 1)
+
+	// next call is assumed to return a nil error on get namespace
+	// now that is has been created
+	creator.getNSErr = nil
+
+	// rewind the file so it can be read again
+	in.Seek(0, io.SeekStart)
+
+	// returns a nil error because namespace exists
+	err = importer.Import(context.Background(), in)
+	require.NoError(t, err)
+
+	// no new namespaces were requested because it already existed
+	assert.Len(t, creator.createNSReqs, 1)
 }
 
 //nolint:unparam

--- a/internal/ext/importer_test.go
+++ b/internal/ext/importer_test.go
@@ -826,6 +826,8 @@ func TestImport_CreateNamespace(t *testing.T) {
 
 	// namespace was created
 	assert.Len(t, creator.createNSReqs, 1)
+	// flag was created
+	assert.Len(t, creator.flagReqs, 1)
 
 	// next call is assumed to return a nil error on get namespace
 	// now that is has been created
@@ -840,6 +842,9 @@ func TestImport_CreateNamespace(t *testing.T) {
 
 	// no new namespaces were requested because it already existed
 	assert.Len(t, creator.createNSReqs, 1)
+	// new flag creation was attempted even though it should
+	// fail in reality because the flag already exists
+	assert.Len(t, creator.flagReqs, 2)
 }
 
 //nolint:unparam

--- a/internal/ext/testdata/import_new_namespace.yml
+++ b/internal/ext/testdata/import_new_namespace.yml
@@ -1,0 +1,1 @@
+namespace: other

--- a/internal/ext/testdata/import_new_namespace.yml
+++ b/internal/ext/testdata/import_new_namespace.yml
@@ -1,1 +1,3 @@
 namespace: other
+flags:
+- key: foo


### PR DESCRIPTION
Supports https://github.com/flipt-io/flipt/issues/2086

This does not fix the main report of the above issue. However, it does address one of the observed symptoms.
We were silently returning a nil error when a namespace existed on `--create-namespace` during import.
This meant the command succeeded, but didn't attempt to populate the namespace with the import contents.