### PR TITLE
chore: rm pr mode for goreleaser tap update; add slack announce

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,6 +121,9 @@ docker_manifests:
 announce:
   discord:
     enabled: true
+  slack:
+    enabled: true
+    channel: '#releases'
 
 brews:
   - name: flipt
@@ -144,5 +147,3 @@ brews:
       owner: flipt-io
       name: homebrew-brew
       branch: main
-      pull_request:
-        enabled: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,11 +44,11 @@ release:
   footer: |
     ## Docker Images
 
-    - [flipt/flipt](https://hub.docker.com/r/flipt/flipt/tags)
-
     ```bash
       docker pull docker.io/flipt/flipt:v{{ .Tag }}
-      # or
+    ```
+
+    ```bash
       docker pull ghcr.io/flipt-io/flipt:v{{ .Tag }}
     ```
 


### PR DESCRIPTION
- rm `pr` mode for homebrew tap update until https://github.com/goreleaser/goreleaser/issues/4283 is fixed
- setup announcing releases in our Slack https://goreleaser.com/customization/announce/slack/