### PR TITLE
feat(oci): add configuration for new OCI backend

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -129,7 +129,7 @@ import "strings"
 	}
 
 	#storage: {
-		type: "database" | "git" | "local" | "object" | *""
+		type: "database" | "git" | "local" | "object" | "oci" | *""
 		local?: path: string | *"."
 		git?: {
 			repository:      string
@@ -164,6 +164,14 @@ import "strings"
 				prefix?:        string
 				endpoint?:      string
 				poll_interval?: =~#duration | *"1m"
+			}
+		}
+		oci?: {
+			repository: string
+			insecure?:  bool | *false
+			authentication?: {
+				username: string
+				password: string
 			}
 		}
 	}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -620,6 +620,28 @@
             }
           },
           "title": "Object"
+        },
+        "oci": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "insecure": {
+              "type": "boolean",
+              "default": false
+            },
+            "authentication": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "username": { "type": "string" },
+                "password": { "type": "string" }
+              }
+            }
+          },
+          "title": "OCI"
         }
       },
       "required": [],

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/net v0.17.0
 	golang.org/x/oauth2 v0.13.0
-	golang.org/x/sync v0.3.0
+	golang.org/x/sync v0.4.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20231030173426-d783a09b4405
 	google.golang.org/grpc v1.59.0
 	google.golang.org/protobuf v1.31.0
@@ -78,6 +78,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools v2.2.0+incompatible
+	oras.land/oras-go/v2 v2.3.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -923,8 +923,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1255,6 +1255,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
+oras.land/oras-go/v2 v2.3.1 h1:lUC6q8RkeRReANEERLfH86iwGn55lbSWP20egdFHVec=
+oras.land/oras-go/v2 v2.3.1/go.mod h1:5AQXVEu1X/FKp1F9DMOb5ZItZBOa0y5dha0yCm4NR9c=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -745,6 +745,34 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			name: "OCI config provided",
+			path: "./testdata/storage/oci_provided.yml",
+			expected: func() *Config {
+				cfg := Default()
+				cfg.Storage = StorageConfig{
+					Type: OCIStorageType,
+					OCI: &OCI{
+						Repository: "some.target/repository/abundle:latest",
+						Authentication: &OCIAuthentication{
+							Username: "foo",
+							Password: "bar",
+						},
+					},
+				}
+				return cfg
+			},
+		},
+		{
+			name:    "OCI invalid no repository",
+			path:    "./testdata/storage/oci_invalid_no_repo.yml",
+			wantErr: errors.New("oci storage repository must be specified"),
+		},
+		{
+			name:    "OCI invalid unexpected repository",
+			path:    "./testdata/storage/oci_invalid_unexpected_repo.yml",
+			wantErr: errors.New("validating OCI configuration: invalid reference: missing repository"),
+		},
+		{
 			name:    "storage readonly config invalid",
 			path:    "./testdata/storage/invalid_readonly.yml",
 			wantErr: errors.New("setting read only mode is only supported with database storage"),
@@ -801,7 +829,7 @@ func TestLoad(t *testing.T) {
 				} else if err.Error() == wantErr.Error() {
 					return
 				}
-				require.Fail(t, "expected error", "expected %q, found %q", err, wantErr)
+				require.Fail(t, "expected error", "expected %q, found %q", wantErr, err)
 			}
 
 			require.NoError(t, err)

--- a/internal/config/testdata/storage/oci_invalid_no_repo.yml
+++ b/internal/config/testdata/storage/oci_invalid_no_repo.yml
@@ -1,0 +1,6 @@
+storage:
+  type: oci
+  oci:
+    authentication:
+      username: foo
+      password: bar

--- a/internal/config/testdata/storage/oci_invalid_unexpected_repo.yml
+++ b/internal/config/testdata/storage/oci_invalid_unexpected_repo.yml
@@ -1,0 +1,7 @@
+storage:
+  type: oci
+  oci:
+    repository: just.a.registry
+    authentication:
+      username: foo
+      password: bar

--- a/internal/config/testdata/storage/oci_provided.yml
+++ b/internal/config/testdata/storage/oci_provided.yml
@@ -1,0 +1,7 @@
+storage:
+  type: oci
+  oci:
+    repository: some.target/repository/abundle:latest
+    authentication:
+      username: foo
+      password: bar


### PR DESCRIPTION
Supports #2296 

This is over the long-running `gm/fs-oci` branch.

Adds configuration sections for the new OCI FS backend.
This section includes repository reference target and authentication credential details.

I chose to not use the wording basic auth, because I believe that we could support user/pass for both basic and for oauth flows via these same parameters (that is how the Oras Go lib appears to support it).