### PR TITLE
fix(auth): ensure only flipt and eval can be accessed with namespaced token

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -293,6 +293,8 @@ func NewGRPCServer(
 		// it's initialized with the default option of skipping authentication for the health service which should never require authentication.
 		authOpts = []containers.Option[auth.InterceptorOptions]{
 			auth.WithServerSkipsAuthentication(healthsrv),
+			auth.WithServerNamespaceScoped(fliptsrv),
+			auth.WithServerNamespaceScoped(evalsrv),
 		}
 		skipAuthIfExcluded = func(server any, excluded bool) {
 			if excluded {


### PR DESCRIPTION
This changes the namespace middleware so that it only allows the Flipt and Eval servers access.
This way meta and the auth services reject namespace scoped tokens.