### PR TITLE
fix(schema): make rollout description optional in cue schema

### DIFF
--- a/internal/cue/flipt.cue
+++ b/internal/cue/flipt.cue
@@ -22,7 +22,7 @@ close({
 #FlagBoolean: {
 	type: "BOOLEAN_FLAG_TYPE"
 	rollouts: [...{
-		description: string
+		description?: string
 		#Rollout
 	}]
 }


### PR DESCRIPTION
Fixes: #2090 

Make rollout description optional in cue def