### PR TITLE
feat(git): support SSH authentication

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -144,13 +144,13 @@ import "strings"
 				token: access_token: string
 			} | {
 				ssh: {
-					user:             string
+					user?:            string | *"git"
 					password:         string
 					private_key_path: string
 				}
 			} | {
 				ssh: {
-					user:              string
+					user?:             string | *"git"
 					password:          string
 					private_key_bytes: string
 				}

--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -142,6 +142,18 @@ import "strings"
 				}
 			} | {
 				token: access_token: string
+			} | {
+				ssh: {
+					user:             string
+					password:         string
+					private_key_path: string
+				}
+			} | {
+				ssh: {
+					user:              string
+					password:          string
+					private_key_bytes: string
+				}
 			})
 		}
 		object?: {

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -544,6 +544,34 @@
                       }
                     }
                   }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "user": {"type": "string"},
+                        "password": {"type": "string"},
+                        "private_key_path": {"type": "string"}
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "user": {"type": "string"},
+                        "password": {"type": "string"},
+                        "private_key_bytes": {"type": "string"}
+                      }
+                    }
+                  }
                 }
               ]
             }

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0
 	go.uber.org/zap v1.26.0
+	golang.org/x/crypto v0.14.0
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/net v0.17.0
 	golang.org/x/oauth2 v0.13.0
@@ -199,7 +200,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/term v0.13.0 // indirect

--- a/go.work.sum
+++ b/go.work.sum
@@ -580,12 +580,14 @@ github.com/hanwen/go-fuse/v2 v2.1.1-0.20220112183258-f57e95bda82d/go.mod h1:B1nG
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.25.1/go.mod h1:iiLVwR/htV7mas/sy0O+XSuEnrdBUUydemjxcUrAt4g=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/consul/sdk v0.14.1/go.mod h1:vFt03juSzocLRFo59NkeQHHmQa6+g7oU0pfzdI1mUhg=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-msgpack v0.5.5/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
@@ -730,6 +732,7 @@ github.com/mutecomm/go-sqlcipher/v4 v4.4.0/go.mod h1:PyN04SaWalavxRGH9E8ZftG6Ju7
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
 github.com/nats-io/jwt/v2 v2.4.1/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
+github.com/nats-io/nats-server/v2 v2.9.20/go.mod h1:aTb/xtLCGKhfTFLxP591CMWfkdgBmcUUSkiSOe5A3gw=
 github.com/nats-io/nats.go v1.30.2/go.mod h1:dcfhUgmQNN4GJEfIb2f9R7Fow+gzBF4emzDHrVBd5qM=
 github.com/nats-io/nkeys v0.4.5/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
@@ -1063,6 +1066,7 @@ golang.org/x/oauth2 v0.6.0/go.mod h1:ycmewcwgD4Rpr3eZJLSB4Kyyljb3qDh40vJ8STE5HKw
 golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4=
 golang.org/x/oauth2 v0.8.0/go.mod h1:yr7u4HXZRm1R1kBWqr/xKNqewf0plRYoB7sla+BCIXE=
 golang.org/x/oauth2 v0.10.0/go.mod h1:kTpgurOux7LqtuxjuyZa4Gj2gdezIt/jQtGnNFfypQI=
+golang.org/x/oauth2 v0.11.0/go.mod h1:LdF7O/8bLR/qWK9DrpXmbHLTouvRHK0SgJl0GmDBchk=
 golang.org/x/sync v0.2.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1109,13 +1113,13 @@ golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20220722155259-a9ba230a4035/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.11.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
@@ -1167,6 +1171,7 @@ google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4/go.mod h1:NWraEVix
 google.golang.org/genproto v0.0.0-20230320184635-7606e756e683/go.mod h1:NWraEVixdDnqcqQ30jipen1STv2r/n24Wb7twVTGR4s=
 google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:xZnkP7mREFX5MORlOPEzLMr+90PPZQ2QWzrVTWfAq64=
 google.golang.org/genproto v0.0.0-20230711160842-782d3b101e98/go.mod h1:S7mY02OqCJTD0E1OiQy1F72PWFB4bZJ87cAtLPYgDR0=
