### PR TITLE
Fix goreleaser

### DIFF
--- a/.goreleaser.darwin.yml
+++ b/.goreleaser.darwin.yml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 
+project_name: flipt
+
 monorepo:
   tag_prefix: v
 

--- a/.goreleaser.linux.yml
+++ b/.goreleaser.linux.yml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 
+project_name: flipt
+
 monorepo:
   tag_prefix: v
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 
+project_name: flipt
+
 monorepo:
   tag_prefix: v
 


### PR DESCRIPTION
Fixes broken releases by setting `project_name` field for GoReleaser

Before (Broken): https://github.com/flipt-io/flipt/actions/runs/6305618044/job/17119520010

This PR (Fixed): https://github.com/flipt-io/flipt/actions/runs/6317979263/job/17156184368