### PR TITLE
fix(security): dont marshal secrets to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.27.2](https://github.com/flipt-io/flipt/releases/tag/v1.27.2) - 2023-09-21
+
+### Fixed
+
+- `security`: dont marshal secrets to JSON
+
 ## [v1.27.1](https://github.com/flipt-io/flipt/releases/tag/v1.27.1) - 2023-09-18
 
 ### Added

--- a/build/testing/integration/api/api.go
+++ b/build/testing/integration/api/api.go
@@ -1233,9 +1233,14 @@ func API(t *testing.T, ctx context.Context, client sdk.SDK, namespace string, au
 		for _, name := range []string{
 			"log",
 			"ui",
+			"authentication",
+			"audit",
 			"cache",
+			"cors",
 			"server",
+			"storage",
 			"db",
+			"tracing",
 		} {
 			field, ok := configMap[name]
 			assert.True(t, ok, "Missing %s.", name)

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -377,8 +377,8 @@ func (a AuthenticationMethodOIDCConfig) info() AuthenticationMethodInfo {
 // AuthenticationOIDCProvider configures provider credentials
 type AuthenticationMethodOIDCProvider struct {
 	IssuerURL       string   `json:"issuerURL,omitempty" mapstructure:"issuer_url"`
-	ClientID        string   `json:"clientID,omitempty" mapstructure:"client_id"`
-	ClientSecret    string   `json:"clientSecret,omitempty" mapstructure:"client_secret"`
+	ClientID        string   `json:"-" mapstructure:"client_id"`
+	ClientSecret    string   `json:"-" mapstructure:"client_secret"`
 	RedirectAddress string   `json:"redirectAddress,omitempty" mapstructure:"redirect_address"`
 	Scopes          []string `json:"scopes,omitempty" mapstructure:"scopes"`
 	UsePKCE         bool     `json:"usePKCE,omitempty" mapstructure:"use_pkce"`
@@ -423,8 +423,8 @@ func (a AuthenticationMethodKubernetesConfig) info() AuthenticationMethodInfo {
 // AuthenticationMethodGithubConfig contains configuration and information for completing an OAuth
 // 2.0 flow with GitHub as a provider.
 type AuthenticationMethodGithubConfig struct {
-	ClientSecret    string   `json:"clientSecret,omitempty" mapstructure:"client_secret"`
-	ClientId        string   `json:"clientId,omitempty" mapstructure:"client_id"`
+	ClientId        string   `json:"-" mapstructure:"client_id"`
+	ClientSecret    string   `json:"-" mapstructure:"client_secret"`
 	RedirectAddress string   `json:"redirectAddress,omitempty" mapstructure:"redirect_address"`
 	Scopes          []string `json:"scopes,omitempty" mapstructure:"scopes"`
 }

--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -108,7 +108,7 @@ type RedisCacheConfig struct {
 	Host            string        `json:"host,omitempty" mapstructure:"host"`
 	Port            int           `json:"port,omitempty" mapstructure:"port"`
 	RequireTLS      bool          `json:"requireTLS" mapstructure:"require_tls"`
-	Password        string        `json:"password,omitempty" mapstructure:"password"`
+	Password        string        `json:"-" mapstructure:"password"`
 	DB              int           `json:"db,omitempty" mapstructure:"db"`
 	PoolSize        int           `json:"poolSize" mapstructure:"pool_size"`
 	MinIdleConn     int           `json:"minIdleConn" mapstructure:"min_idle_conn"`

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -35,7 +35,7 @@ type DatabaseConfig struct {
 	ConnMaxLifetime           time.Duration    `json:"connMaxLifetime,omitempty" mapstructure:"conn_max_lifetime"`
 	Name                      string           `json:"name,omitempty" mapstructure:"name,omitempty"`
 	User                      string           `json:"user,omitempty" mapstructure:"user,omitempty"`
-	Password                  string           `json:"password,omitempty" mapstructure:"password,omitempty"`
+	Password                  string           `json:"-" mapstructure:"password,omitempty"`
 	Host                      string           `json:"host,omitempty" mapstructure:"host,omitempty"`
 	Port                      int              `json:"port,omitempty" mapstructure:"port,omitempty"`
 	Protocol                  DatabaseProtocol `json:"protocol,omitempty" mapstructure:"protocol,omitempty"`

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -18,8 +18,8 @@ type ServerConfig struct {
 	HTTPPort  int    `json:"httpPort,omitempty" mapstructure:"http_port"`
 	HTTPSPort int    `json:"httpsPort,omitempty" mapstructure:"https_port"`
 	GRPCPort  int    `json:"grpcPort,omitempty" mapstructure:"grpc_port"`
-	CertFile  string `json:"certFile,omitempty" mapstructure:"cert_file"`
-	CertKey   string `json:"certKey,omitempty" mapstructure:"cert_key"`
+	CertFile  string `json:"-" mapstructure:"cert_file"`
+	CertKey   string `json:"-" mapstructure:"cert_key"`
 }
 
 func (c *ServerConfig) setDefaults(v *viper.Viper) error {

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -105,7 +105,7 @@ type Git struct {
 	Repository     string         `json:"repository,omitempty" mapstructure:"repository"`
 	Ref            string         `json:"ref,omitempty" mapstructure:"ref"`
 	PollInterval   time.Duration  `json:"pollInterval,omitempty" mapstructure:"poll_interval"`
-	Authentication Authentication `json:"authentication,omitempty" mapstructure:"authentication,omitempty"`
+	Authentication Authentication `json:"-" mapstructure:"authentication,omitempty"`
 }
 
 // Object contains configuration of readonly object storage.
@@ -143,8 +143,8 @@ type S3 struct {
 // not all inputs are given but only partially, we will return a validation error.
 // (e.g. if username for basic auth is given, and token is also given a validation error will be returned)
 type Authentication struct {
-	BasicAuth *BasicAuth `json:"basic,omitempty" mapstructure:"basic,omitempty"`
-	TokenAuth *TokenAuth `json:"token,omitempty" mapstructure:"token,omitempty"`
+	BasicAuth *BasicAuth `json:"-" mapstructure:"basic,omitempty"`
+	TokenAuth *TokenAuth `json:"-" mapstructure:"token,omitempty"`
 }
 
 func (a *Authentication) validate() error {
@@ -165,8 +165,8 @@ func (a *Authentication) validate() error {
 // BasicAuth has configuration for authenticating with private git repositories
 // with basic auth.
 type BasicAuth struct {
-	Username string `json:"username,omitempty" mapstructure:"username"`
-	Password string `json:"password,omitempty" mapstructure:"password"`
+	Username string `json:"-" mapstructure:"username"`
+	Password string `json:"-" mapstructure:"password"`
 }
 
 func (b BasicAuth) validate() error {


### PR DESCRIPTION
do not expose secrets to JSON endpoints

we should come up with a strategy to test for this to prevent regressions and also to guard against any future config options having to do with secrets