### PR TITLE
fix: readOnly config option should be read_only

### DIFF
--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -33,7 +33,7 @@ type StorageConfig struct {
 	Local    *Local      `json:"local,omitempty" mapstructure:"local,omitempty" yaml:"local,omitempty"`
 	Git      *Git        `json:"git,omitempty" mapstructure:"git,omitempty" yaml:"git,omitempty"`
 	Object   *Object     `json:"object,omitempty" mapstructure:"object,omitempty" yaml:"object,omitempty"`
-	ReadOnly *bool       `json:"readOnly,omitempty" mapstructure:"readOnly,omitempty" yaml:"read_only,omitempty"`
+	ReadOnly *bool       `json:"readOnly,omitempty" mapstructure:"read_only,omitempty" yaml:"read_only,omitempty"`
 }
 
 func (c *StorageConfig) setDefaults(v *viper.Viper) error {

--- a/internal/config/testdata/storage/invalid_readonly.yml
+++ b/internal/config/testdata/storage/invalid_readonly.yml
@@ -1,6 +1,6 @@
 storage:
   type: object
-  readOnly: false
+  read_only: false
   object:
     type: s3
     s3:


### PR DESCRIPTION
found this while trying to test if the namespace picker works in read only (it does), this makes `read_only` match our other config properties, snake_case instead of camelCase.

we should likely add a test somehow that all config properties in YAML are specified in snake_case

I don't think this is a breaking change since it was never publicly documented