+google.golang.org/genproto v0.0.0-20230822172742-b8732ec3820d/go.mod h1:yZTlhN0tQnXo3h00fuXNCxJdLdIdnVFVBaRJ5LWBbw4=
 google.golang.org/genproto v0.0.0-20230913181813-007df8e322eb/go.mod h1:yZTlhN0tQnXo3h00fuXNCxJdLdIdnVFVBaRJ5LWBbw4=
 google.golang.org/genproto v0.0.0-20231002182017-d307bd883b97/go.mod h1:t1VqOqqvce95G3hIDCT5FeO3YUc6Q4Oe24L/+rNMxRk=
 google.golang.org/genproto/googleapis/api v0.0.0-20230530153820-e85fd2cbaebc/go.mod h1:vHYtlOoi6TsQ3Uk2yxR7NI5z8uoV+3pZtR4jmHIkRig=

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -186,11 +186,9 @@ func NewGRPCServer(
 				return nil, err
 			}
 
-			// TODO(georgemac): In the future we may want to support a static set
-			// of trusted known hosts. Or perhaps a process similar to local ssh
-			// whereby the first interaction with the server writes down the host
-			// and key pair for future reference.
-			method.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+			if auth.SSHAuth.InsecureIgnoreHostKey {
+				method.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+			}
 
 			opts = append(opts, git.WithAuth(method))
 		}

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -186,7 +186,10 @@ func NewGRPCServer(
 				return nil, err
 			}
 
