### PR TITLE
fix: export with https

### DIFF
--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -85,7 +85,11 @@ func (c *exportCommand) run(cmd *cobra.Command, _ []string) error {
 
 	// Use client when remote address is configured.
 	if c.address != "" {
-		return c.export(cmd.Context(), out, fliptClient(logger, c.address, c.token))
+		client, err := fliptClient(c.address, c.token)
+		if err != nil {
+			return err
+		}
+		return c.export(cmd.Context(), out, client)
 	}
 
 	// Otherwise, go direct to the DB using Flipt configuration file.

--- a/cmd/flipt/import.go
+++ b/cmd/flipt/import.go
@@ -120,10 +120,11 @@ func (c *importCommand) run(cmd *cobra.Command, args []string) error {
 
 	// Use client when remote address is configured.
 	if c.address != "" {
-		return ext.NewImporter(
-			fliptClient(logger, c.address, c.token),
-			opts...,
-		).Import(cmd.Context(), in)
+		client, err := fliptClient(c.address, c.token)
+		if err != nil {
+			return err
+		}
+		return ext.NewImporter(client, opts...).Import(cmd.Context(), in)
 	}
 
 	logger, cfg := buildConfig()

--- a/go.work.sum
+++ b/go.work.sum
@@ -983,6 +983,7 @@ github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUB
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=


### PR DESCRIPTION
Fixes: FLI-607

Fixes a bug when trying to export with a call to a server running https

## Before

```
flipt export --address https://flipt-xyz.onrender.com/
2023-09-20T12:25:13.050-0400	FATAL	flipt/server.go:65	unexpected protocol	{"address": "https://flipt-xyz.onrender.com/"}
main.fliptClient
	go.flipt.io/flipt/cmd/flipt/server.go:65
main.(*exportCommand).run
	go.flipt.io/flipt/cmd/flipt/export.go:88
github.com/spf13/cobra.(*Command).execute
	github.com/spf13/cobra@v1.7.0/command.go:940
github.com/spf13/cobra.(*Command).ExecuteC
	github.com/spf13/cobra@v1.7.0/command.go:1068
github.com/spf13/cobra.(*Command).Execute
	github.com/spf13/cobra@v1.7.0/command.go:992
github.com/spf13/cobra.(*Command).ExecuteContext
	github.com/spf13/cobra@v1.7.0/command.go:985
main.main
	go.flipt.io/flipt/cmd/flipt/main.go:163
runtime.main
	runtime/proc.go:250
```

## After

```
» ./bin/flipt export --address https://flipt-xyz.onrender.com
version: "1.2"
namespace: default
flags:
- key: marktest
  name: marktest
  type: BOOLEAN_FLAG_TYPE
  enabled: false

» ./bin/flipt export --address httpxs://flipt-xyz.onrender.com
Error: unexpected protocol httpxs
```