### PR TITLE
feat: Support YAML stream for FS Backends

### DIFF
--- a/internal/cue/testdata/invalid_yaml_stream.yaml
+++ b/internal/cue/testdata/invalid_yaml_stream.yaml
@@ -1,0 +1,74 @@
+namespace: default
+flags:
+- key: flipt
+  name: flipt
+  description: flipt
+  enabled: false
+  variants:
+  - key: flipt
+    name: flipt
+  - key: flipt
+    name: flipt
+  rules:
+  - segment: internal-users
+    rank: 1
+    distributions:
+    - variant: fromFlipt
+      rollout: 100
+  - segment: all-users
+    rank: 2
+    distributions:
+    - variant: fromFlipt2
+      rollout: 100
+segments:
+- key: all-users
+  name: All Users
+  description: All Users
+  match_type: ALL_MATCH_TYPE
+- key: internal-users
+  name: Internal Users
+  description: All internal users at flipt.
+  constraints:
+  - type: STRING_COMPARISON_TYPE
+    property: organization
+    operator: eq
+    value: flipt
+  match_type: ALL_MATCH_TYPE
+---
+namespace: foo
+flags:
+- key: flipt
+  name: flipt
+  description: flipt
+  enabled: false
+  variants:
+  - key: flipt
+    name: flipt
+  - key: flipt
+    name: flipt
+  rules:
+  - segment: internal-users
+    rank: 1
+    distributions:
+    - variant: fromFlipt
+      rollout: 100
+  - segment: all-users
+    rank: 2
+    distributions:
+    - variant: fromFlipt2
+      rollout: 110
+segments:
+- key: all-users
+  name: All Users
+  description: All Users
+  match_type: ALL_MATCH_TYPE
+- key: internal-users
+  name: Internal Users
+  description: All internal users at flipt.
+  constraints:
+  - type: STRING_COMPARISON_TYPE
+    property: organization
+    operator: eq
+    value: flipt
+  match_type: ALL_MATCH_TYPE
+

--- a/internal/cue/testdata/valid_yaml_stream.yaml
+++ b/internal/cue/testdata/valid_yaml_stream.yaml
@@ -1,0 +1,97 @@
+namespace: default
+flags:
+- key: flipt
+  name: flipt
+  description: flipt
+  enabled: false
+  variants:
+  - key: flipt
+    name: flipt
+  - key: flipt
+    name: flipt
+    description: I'm a description.
+  rules:
+  - segment: internal-users
+    distributions:
+    - variant: fromFlipt
+      rollout: 100
+  - segment: all-users
+    distributions:
+    - variant: fromFlipt2
+      rollout: 100
+- key: boolean
+  name: Boolean
+  description: Boolean flag
+  enabled: false
+  rollouts:
+  - description: enabled for internal users
+    segment:
+      key: internal-users
+      value: true
+  - description: enabled for 50%
+    threshold:
+      percentage: 50.0
+      value: true
+segments:
+- key: all-users
+  name: All Users
+  description: All Users
+  match_type: ALL_MATCH_TYPE
+- key: internal-users
+  name: Internal Users
+  description: All internal users at flipt.
+  constraints:
+  - type: STRING_COMPARISON_TYPE
+    property: organization
+    operator: eq
+    value: flipt
+  match_type: ALL_MATCH_TYPE
+---
+namespace: foo
+flags:
+- key: flipt
+  name: flipt
+  description: flipt
+  enabled: false
+  variants:
+  - key: flipt
+    name: flipt
+  - key: flipt
+    name: flipt
+    description: I'm a description.
+  rules:
+  - segment: internal-users
+    distributions:
+    - variant: fromFlipt
+      rollout: 100
+  - segment: all-users
+    distributions:
+    - variant: fromFlipt2
+      rollout: 100
+- key: boolean
+  name: Boolean
+  description: Boolean flag
+  enabled: false
+  rollouts:
+  - description: enabled for internal users
+    segment:
+      key: internal-users
+      value: true
+  - description: enabled for 50%
+    threshold:
+      percentage: 50.0
+      value: true
+segments:
+- key: all-users
+  name: All Users
+  description: All Users
+  match_type: ALL_MATCH_TYPE
+- key: internal-users
+  name: Internal Users
+  description: All internal users at flipt.
+  constraints:
+  - type: STRING_COMPARISON_TYPE
+    property: organization
+    operator: eq
+    value: flipt
+  match_type: ALL_MATCH_TYPE