+			// we're protecting against this explicitly so we can disable
+			// the gosec linting rule
 			if auth.SSHAuth.InsecureIgnoreHostKey {
+				// nolint:gosec
 				method.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 			}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -669,11 +669,6 @@ func TestLoad(t *testing.T) {
 			wantErr: errors.New("both username and password need to be provided for basic auth"),
 		},
 		{
-			name:    "git ssh auth missing user",
-			path:    "./testdata/storage/git_ssh_auth_invalid_missing_user.yml",
-			wantErr: errors.New("ssh authentication: user required"),
-		},
-		{
 			name:    "git ssh auth missing password",
 			path:    "./testdata/storage/git_ssh_auth_invalid_missing_password.yml",
 			wantErr: errors.New("ssh authentication: password required"),
@@ -701,7 +696,7 @@ func TestLoad(t *testing.T) {
 						PollInterval: 30 * time.Second,
 						Authentication: Authentication{
 							SSHAuth: &SSHAuth{
-								User:           "foo",
+								User:           "git",
 								Password:       "bar",
 								PrivateKeyPath: "/path/to/pem.key",
 							},
@@ -798,14 +793,15 @@ func TestLoad(t *testing.T) {
 
 			if wantErr != nil {
 				t.Log(err)
-				match := false
-				if errors.Is(err, wantErr) {
-					match = true
-				} else if err.Error() == wantErr.Error() {
-					match = true
+				if err == nil {
+					require.Failf(t, "expected error", "expected %q, found <nil>", wantErr)
 				}
-				require.True(t, match, "expected error %v to match: %v", err, wantErr)
-				return
+				if errors.Is(err, wantErr) {
+					return
+				} else if err.Error() == wantErr.Error() {
+					return
+				}
+				require.Fail(t, "expected error", "expected %q, found %q", err, wantErr)
 			}
 
 			require.NoError(t, err)
@@ -845,14 +841,15 @@ func TestLoad(t *testing.T) {
 
 			if wantErr != nil {
 				t.Log(err)
-				match := false
-				if errors.Is(err, wantErr) {
-					match = true
-				} else if err.Error() == wantErr.Error() {
-					match = true
+				if err == nil {
+					require.Failf(t, "expected error", "expected %q, found <nil>", wantErr)
 				}
-				require.True(t, match, "expected error %v to match: %v", err, wantErr)
-				return
+				if errors.Is(err, wantErr) {
+					return
+				} else if err.Error() == wantErr.Error() {
+					return
+				}
+				require.Fail(t, "expected error", "expected %q, found %q", err, wantErr)
 			}
 
 			require.NoError(t, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -669,6 +669,49 @@ func TestLoad(t *testing.T) {
 			wantErr: errors.New("both username and password need to be provided for basic auth"),
 		},
 		{
+			name:    "git ssh auth missing user",
+			path:    "./testdata/storage/git_ssh_auth_invalid_missing_user.yml",
+			wantErr: errors.New("ssh authentication: user required"),
+		},
+		{
+			name:    "git ssh auth missing password",
+			path:    "./testdata/storage/git_ssh_auth_invalid_missing_password.yml",
+			wantErr: errors.New("ssh authentication: password required"),
+		},
+		{
+			name:    "git ssh auth missing private key parts",
+			path:    "./testdata/storage/git_ssh_auth_invalid_private_key_missing.yml",
+			wantErr: errors.New("ssh authentication: please provide exclusively one of private_key_bytes or private_key_path"),
+		},
+		{
+			name:    "git ssh auth provided both private key forms",
+			path:    "./testdata/storage/git_ssh_auth_invalid_private_key_both.yml",
+			wantErr: errors.New("ssh authentication: please provide exclusively one of private_key_bytes or private_key_path"),
+		},
+		{
+			name: "git valid with ssh auth",
+			path: "./testdata/storage/git_ssh_auth_valid_with_path.yml",
+			expected: func() *Config {
+				cfg := Default()
+				cfg.Storage = StorageConfig{
+					Type: GitStorageType,
+					Git: &Git{
+						Ref:          "main",
+						Repository:   "git@github.com:foo/bar.git",
+						PollInterval: 30 * time.Second,
+						Authentication: Authentication{
+							SSHAuth: &SSHAuth{
+								User:           "foo",
+								Password:       "bar",
+								PrivateKeyPath: "/path/to/pem.key",
+							},
+						},
+					},
+				}
+				return cfg
+			},
+		},
+		{
 			name: "s3 config provided",
 			path: "./testdata/storage/s3_provided.yml",
 			expected: func() *Config {

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -43,6 +43,11 @@ func (c *StorageConfig) setDefaults(v *viper.Viper) error {
 	case string(GitStorageType):
 		v.SetDefault("storage.git.ref", "main")
 		v.SetDefault("storage.git.poll_interval", "30s")
+		if v.GetString("storage.git.authentication.ssh.password") != "" ||
+			v.GetString("storage.git.authentication.ssh.private_key_path") != "" ||
+			v.GetString("storage.git.authentication.ssh.private_key_bytes") != "" {
+			v.SetDefault("storage.git.authentication.ssh.user", "git")
+		}
 	case string(ObjectStorageType):
 		// keep this as a case statement in anticipation of
 		// more object types in the future
@@ -207,10 +212,6 @@ func (a SSHAuth) validate() (err error) {
 			err = fmt.Errorf("ssh authentication: %w", err)
 		}
 	}()
-
-	if a.User == "" {
-		return errors.New("user required")
-	}
 
 	if a.Password == "" {
 		return errors.New("password required")

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -200,10 +200,11 @@ func (t TokenAuth) validate() error { return nil }
 // SSHAuth provides configuration support for SSH private key credentials when
 // authenticating with private git repositories
 type SSHAuth struct {
-	User            string `json:"-" mapstructure:"user" yaml:"-" `
-	Password        string `json:"-" mapstructure:"password" yaml:"-" `
-	PrivateKeyBytes string `json:"-" mapstructure:"private_key_bytes" yaml:"-" `
-	PrivateKeyPath  string `json:"-" mapstructure:"private_key_path" yaml:"-" `
+	User                  string `json:"-" mapstructure:"user" yaml:"-" `
+	Password              string `json:"-" mapstructure:"password" yaml:"-" `
+	PrivateKeyBytes       string `json:"-" mapstructure:"private_key_bytes" yaml:"-" `
+	PrivateKeyPath        string `json:"-" mapstructure:"private_key_path" yaml:"-" `
+	InsecureIgnoreHostKey bool   `json:"-" mapstructure:"insecure_ignore_host_key" yaml:"-"`
 }
 
 func (a SSHAuth) validate() (err error) {

--- a/internal/config/testdata/storage/git_ssh_auth_invalid_missing_password.yml
+++ b/internal/config/testdata/storage/git_ssh_auth_invalid_missing_password.yml
@@ -1,0 +1,8 @@
+storage:
+  type: git
+  git:
+    repository: "git@github.com:foo/bar.git"
+    authentication:
+      ssh:
+        user: foo
+        private_key_path: "/path/to/pem.key"

--- a/internal/config/testdata/storage/git_ssh_auth_invalid_missing_user.yml
+++ b/internal/config/testdata/storage/git_ssh_auth_invalid_missing_user.yml
@@ -1,0 +1,8 @@
+storage:
+  type: git
+  git:
+    repository: "git@github.com:foo/bar.git"
+    authentication:
+      ssh:
+        password: foo
+        private_key_path: "/path/to/pem.key"

--- a/internal/config/testdata/storage/git_ssh_auth_invalid_missing_user.yml
+++ b/internal/config/testdata/storage/git_ssh_auth_invalid_missing_user.yml
@@ -1,8 +1,0 @@
-storage:
-  type: git
-  git:
-    repository: "git@github.com:foo/bar.git"
-    authentication:
-      ssh:
-        password: foo
-        private_key_path: "/path/to/pem.key"

--- a/internal/config/testdata/storage/git_ssh_auth_invalid_private_key_both.yml
+++ b/internal/config/testdata/storage/git_ssh_auth_invalid_private_key_both.yml
@@ -1,0 +1,10 @@
+storage:
+  type: git
+  git:
+    repository: "git@github.com:foo/bar.git"
+    authentication:
+      ssh:
+        user: foo
+        password: bar
+        private_key_path: "/path/to/pem.key"
+        private_key_bytes: "aswellassomepemdata"

--- a/internal/config/testdata/storage/git_ssh_auth_invalid_private_key_missing.yml
+++ b/internal/config/testdata/storage/git_ssh_auth_invalid_private_key_missing.yml
@@ -1,0 +1,8 @@
+storage:
+  type: git
+  git:
+    repository: "git@github.com:foo/bar.git"
+    authentication:
+      ssh:
+        user: foo
+        password: bar

--- a/internal/config/testdata/storage/git_ssh_auth_valid_with_path.yml
+++ b/internal/config/testdata/storage/git_ssh_auth_valid_with_path.yml
@@ -1,0 +1,9 @@
+storage:
+  type: git
+  git:
+    repository: "git@github.com:foo/bar.git"
+    authentication:
+      ssh:
+        user: foo
+        password: bar
+        private_key_path: "/path/to/pem.key"

--- a/internal/config/testdata/storage/git_ssh_auth_valid_with_path.yml
+++ b/internal/config/testdata/storage/git_ssh_auth_valid_with_path.yml
@@ -4,6 +4,5 @@ storage:
     repository: "git@github.com:foo/bar.git"
     authentication:
       ssh:
-        user: foo
         password: bar
         private_key_path: "/path/to/pem.key"


### PR DESCRIPTION
Fixes #2271 

This introduces SSH authentication credential support for the Git backend.
Using either explicit private key bytes, or a path to the private key bytes, you can configure Flipt to pull over SSH.
This is an alternative approach for pulling from private registries.

I recommend following along with GitHubs documentation on deploy keys to learn how to setup a repo with this.
We can add some documentation on our side to point to this too.

https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys

The Flipt server configuration looks like the following:
```yaml
storage:
  type: git
  git:
    repository: git@github.com:flipt-io/some-private-repo.git
    authentication:
      ssh:
        password: flipt
        private_key_path: private-key.pem
        insecure_ignore_host_key: true
```

The `insecure_ignore_host_key` is not encouraged for production use.
(I will ensure this goes into the docs for this feature)
Instead, you are advised to put the key fingerprint in the known hosts file.