### PR TITLE
fix: csp header for monaco editor

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -90,7 +90,7 @@ func NewHTTPServer(
 	// TODO: replace with more robust 'mode' detection
 	if !info.IsDevelopment() {
 		r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
-		r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; img-src * data:; frame-ancestors 'none';"))
+		r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src * data:; frame-ancestors 'none';"))
 	}
 
 	r.Use(middleware.RequestID)
@@ -204,7 +204,7 @@ func NewHTTPServer(
 		return server, nil
 	}
 
-	server.Server.TLSConfig = &tls.Config{
+	server.TLSConfig = &tls.Config{
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
@@ -215,7 +215,7 @@ func NewHTTPServer(
 		},
 	}
 
-	server.Server.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
+	server.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler))
 
 	server.listenAndServe = func() error {
 		return server.ListenAndServeTLS(cfg.Server.CertFile, cfg.Server.CertKey)


### PR DESCRIPTION
Fixes: #2198 

Re: https://github.com/microsoft/monaco-editor/issues/271

Looks like this is required for using monaco editor 🤷🏻 

I tried it out by removing the:

```
if !info.IsDevelopment() { }
```

Reproduced it and then applied the fix.

Need to figure out how to better test this, or if the `info.IsDevelopment` check is even necessary anymore (I think its only necessary if you run the server (Go) and the UI (React) on different ports like when wanting to iterate quickly on the UI without recompiling