--- a/internal/cue/validate.go
+++ b/internal/cue/validate.go
@@ -20,9 +20,8 @@ var cueFile []byte
 // Location contains information about where an error has occurred during cue
 // validation.
 type Location struct {
-	File   string `json:"file,omitempty"`
-	Line   int    `json:"line"`
-	Column int    `json:"column"`
+	File string `json:"file,omitempty"`
+	Line int    `json:"line"`
 }
 
 type unwrapable interface {
@@ -57,12 +56,11 @@ func (e Error) Format(f fmt.State, verb rune) {
 - Message  : %s
   File     : %s
   Line     : %d
-  Column   : %d
-`, e.Message, e.Location.File, e.Location.Line, e.Location.Column)
+`, e.Message, e.Location.File, e.Location.Line)
 }
 
 func (e Error) Error() string {
-	return fmt.Sprintf("%s (%s %d:%d)", e.Message, e.Location.File, e.Location.Line, e.Location.Column)
+	return fmt.Sprintf("%s (%s %d)", e.Message, e.Location.File, e.Location.Line)
 }
 
 type FeaturesValidator struct {
@@ -105,7 +103,6 @@ func (v FeaturesValidator) validateSingleDocument(file string, f *ast.File, offs
 		if pos := cueerrors.Positions(e); len(pos) > 0 {
 			p := pos[len(pos)-1]
 			rerr.Location.Line = p.Line() + offset
-			rerr.Location.Column = p.Column()
 		}
 
 		errs = append(errs, rerr)

--- a/internal/cue/validate_fuzz_test.go
+++ b/internal/cue/validate_fuzz_test.go
@@ -4,7 +4,7 @@
 package cue
 
 import (
-	"io"
+	"bytes"
 	"os"
 	"testing"
 )
@@ -13,18 +13,18 @@ func FuzzValidate(f *testing.F) {
 	testcases := []string{"testdata/valid.yml", "testdata/invalid.yml"}
 
 	for _, tc := range testcases {
-		fi, _ := os.Open(tc)
+		fi, _ := os.ReadFile(tc)
 		f.Add(fi)
 	}
 
-	f.Fuzz(func(t *testing.T, in io.Reader) {
+	f.Fuzz(func(t *testing.T, in []byte) {
 		validator, err := NewFeaturesValidator()
 		if err != nil {
 			// only care about errors from Validating
 			t.Skip()
 		}
 
-		if err := validator.Validate("foo", in); err != nil {
+		if err := validator.Validate("foo", bytes.NewBuffer(in)); err != nil {
 			// we only care about panics
 			t.Skip()
 		}

--- a/internal/cue/validate_fuzz_test.go
+++ b/internal/cue/validate_fuzz_test.go
@@ -4,6 +4,7 @@
 package cue
 
 import (
+	"io"
 	"os"
 	"testing"
 )
@@ -12,11 +13,11 @@ func FuzzValidate(f *testing.F) {
 	testcases := []string{"testdata/valid.yml", "testdata/invalid.yml"}
 
 	for _, tc := range testcases {
-		b, _ := os.ReadFile(tc)
-		f.Add(b)
+		fi, _ := os.Open(tc)
+		f.Add(fi)
 	}
 
-	f.Fuzz(func(t *testing.T, in []byte) {
+	f.Fuzz(func(t *testing.T, in io.Reader) {
 		validator, err := NewFeaturesValidator()
 		if err != nil {
 			// only care about errors from Validating

--- a/internal/cue/validate_test.go
+++ b/internal/cue/validate_test.go
@@ -42,6 +42,17 @@ func TestValidate_Latest_Segments_V2(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidate_YAML_Stream(t *testing.T) {
+	f, err := os.Open("testdata/valid_yaml_stream.yaml")
+	require.NoError(t, err)
+
+	v, err := NewFeaturesValidator()
+	require.NoError(t, err)
+
+	err = v.Validate("testdata/valid_yaml_stream.yaml", f)
+	assert.NoError(t, err)
+}
+
 func TestValidate_Failure(t *testing.T) {
 	f, err := os.Open("testdata/invalid.yaml")
 	require.NoError(t, err)
@@ -60,5 +71,24 @@ func TestValidate_Failure(t *testing.T) {
 	assert.Equal(t, "flags.0.rules.1.distributions.0.rollout: invalid value 110 (out of bound <=100)", ferr.Message)
 	assert.Equal(t, "testdata/invalid.yaml", ferr.Location.File)
 	assert.Equal(t, 22, ferr.Location.Line)
-	assert.Equal(t, 17, ferr.Location.Column)
+}
+
+func TestValidate_Failure_YAML_Stream(t *testing.T) {
+	f, err := os.Open("testdata/invalid_yaml_stream.yaml")
+	require.NoError(t, err)
+
+	v, err := NewFeaturesValidator()
+	require.NoError(t, err)
+
+	err = v.Validate("testdata/invalid_yaml_stream.yaml", f)
+
+	errs, ok := Unwrap(err)
+	require.True(t, ok)
+
+	var ferr Error
+	require.True(t, errors.As(errs[0], &ferr))
+
+	assert.Equal(t, "flags.0.rules.1.distributions.0.rollout: invalid value 110 (out of bound <=100)", ferr.Message)
+	assert.Equal(t, "testdata/invalid_yaml_stream.yaml", ferr.Location.File)
+	assert.Equal(t, 59, ferr.Location.Line)
 }

--- a/internal/cue/validate_test.go
+++ b/internal/cue/validate_test.go
@@ -10,46 +10,46 @@ import (
 )
 
 func TestValidate_V1_Success(t *testing.T) {
-	b, err := os.ReadFile("testdata/valid_v1.yaml")
+	f, err := os.Open("testdata/valid_v1.yaml")
 	require.NoError(t, err)
 
 	v, err := NewFeaturesValidator()
 	require.NoError(t, err)
 
-	err = v.Validate("testdata/valid_v1.yaml", b)
+	err = v.Validate("testdata/valid_v1.yaml", f)
 	assert.NoError(t, err)
 }
 
 func TestValidate_Latest_Success(t *testing.T) {
-	b, err := os.ReadFile("testdata/valid.yaml")
+	f, err := os.Open("testdata/valid.yaml")
 	require.NoError(t, err)
 
 	v, err := NewFeaturesValidator()
 	require.NoError(t, err)
 
-	err = v.Validate("testdata/valid.yaml", b)
+	err = v.Validate("testdata/valid.yaml", f)
 	assert.NoError(t, err)
 }
 
 func TestValidate_Latest_Segments_V2(t *testing.T) {
-	b, err := os.ReadFile("testdata/valid_segments_v2.yaml")
+	f, err := os.Open("testdata/valid_segments_v2.yaml")
 	require.NoError(t, err)
 
 	v, err := NewFeaturesValidator()
 	require.NoError(t, err)
 
-	err = v.Validate("testdata/valid_segments_v2.yaml", b)
+	err = v.Validate("testdata/valid_segments_v2.yaml", f)
 	assert.NoError(t, err)
 }
 
 func TestValidate_Failure(t *testing.T) {
-	b, err := os.ReadFile("testdata/invalid.yaml")
+	f, err := os.Open("testdata/invalid.yaml")
 	require.NoError(t, err)
 
 	v, err := NewFeaturesValidator()
 	require.NoError(t, err)
 
-	err = v.Validate("testdata/invalid.yaml", b)
+	err = v.Validate("testdata/invalid.yaml", f)
 
 	errs, ok := Unwrap(err)
 	require.True(t, ok)

--- a/internal/storage/fs/fixtures/fswithindex/prod/prod.features.yml
+++ b/internal/storage/fs/fixtures/fswithindex/prod/prod.features.yml
@@ -208,4 +208,3 @@ segments:
     operator: eq
     value: baz
   match_type: ANY_MATCH_TYPE
-

--- a/internal/storage/fs/fixtures/yaml_stream/features.yaml
+++ b/internal/storage/fs/fixtures/yaml_stream/features.yaml
@@ -1,0 +1,27 @@
+namespace: fruit
+flags:
+- key: apple
+  name: Apple
+  variants:
+  - key: royal-gala
+  - key: pink-lady
+  rules:
+    - segment: internal
+segments:
+- key: internal
+  name: Internal
+  match_type: ANY_MATCH_TYPE
+---
+namespace: football
+flags:
+- key: team
+  name: Team
+  variants:
+  - key: bears
+  - key: rams
+  rules:
+    - segment: internal
+segments:
+- key: internal
+  name: Internal
+  match_type: ANY_MATCH_TYPE

--- a/internal/storage/fs/snapshot_test.go
+++ b/internal/storage/fs/snapshot_test.go
@@ -1661,3 +1661,48 @@ func TestFS_Invalid_BooleanFlag_Segment(t *testing.T) {
 	_, err := SnapshotFromFS(zaptest.NewLogger(t), fs)
 	require.EqualError(t, err, "flag fruit/apple rule 1 references unknown segment \"unknown\"")
 }
+
+func TestFS_YAML_Stream(t *testing.T) {
+	fs, _ := fs.Sub(testdata, "fixtures/yaml_stream")
+	ss, err := SnapshotFromFS(zaptest.NewLogger(t), fs)
+	require.NoError(t, err)
+
+	ns, err := ss.ListNamespaces(context.TODO())
+	require.NoError(t, err)
+
+	// 3 namespaces including default
+	assert.Len(t, ns.Results, 3)
+	var namespaces = make([]string, 0, len(ns.Results))
+
+	for _, n := range ns.Results {
+		namespaces = append(namespaces, n.Key)
+	}
+
+	for _, namespace := range []string{"default", "football", "fruit"} {
+		assert.Contains(t, namespaces, namespace)
+	}
+
+	fflags, err := ss.ListFlags(context.TODO(), "football")
+	require.NoError(t, err)
+
+	assert.Len(t, fflags.Results, 1)
+	assert.Equal(t, "team", fflags.Results[0].Key)
+
+	frflags, err := ss.ListFlags(context.TODO(), "fruit")
+	require.NoError(t, err)
+
+	assert.Len(t, frflags.Results, 1)
+	assert.Equal(t, "apple", frflags.Results[0].Key)
+
+	fsegments, err := ss.ListSegments(context.TODO(), "football")
+	require.NoError(t, err)
+
+	assert.Len(t, fsegments.Results, 1)
+	assert.Equal(t, "internal", fsegments.Results[0].Key)
+
+	frsegments, err := ss.ListSegments(context.TODO(), "fruit")
+	require.NoError(t, err)
+
+	assert.Len(t, frsegments.Results, 1)
+	assert.Equal(t, "internal", frsegments.Results[0].Key)
+}


### PR DESCRIPTION
We have recently added the ability to import/export files with multiple YAML documents contained within them. This PR adds the ability for the FS backends to craft flag state from either single document YAML files, multi-document YAML files or both.

This change also has the effect of removing the column number from error reporting out of the cue validate logic.

I talked with @markphelps offline about this, it seems that supporting YAML streams with cue's File semantics is a bit weird. We can follow up with this issue on another iteration.

Completes FLI-618