### PR TITLE
 fix(service/middleware): use separate cache keys for old and new evaluations

### DIFF
--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -118,7 +118,7 @@ func EvaluationUnaryInterceptor(ctx context.Context, req interface{}, _ *grpc.Un
 }
 
 var (
-	legacyEvalCache    evaluationCacheKey[*flipt.EvaluationRequest]      = "e"
+	legacyEvalCache    evaluationCacheKey[*flipt.EvaluationRequest]      = "ev1"
 	newEvaluationCache evaluationCacheKey[*evaluation.EvaluationRequest] = "ev2"
 )
 

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -118,8 +118,8 @@ func EvaluationUnaryInterceptor(ctx context.Context, req interface{}, _ *grpc.Un
 }
 
 var (
-	legacyEvalCache    evaluationCacheKey[*flipt.EvaluationRequest]      = "ev1"
-	newEvaluationCache evaluationCacheKey[*evaluation.EvaluationRequest] = "ev2"
+	legacyEvalCachePrefix evaluationCacheKey[*flipt.EvaluationRequest]      = "ev1"
+	newEvalCachePrefix    evaluationCacheKey[*evaluation.EvaluationRequest] = "ev2"
 )
 
 // CacheUnaryInterceptor caches the response of a request if the request is cacheable.
@@ -132,7 +132,7 @@ func CacheUnaryInterceptor(cache cache.Cacher, logger *zap.Logger) grpc.UnarySer
 
 		switch r := req.(type) {
 		case *flipt.EvaluationRequest:
-			key, err := legacyEvalCache.Key(r)
+			key, err := legacyEvalCachePrefix.Key(r)
 			if err != nil {
 				logger.Error("getting cache key", zap.Error(err))
 				return handler(ctx, req)
@@ -233,7 +233,7 @@ func CacheUnaryInterceptor(cache cache.Cacher, logger *zap.Logger) grpc.UnarySer
 				logger.Error("deleting from cache", zap.Error(err))
 			}
 		case *evaluation.EvaluationRequest:
-			key, err := newEvaluationCache.Key(r)
+			key, err := newEvalCachePrefix.Key(r)
 			if err != nil {
 				logger.Error("getting cache key", zap.Error(err))
 				return handler(ctx, req)


### PR DESCRIPTION
Fixes https://github.com/flipt-io/flipt/issues/2236

It was reported that the API responds inconsistently when the cache is enabled and you attempt to evaluate using both the new and the legacy API. @rudineirk correctly identified the root cause being that the cache key is shared for both the old and new evaluation responses. Further investigation showed that when Flipt attempts to unmarshall a new evaluation API response payload into the old protobuf type, it succeeds to unmarshal (no wire protocol errors). However, what it produces is an invalid result as the fields are all in different locations.

This means the API responds as a successful evaluation, however, it returns a completely invalid result. For example, this leads to a flag incorrectly reporting as disabled.

The fix for this change is to use separate cache prefixes for the different evaluation response types.
This PR includes the change to prefix the two type seperately when storing them in the cache.