### PR TITLE
feat(oci): integrate new FS backend into Flipt

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,7 +50,7 @@ jobs:
       fail-fast: false
       matrix:
         test:
-          ["api", "api/cache", "fs/git", "fs/local", "fs/s3", "import/export"]
+          ["api", "api/cache", "fs/git", "fs/local", "fs/s3", "fs/oci", "import/export"]
     steps:
       - uses: actions/checkout@v4
 

--- a/cmd/flipt/bundle.go
+++ b/cmd/flipt/bundle.go
@@ -6,6 +6,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	"go.flipt.io/flipt/internal/config"
 	"go.flipt.io/flipt/internal/containers"
 	"go.flipt.io/flipt/internal/oci"
 )
@@ -151,21 +152,24 @@ func (c *bundleCommand) getStore() (*oci.Store, error) {
 		return nil, err
 	}
 
+	dir, err := config.DefaultBundleDir()
+	if err != nil {
+		return nil, err
+	}
+
 	var opts []containers.Option[oci.StoreOptions]
 	if cfg := cfg.Storage.OCI; cfg != nil {
-		if cfg.BundleDirectory != "" {
-			opts = append(opts, oci.WithBundleDir(cfg.BundleDirectory))
-		}
-
 		if cfg.Authentication != nil {
 			opts = append(opts, oci.WithCredentials(
 				cfg.Authentication.Username,
 				cfg.Authentication.Password,
 			))
 		}
+
+		dir = cfg.BundlesDirectory
 	}
 
-	return oci.NewStore(logger, opts...)
+	return oci.NewStore(logger, dir, opts...)
 }
 
 func writer() *tabwriter.Writer {

--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -167,12 +167,13 @@ import "strings"
 			}
 		}
 		oci?: {
-			repository: string
-			insecure?:  bool | *false
+			repository:         string
+			bundles_directory?: string
 			authentication?: {
 				username: string
 				password: string
 			}
+			poll_interval?: =~#duration | *"30s"
 		}
 	}
 

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -628,9 +628,8 @@
             "repository": {
               "type": "string"
             },
-            "insecure": {
-              "type": "boolean",
-              "default": false
+            "bundles_directory": {
+              "type": "string"
             },
             "authentication": {
               "type": "object",
@@ -639,6 +638,18 @@
                 "username": { "type": "string" },
                 "password": { "type": "string" }
               }
+            },
+            "poll_interval": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "default": "1m"
             }
           },
           "title": "OCI"

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -244,6 +244,9 @@ func NewGRPCServer(
 		source, err := storageoci.NewSource(logger, ocistore, ref,
 			storageoci.WithPollInterval(cfg.Storage.OCI.PollInterval),
 		)
+		if err != nil {
+			return nil, err
+		}
 
 		store, err = fs.NewStore(logger, source)
 		if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -752,12 +752,13 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: OCIStorageType,
 					OCI: &OCI{
-						Repository:      "some.target/repository/abundle:latest",
-						BundleDirectory: "/tmp/bundles",
+						Repository:       "some.target/repository/abundle:latest",
+						BundlesDirectory: "/tmp/bundles",
 						Authentication: &OCIAuthentication{
 							Username: "foo",
 							Password: "bar",
 						},
+						PollInterval: 5 * time.Minute,
 					},
 				}
 				return cfg
@@ -769,9 +770,9 @@ func TestLoad(t *testing.T) {
 			wantErr: errors.New("oci storage repository must be specified"),
 		},
 		{
-			name:    "OCI invalid unexpected repository",
-			path:    "./testdata/storage/oci_invalid_unexpected_repo.yml",
-			wantErr: errors.New("validating OCI configuration: invalid reference: missing repository"),
+			name:    "OCI invalid unexpected scheme",
+			path:    "./testdata/storage/oci_invalid_unexpected_scheme.yml",
+			wantErr: errors.New("validating OCI configuration: unexpected repository scheme: \"unknown\" should be one of [http|https|flipt]"),
 		},
 		{
 			name:    "storage readonly config invalid",

--- a/internal/config/testdata/storage/oci_invalid_unexpected_scheme.yml
+++ b/internal/config/testdata/storage/oci_invalid_unexpected_scheme.yml
@@ -1,7 +1,7 @@
 storage:
   type: oci
   oci:
-    repository: just.a.registry
+    repository: unknown://registry/repo:tag
     authentication:
       username: foo
       password: bar

--- a/internal/config/testdata/storage/oci_provided.yml
+++ b/internal/config/testdata/storage/oci_provided.yml
@@ -6,3 +6,4 @@ storage:
     authentication:
       username: foo
       password: bar
+    poll_interval: 5m

--- a/internal/oci/file.go
+++ b/internal/oci/file.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"go.flipt.io/flipt/internal/config"
 	"go.flipt.io/flipt/internal/containers"
 	"go.flipt.io/flipt/internal/ext"
 	storagefs "go.flipt.io/flipt/internal/storage/fs"
@@ -55,14 +54,6 @@ type StoreOptions struct {
 	}
 }
 
