### PR TITLE
UI changes for `IS ONE OF`

### DIFF
--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -4,7 +4,7 @@ import {
   TrashIcon
 } from '@heroicons/react/24/outline';
 import { formatDistanceToNowStrict, parseISO } from 'date-fns';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { selectReadonly } from '~/app/meta/metaSlice';
@@ -12,6 +12,7 @@ import {
   selectCurrentNamespace,
   selectNamespaces
 } from '~/app/namespaces/namespacesSlice';
+import Chips from '~/components/Chips';
 import EmptyState from '~/components/EmptyState';
 import Button from '~/components/forms/buttons/Button';
 import Dropdown from '~/components/forms/Dropdown';
@@ -39,6 +40,36 @@ import {
   IConstraint
 } from '~/types/Constraint';
 import { ISegment } from '~/types/Segment';
+
+function ConstraintArrayValue({ value }: { value: string | undefined }) {
+  const items: string[] | number[] = useMemo(() => {
+    try {
+      return JSON.parse(value || '[]');
+    } catch (err) {
+      return [];
+    }
+  }, [value]);
+
+  return <Chips values={items} maxItemCount={5} />;
+}
+
+function ConstraintValue({ constraint }: { constraint: IConstraint }) {
+  const { inTimezone } = useTimezone();
+  const isArrayValue = ['isoneof', 'isnotoneof'].includes(constraint.operator);
+
+  if (
+    constraint.type === ConstraintType.DATETIME &&
+    constraint.value !== undefined
+  ) {
+    return <>{inTimezone(constraint.value)}</>;
+  }
+
+  if (isArrayValue) {
+    return <ConstraintArrayValue value={constraint.value} />;
+  }
+
+  return <div className="whitespace-normal">{constraint.value}</div>;
+}
 
 export default function Segment() {
   let { segmentKey } = useParams();
@@ -343,10 +374,7 @@ export default function Segment() {
                           {ConstraintOperators[constraint.operator]}
                         </td>
                         <td className="text-gray-500 hidden whitespace-normal px-3 py-4 text-sm lg:table-cell">
-                          {constraint.type === ConstraintType.DATETIME &&
-                          constraint.value !== undefined
-                            ? inTimezone(constraint.value)
-                            : constraint.value}
+                          <ConstraintValue constraint={constraint} />
                         </td>
                         <td className="text-gray-500 hidden truncate whitespace-nowrap px-3 py-4 text-sm lg:table-cell">
                           {constraint.description}

--- a/ui/src/components/Chips.tsx
+++ b/ui/src/components/Chips.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+export default function ChipList({
+  values,
+  maxItemCount = 5,
+  showAll = false
+}: {
+  values: (string | number)[];
+  maxItemCount?: number;
+  showAll?: boolean;
+}) {
+  const [showAllValues, setShowAllValues] = useState<boolean>(showAll);
+
+  const visibleValues = showAllValues ? values : values.slice(0, maxItemCount);
+  return (
+    <div className="flex flex-wrap gap-2">
+      {visibleValues.map((value, i) => (
+        <div className="text-gray-900 bg-gray-200 rounded px-1.5" key={i}>
+          {value}
+        </div>
+      ))}
+      {!showAll && values.length > maxItemCount && (
+        <button
+          className="text-gray-700 rounded px-1.5"
+          onClick={() => setShowAllValues((b) => !b)}
+        >
+          {showAllValues ? 'show less' : '...'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/segments/ConstraintForm.tsx
+++ b/ui/src/components/segments/ConstraintForm.tsx
@@ -3,7 +3,7 @@ import { QuestionMarkCircleIcon } from '@heroicons/react/20/solid';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Form, Formik, useField, useFormikContext } from 'formik';
 import moment from 'moment';
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import * as Yup from 'yup';
@@ -68,6 +68,7 @@ const constraintOperators = (c: string) => {
 type ConstraintInputProps = {
   name: string;
   id: string;
+  placeholder?: string;
 };
 
 type ConstraintOperatorSelectProps = ConstraintInputProps & {
@@ -253,6 +254,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
 
   const [hasValue, setHasValue] = useState(true);
   const [type, setType] = useState(constraint?.type || ConstraintType.STRING);
+  const [operator, setOperator] = useState(constraint?.operator || '');
 
   const namespace = useSelector(selectCurrentNamespace);
 
@@ -270,6 +272,22 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
     }
     return updateConstraint(namespace.key, segmentKey, constraint?.id, values);
   };
+
+  const placeholder = useMemo(() => {
+    if (['isoneof', 'isnotoneof'].includes(operator)) {
+      const placeholder = {
+        [ConstraintType.STRING]: 'Eg: ["value1", "value2"]',
+        [ConstraintType.NUMBER]: 'Eg: [1, 2, 3]'
+      }[type as string];
+      return placeholder ?? '';
+    }
+
+    const placeholder = {
+      [ConstraintType.STRING]: 'Eg: Any text',
+      [ConstraintType.NUMBER]: 'Eg: 200'
+    }[type as string];
+    return placeholder ?? '';
+  }, [type, operator]);
 
   return (
     <Formik
@@ -383,6 +401,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                     onChange={(e) => {
                       const noValue = NoValueOperators.includes(e.target.value);
                       setHasValue(!noValue);
+                      setOperator(e.target.value);
                     }}
                   />
                 </div>
@@ -391,7 +410,11 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                 (type === ConstraintType.DATETIME ? (
                   <ConstraintValueDateTimeInput name="value" id="value" />
                 ) : (
-                  <ConstraintValueInput name="value" id="value" />
+                  <ConstraintValueInput
+                    name="value"
+                    id="value"
+                    placeholder={placeholder}
+                  />
                 ))}
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                 <div>

--- a/ui/src/components/segments/ConstraintForm.tsx
+++ b/ui/src/components/segments/ConstraintForm.tsx
@@ -3,7 +3,7 @@ import { QuestionMarkCircleIcon } from '@heroicons/react/20/solid';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Form, Formik, useField, useFormikContext } from 'formik';
 import moment from 'moment';
-import { forwardRef, useEffect, useMemo, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import * as Yup from 'yup';
@@ -253,8 +253,6 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
   const { setSuccess } = useSuccess();
 
   const [hasValue, setHasValue] = useState(true);
-  const [type, setType] = useState(constraint?.type || ConstraintType.STRING);
-  const [operator, setOperator] = useState(constraint?.operator || '');
 
   const namespace = useSelector(selectCurrentNamespace);
 
@@ -273,7 +271,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
     return updateConstraint(namespace.key, segmentKey, constraint?.id, values);
   };
 
-  const placeholder = useMemo(() => {
+  const getValuePlaceholder = (type: ConstraintType, operator: string) => {
     if (['isoneof', 'isnotoneof'].includes(operator)) {
       const placeholder = {
         [ConstraintType.STRING]: 'Eg: ["value1", "value2"]',
@@ -287,7 +285,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
       [ConstraintType.NUMBER]: 'Eg: 200'
     }[type as string];
     return placeholder ?? '';
-  }, [type, operator]);
+  };
 
   return (
     <Formik
@@ -371,7 +369,6 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                     onChange={(e) => {
                       const type = e.target.value as ConstraintType;
                       formik.setFieldValue('type', type);
-                      setType(type);
 
                       if (e.target.value === ConstraintType.BOOLEAN) {
                         formik.setFieldValue('operator', 'true');
@@ -397,23 +394,25 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
                   <ConstraintOperatorSelect
                     id="operator"
                     name="operator"
-                    type={type}
+                    type={formik.values.type}
                     onChange={(e) => {
                       const noValue = NoValueOperators.includes(e.target.value);
                       setHasValue(!noValue);
-                      setOperator(e.target.value);
                     }}
                   />
                 </div>
               </div>
               {hasValue &&
-                (type === ConstraintType.DATETIME ? (
+                (formik.values.type === ConstraintType.DATETIME ? (
                   <ConstraintValueDateTimeInput name="value" id="value" />
                 ) : (
                   <ConstraintValueInput
                     name="value"
                     id="value"
-                    placeholder={placeholder}
+                    placeholder={getValuePlaceholder(
+                      formik.values.type,
+                      formik.values.operator
+                    )}
                   />
                 ))}
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">


### PR DESCRIPTION
## Changes (UI changes discussed in PR #2368)
- Only shows 5 values by default. Clicking on the ellipsis, shows all the values
- Adds placeholder for string and number values
- Minor refactor of `type` state in form


| | | |
|--------|--------|--------|
| Chip UI | ![part-2023_11_13_18_09_50](https://github.com/flipt-io/flipt/assets/11407672/9a755d5b-6aef-4fe1-ac0b-0e48bf7b530e) | ![part-2023_11_13_20_14_14](https://github.com/flipt-io/flipt/assets/11407672/f9359709-e63f-4d31-8c87-c0bb90b1e9fe) |
| Placeholders | ![part-2023_11_13_16_52_21](https://github.com/flipt-io/flipt/assets/11407672/501c4cea-ce16-4fe3-93f6-5dfba5e1a35d) | ![part-2023_11_13_20_34_46](https://github.com/flipt-io/flipt/assets/11407672/e965463b-34a2-4421-badc-8e7dbb436adf) |
