### PR TITLE
feat: move events to top level of audit configuration

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -223,7 +223,6 @@ import "strings"
 
 	#audit: {
 		sinks?: {
-			events?: [...string] | *["*:*"]
 			log?: {
 				enabled?: bool | *false
 				file?:    string | *""
@@ -239,6 +238,7 @@ import "strings"
 			capacity?:     int | *2
 			flush_period?: string | *"2m"
 		}
+		events?: [...string] | *["*:*"]
 	}
 
 	#experimental: {}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -652,10 +652,6 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "events": {
-              "type": "array",
-              "default": ["*:*"]
-            },
             "log": {
               "type": "object",
               "additionalProperties": false,
@@ -716,6 +712,10 @@
               "default": "2m"
             }
           }
+        },
+        "events": {
+          "type": "array",
+          "default": ["*:*"]
         }
       },
       "title": "Audit"

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -345,7 +345,7 @@ func NewGRPCServer(
 	// based on audit sink configuration from the user, provision the audit sinks and add them to a slice,
 	// and if the slice has a non-zero length, add the audit sink interceptor
 	if len(sinks) > 0 {
-		checker, err := audit.NewChecker(cfg.Audit.Sinks.Events)
+		checker, err := audit.NewChecker(cfg.Audit.Events)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/audit.go
+++ b/internal/config/audit.go
@@ -15,17 +15,17 @@ var _ defaulter = (*AuditConfig)(nil)
 type AuditConfig struct {
 	Sinks  SinksConfig  `json:"sinks,omitempty" mapstructure:"sinks"`
 	Buffer BufferConfig `json:"buffer,omitempty" mapstructure:"buffer"`
+	Events []string     `json:"events,omitempty" mapstructure:"events"`
 }
 
 // Enabled returns true if any nested sink is enabled
 func (c *AuditConfig) Enabled() bool {
-	return c.Sinks.LogFile.Enabled
+	return c.Sinks.LogFile.Enabled || c.Sinks.Webhook.Enabled
 }
 
 func (c *AuditConfig) setDefaults(v *viper.Viper) error {
 	v.SetDefault("audit", map[string]any{
 		"sinks": map[string]any{
-			"events": []string{"*:*"},
 			"log": map[string]any{
 				"enabled": "false",
 				"file":    "",
@@ -38,6 +38,7 @@ func (c *AuditConfig) setDefaults(v *viper.Viper) error {
 			"capacity":     2,
 			"flush_period": "2m",
 		},
+		"events": []string{"*:*"},
 	})
 
 	return nil
@@ -66,7 +67,6 @@ func (c *AuditConfig) validate() error {
 // SinksConfig contains configuration held in structures for the different sinks
 // that we will send audits to.
 type SinksConfig struct {
-	Events  []string          `json:"events,omitempty" mapstructure:"events"`
 	LogFile LogFileSinkConfig `json:"log,omitempty" mapstructure:"log"`
 	Webhook WebhookSinkConfig `json:"webhook,omitempty" mapstructure:"webhook"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -511,7 +511,6 @@ func Default() *Config {
 
 		Audit: AuditConfig{
 			Sinks: SinksConfig{
-				Events: []string{"*:*"},
 				LogFile: LogFileSinkConfig{
 					Enabled: false,
 					File:    "",
@@ -521,6 +520,7 @@ func Default() *Config {
 				Capacity:    2,
 				FlushPeriod: 2 * time.Minute,
 			},
+			Events: []string{"*:*"},
 		},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -449,7 +449,6 @@ func TestLoad(t *testing.T) {
 
 				cfg.Audit = AuditConfig{
 					Sinks: SinksConfig{
-						Events: []string{"*:*"},
 						LogFile: LogFileSinkConfig{
 							Enabled: true,
 							File:    "/path/to/logs.txt",
@@ -459,6 +458,7 @@ func TestLoad(t *testing.T) {
 						Capacity:    10,
 						FlushPeriod: 3 * time.Minute,
 					},
+					Events: []string{"*:*"},
 				}
 
 				cfg.Log = LogConfig{


### PR DESCRIPTION
Move `events` to top level of the audit configuration.