### PR TITLE
feat: Gen cli docs

### DIFF
--- a/build/testing/testdata/cli.txt
+++ b/build/testing/testdata/cli.txt
@@ -12,9 +12,9 @@ $ flipt --config /path/to/config.yml migrate
 
 Available Commands:
   config      Manage Flipt configuration
-  export      Export flags/segments/rules to file/stdout
+  export      Export Flipt data to file/stdout
   help        Help about any command
-  import      Import flags/segments/rules from file
+  import      Import Flipt data from file/stdin
   migrate     Run pending database migrations
   validate    Validate Flipt flag state (.yaml, .yml) files
 

--- a/cmd/flipt/doc.go
+++ b/cmd/flipt/doc.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+// docCommand represents the documentation command
+func newDocCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "doc",
+		Short:  "Generate command documentation",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := os.MkdirAll("./tmp/docs", 0755); err != nil {
+				return fmt.Errorf("failed to create docs directory: %w", err)
+			}
+
+			return doc.GenMarkdownTree(cmd.Root(), "./tmp/docs")
+		},
+	}
+}

--- a/cmd/flipt/doc.go
+++ b/cmd/flipt/doc.go
@@ -11,11 +11,15 @@ import (
 // docCommand represents the documentation command
 func newDocCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:    "doc",
+		Use:    "doc [path]",
 		Short:  "Generate command documentation",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := os.MkdirAll("./tmp/docs", 0755); err != nil {
+			path := "./tmp/docs"
+			if len(args) > 0 {
+				path = args[0]
+			}
+			if err := os.MkdirAll(path, 0755); err != nil {
 				return fmt.Errorf("failed to create docs directory: %w", err)
 			}
 

--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -26,7 +26,7 @@ func newExportCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "export",
-		Short: "Export flags/segments/rules to file/stdout",
+		Short: "Export Flipt data to file/stdout",
 		RunE:  export.run,
 	}
 

--- a/cmd/flipt/import.go
+++ b/cmd/flipt/import.go
@@ -25,7 +25,7 @@ func newImportCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "import",
-		Short: "Import flags/segments/rules from file",
+		Short: "Import Flipt data from file/stdin",
 		RunE:  importCmd.run,
 	}
 

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -139,6 +139,7 @@ func exec() error {
 	rootCmd.AddCommand(newValidateCommand())
 	rootCmd.AddCommand(newConfigCommand())
 	rootCmd.AddCommand(newCompletionCommand())
+	rootCmd.AddCommand(newDocCommand())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/codahale/hdrhistogram v0.0.0-00010101000000-000000000000 // indirect
 	github.com/containerd/containerd v1.7.3 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -162,6 +163,7 @@ require (
 	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.43.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/segmentio/backo-go v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,7 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cpuguy83/dockercfg v0.3.1 h1:/FpZ+JaygUR/lZP2NlFI2DVfrOEMAIKP5wWEJdoYe9E=
 github.com/cpuguy83/dockercfg v0.3.1/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -553,6 +554,7 @@ github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=


### PR DESCRIPTION
re: FLI-608

- adds hidden subcommand to enable us to generate the CLI docs for copy/pasting into our actual documentation

## Usage

```
$ flipt docs
$ tree tmp/docs/
tmp/docs/
├── flipt.md
├── flipt_config.md
├── flipt_config_edit.md
├── flipt_config_init.md
├── flipt_export.md
├── flipt_import.md
├── flipt_migrate.md
└── flipt_validate.md

1 directory, 8 files
```
