### PR TITLE
feat: cmd shell completions

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,6 +48,8 @@ release:
 
     ```bash
       brew install flipt-io/brew/flipt
+      # or upgrade existing
+      brew update && brew upgrade flipt
     ```
 
     ### Docker Images :whale:
@@ -140,6 +142,12 @@ brews:
     license: GPL-3.0-only
     folder: Formula
     skip_upload: auto
+    install: |
+      bin.install "flipt"
+      output = Utils.popen_read("SHELL=bash #{bin}/flipt completion bash")
+      (bash_completion/"flipt").write output
+      output = Utils.popen_read("SHELL=zsh #{bin}/flipt completion zsh")
+      (zsh_completion/"_flipt").write output
 
     post_install: |
       (var/"log/flipt").mkpath

--- a/cmd/flipt/completion.go
+++ b/cmd/flipt/completion.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// completionCmd represents the completion command
+func newCompletionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "completion [SHELL]",
+		Short:  "Generate completion scripts",
+		Args:   cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "bash":
+				_ = cmd.Root().GenBashCompletion(cmd.OutOrStdout())
+			case "zsh":
+				_ = cmd.Root().GenZshCompletion(cmd.OutOrStdout())
+			case "fish":
+				_ = cmd.Root().GenFishCompletion(cmd.OutOrStdout(), true)
+			case "powershell":
+				_ = cmd.Root().GenPowerShellCompletion(cmd.OutOrStdout())
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/flipt/config.go
+++ b/cmd/flipt/config.go
@@ -68,7 +68,7 @@ func (c *initCommand) run(cmd *cobra.Command, args []string) error {
 }
 
 func newConfigCommand() *cobra.Command {
-	var configCmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage Flipt configuration",
 	}
@@ -83,6 +83,8 @@ func newConfigCommand() *cobra.Command {
 
 	init.Flags().BoolVarP(&initCmd.force, "force", "y", false, "Overwrite existing configuration file")
 
-	configCmd.AddCommand(init)
-	return configCmd
+	cmd.PersistentFlags().StringVar(&providedConfigFile, "config", "", "path to config file")
+	cmd.AddCommand(init)
+
+	return cmd
 }

--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -57,6 +57,7 @@ func newExportCommand() *cobra.Command {
 		"source namespace for exported resources.",
 	)
 
+	cmd.Flags().StringVar(&providedConfigFile, "config", "", "path to config file")
 	return cmd
 }
 

--- a/cmd/flipt/import.go
+++ b/cmd/flipt/import.go
@@ -74,6 +74,7 @@ func newImportCommand() *cobra.Command {
 		"create the namespace if it does not exist.",
 	)
 
+	cmd.Flags().StringVar(&providedConfigFile, "config", "", "path to config file")
 	return cmd
 }
 

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -129,7 +129,7 @@ func exec() error {
 	banner = buf.String()
 
 	rootCmd.SetVersionTemplate(banner)
-	rootCmd.PersistentFlags().StringVar(&providedConfigFile, "config", "", "path to config file")
+	rootCmd.Flags().StringVar(&providedConfigFile, "config", "", "path to config file")
 	rootCmd.Flags().BoolVar(&forceMigrate, "force-migrate", false, "force migrations before running")
 	_ = rootCmd.Flags().MarkHidden("force-migrate")
 
@@ -138,6 +138,7 @@ func exec() error {
 	rootCmd.AddCommand(newImportCommand())
 	rootCmd.AddCommand(newValidateCommand())
 	rootCmd.AddCommand(newConfigCommand())
+	rootCmd.AddCommand(newCompletionCommand())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/flipt/migrate.go
+++ b/cmd/flipt/migrate.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newMigrateCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "migrate",
 		Short: "Run pending database migrations",
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -35,4 +35,7 @@ func newMigrateCommand() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(&providedConfigFile, "config", "", "path to config file")
+	return cmd
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -983,7 +983,6 @@ github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUB
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
@@ -1244,6 +1243,7 @@ go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85
 go.opentelemetry.io/otel/exporters/otlp v0.20.0/go.mod h1:YIieizyaN77rtLJra0buKiNBOm9XQfkPEKBeuhoMwAM=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0/go.mod h1:VpP4/RMn8bv8gNo9uK7/IMY4mtWLELsS+JIP0inH0h4=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.14.0/go.mod h1:UFG7EBMRdXyFstOwH028U0sVf+AvukSGhF0g8+dmNG8=
+go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 h1:t4ZwRPU+emrcvM2e9DHd0Fsf0JTPVcbfa/BhTDF03d0=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0/go.mod h1:vLarbg68dH2Wa77g71zmKQqlQ8+8Rq3GRG31uc0WcWI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0/go.mod h1:hO1KLR7jcKaDDKDkvI9dP/FIhpmna5lkqPUQdEjFAM8=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.14.0/go.mod h1:HrbCVv40OOLTABmOn1ZWty6CHXkU8DK/Urc43tHug70=
@@ -1251,6 +1251,7 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.17.0/go.mod h1:aFsJfCEnLzEu
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.3.0/go.mod h1:keUU7UfnwWTWpJ+FWnyqmogPa82nuU5VUANFq49hlMY=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.14.0/go.mod h1:5w41DY6S9gZrbjuq6Y+753e96WfPha5IcsOSZTtullM=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.3.0/go.mod h1:QNX1aly8ehqqX1LEa6YniTU7VY9I6R3X/oPxhGdTceE=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.14.0 h1:3jAYbRHQAqzLjd9I4tzxwJ8Pk/N6AqBcF6m1ZHrxG94=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.14.0/go.mod h1:+N7zNjIJv4K+DeX67XXET0P+eIciESgaFDBqh+ZJFS4=
 go.opentelemetry.io/otel/metric v0.20.0/go.mod h1:598I5tYlH1vzBjn+BTuhzTCSb/9debfNp6R3s7Pr1eU=
 go.opentelemetry.io/otel/metric v0.37.0/go.mod h1:DmdaHfGt54iV6UKxsV9slj2bBRJcKC1B1uvDLIioc1s=
@@ -1478,7 +1479,6 @@ gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 gotest.tools/v3 v3.5.0/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=


### PR DESCRIPTION
![2023-09-25 11 34 33](https://github.com/flipt-io/flipt/assets/209477/7c1e6bda-b689-470c-99bc-34d25535087c)

- Adds shell completion to CLI
- Install shell completion via homebrew (goreleaser)
- Moves `--config` option from global to only the commands that leverage it