-// WithBundleDir overrides the default bundles directory on the host for storing
-// local builds of Flipt bundles
-func WithBundleDir(dir string) containers.Option[StoreOptions] {
-	return func(so *StoreOptions) {
-		so.bundleDir = dir
-	}
-}
-
 // WithCredentials configures username and password credentials used for authenticating
 // with remote registries
 func WithCredentials(user, pass string) containers.Option[StoreOptions] {
@@ -78,19 +69,14 @@ func WithCredentials(user, pass string) containers.Option[StoreOptions] {
 }
 
 // NewStore constructs and configures an instance of *Store for the provided config
-func NewStore(logger *zap.Logger, opts ...containers.Option[StoreOptions]) (*Store, error) {
+func NewStore(logger *zap.Logger, dir string, opts ...containers.Option[StoreOptions]) (*Store, error) {
 	store := &Store{
-		opts:   StoreOptions{},
+		opts: StoreOptions{
+			bundleDir: dir,
+		},
 		logger: logger,
 		local:  memory.New(),
 	}
-
-	dir, err := defaultBundleDirectory()
-	if err != nil {
-		return nil, err
-	}
-
-	store.opts.bundleDir = dir
 
 	containers.ApplyAll(&store.opts, opts...)
 
@@ -554,18 +540,4 @@ func (f FileInfo) Sys() any {
 
 func parseCreated(annotations map[string]string) (time.Time, error) {
 	return time.Parse(time.RFC3339, annotations[v1.AnnotationCreated])
-}
-
-func defaultBundleDirectory() (string, error) {
-	dir, err := config.Dir()
-	if err != nil {
-		return "", err
-	}
-
-	bundlesDir := filepath.Join(dir, "bundles")
-	if err := os.MkdirAll(bundlesDir, 0755); err != nil {
-		return "", fmt.Errorf("creating image directory: %w", err)
-	}
-
-	return bundlesDir, nil
 }

--- a/internal/oci/file.go
+++ b/internal/oci/file.go
@@ -448,13 +448,8 @@ func (s *Store) Copy(ctx context.Context, src, dst Reference) (Bundle, error) {
 		return Bundle{}, err
 	}
 
-	data, err := io.ReadAll(rd)
-	if err != nil {
-		return Bundle{}, err
-	}
-
 	var man v1.Manifest
-	if err := json.Unmarshal(data, &man); err != nil {
+	if err := json.NewDecoder(rd).Decode(&man); err != nil {
 		return Bundle{}, err
 	}
 

--- a/internal/oci/file_test.go
+++ b/internal/oci/file_test.go
@@ -124,7 +124,7 @@ func TestStore_Fetch_InvalidMediaType(t *testing.T) {
 	ref, err := ParseReference(fmt.Sprintf("flipt://local/%s:latest", repo))
 	require.NoError(t, err)
 
-	store, err := NewStore(zaptest.NewLogger(t), WithBundleDir(dir))
+	store, err := NewStore(zaptest.NewLogger(t), dir)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -135,7 +135,7 @@ func TestStore_Fetch_InvalidMediaType(t *testing.T) {
 		layer("default", `{"namespace":"default"}`, MediaTypeFliptNamespace+"+unknown"),
 	)
 
-	store, err = NewStore(zaptest.NewLogger(t), WithBundleDir(dir))
+	store, err = NewStore(zaptest.NewLogger(t), dir)
 	require.NoError(t, err)
 
 	_, err = store.Fetch(ctx, ref)
@@ -151,7 +151,7 @@ func TestStore_Fetch(t *testing.T) {
 	ref, err := ParseReference(fmt.Sprintf("flipt://local/%s:latest", repo))
 	require.NoError(t, err)
 
-	store, err := NewStore(zaptest.NewLogger(t), WithBundleDir(dir))
+	store, err := NewStore(zaptest.NewLogger(t), dir)
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -205,7 +205,7 @@ func TestStore_Build(t *testing.T) {
 	ref, err := ParseReference(fmt.Sprintf("flipt://local/%s:latest", repo))
 	require.NoError(t, err)
 
-	store, err := NewStore(zaptest.NewLogger(t), WithBundleDir(dir))
+	store, err := NewStore(zaptest.NewLogger(t), dir)
 	require.NoError(t, err)
 
 	testdata, err := fs.Sub(testdata, "testdata")
@@ -233,7 +233,7 @@ func TestStore_List(t *testing.T) {
 	ref, err := ParseReference(fmt.Sprintf("%s:latest", repo))
 	require.NoError(t, err)
 
-	store, err := NewStore(zaptest.NewLogger(t), WithBundleDir(dir))
+	store, err := NewStore(zaptest.NewLogger(t), dir)
 	require.NoError(t, err)
 
 	bundles, err := store.List(ctx)
@@ -272,7 +272,7 @@ func TestStore_Copy(t *testing.T) {
 	src, err := ParseReference("flipt://local/source:latest")
 	require.NoError(t, err)
 
-	store, err := NewStore(zaptest.NewLogger(t), WithBundleDir(dir))
+	store, err := NewStore(zaptest.NewLogger(t), dir)
 	require.NoError(t, err)
 
 	testdata, err := fs.Sub(testdata, "testdata")

--- a/internal/storage/fs/oci/source_test.go
+++ b/internal/storage/fs/oci/source_test.go
@@ -91,7 +91,7 @@ func testSource(t *testing.T) (*Source, oras.Target) {
 		layer("production", `{"namespace":"production"}`, fliptoci.MediaTypeFliptNamespace),
 	)
 
-	store, err := fliptoci.NewStore(zaptest.NewLogger(t), fliptoci.WithBundleDir(dir))
+	store, err := fliptoci.NewStore(zaptest.NewLogger(t), dir)
 	require.NoError(t, err)
 
 	ref, err := fliptoci.ParseReference(fmt.Sprintf("flipt://local/%s:latest", repo))


### PR DESCRIPTION
Fixes FLI-663

This the last PR to add the OCI backend to Flipt.
It installs the new OCI storage into the main Flipt process.
It also includes the wiring to add the OCI integration test suite to dagger and the associated GH workflow.