### PR TITLE
chore: specify region to fix s3 feature

### DIFF
--- a/internal/storage/fs/s3/source.go
+++ b/internal/storage/fs/s3/source.go
@@ -49,7 +49,7 @@ func NewSource(logger *zap.Logger, bucket string, opts ...containers.Option[Sour
 					PartitionID:       "aws",
 					URL:               s.endpoint,
 					HostnameImmutable: true,
-					SigningRegion:     "",
+					SigningRegion:     s.region,
 				}, nil
 			}
 			return aws.Endpoint{}, fmt.Errorf("unknown endpoint requested")


### PR DESCRIPTION
The application was not honoring the region configuration.

This PR will set the region value from configuration wherever it was set, either environment variable or configuration file.

Without this the following error occurred:

```
Error: Open .flipt.yml: operation error S3: GetObject, https response error StatusCode: 400, RequestID: N7MN8TJY9CFY5BXF, HostID: 7KtR0/CRqaCS7aU4+8LLyDz9MTw2aFPEE/a7VSMUk6JE5DEnl8xCYalJHuBBkCKiB9rN65cZmb8=, api error AuthorizationHeaderMalformed: The authorization header is malformed; a non-empty region must be provided in the credential.
```