### PR TITLE
feat: add initial commit for flipt-client-go evaluation client

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.21.3
 
 use (
 	.
@@ -8,4 +8,5 @@ use (
 	./internal/cmd/protoc-gen-go-flipt-sdk
 	./rpc/flipt
 	./sdk/go
+	./sdk/client/go/flipt-client-go
 )

--- a/sdk/client/go/README.md
+++ b/sdk/client/go/README.md
@@ -1,4 +1,4 @@
-## Flipt Client Golang
+## Flipt Client Go
 
 The `flipt-client-go` directory contains the Golang source code for a Flipt evaluation client using FFI to make calls to a core built in Rust.
 
@@ -12,7 +12,7 @@ cargo build
 
 This should generate a `target/` directory in the root of this repository, which contains the dynamic linking library built for your platform. This dynamic library will contain the functionality necessary for the Golang client to make FFI calls.
 
-You can import the module that contains the evaluation client: `go.flipt.io/flipt/flipt-client-go` and build your Go project with the environment variable:
+You can import the module that contains the evaluation client: `go.flipt.io/flipt/flipt-client-go` and build your Go project with the `CGO_LDFLAGS` environment variable set:
 
 ```bash
 CGO_LDFLAGS="-L/path/to/lib -lengine"
@@ -24,7 +24,7 @@ The `path/to/lib` will be the path to the dynamic library which will have the fo
 - **Windows**: `{FLIPT_REPO_ROOT}/target/debug/libengine.dll`
 - **MacOS**: `{FLIPT_REPO_ROOT}/target/debug/libengine.dylib`
 
-A sample code will look something like the following:
+You can then use the client like so:
 
 ```golang
 package main

--- a/sdk/client/go/README.md
+++ b/sdk/client/go/README.md
@@ -39,7 +39,7 @@ import (
 )
 
 func main() {
-	evaluationClient := evaluation.NewClient([]string{"default"})
+	evaluationClient := evaluation.NewClient("default")
 
 	evalCtx := map[string]string{
 		"fizz": "buzz",

--- a/sdk/client/go/README.md
+++ b/sdk/client/go/README.md
@@ -14,7 +14,7 @@ This should generate a `target/` directory in the root of this repository, which
 
 You can import the module that contains the evaluation client: `go.flipt.io/flipt/flipt-client-go` and build your Go project with the environment variable:
 
-```
+```bash
 CGO_LDFLAGS="-L/path/to/lib -lengine"
 ```
 

--- a/sdk/client/go/README.md
+++ b/sdk/client/go/README.md
@@ -1,0 +1,65 @@
+## Flipt Client Golang
+
+The `flipt-client-go` directory contains the Golang source code for a Flipt evaluation client using FFI to make calls to a core built in Rust.
+
+### Instructions
+
+To use this client, you can run the following command from the root of the repository:
+
+```bash
+cargo build
+```
+
+This should generate a `target/` directory in the root of this repository, which contains the dynamic linking library built for your platform. This dynamic library will contain the functionality necessary for the Golang client to make FFI calls.
+
+You can import the module that contains the evaluation client: `go.flipt.io/flipt/flipt-client-go` and build your Go project with the environment variable:
+
+```
+CGO_LDFLAGS="-L/path/to/lib -lengine"
+```
+
+The `path/to/lib` will be the path to the dynamic library which will have the following paths depending on your platform.
+
+- **Linux**: `{FLIPT_REPO_ROOT}/target/debug/libengine.so`
+- **Windows**: `{FLIPT_REPO_ROOT}/target/debug/libengine.dll`
+- **MacOS**: `{FLIPT_REPO_ROOT}/target/debug/libengine.dylib`
+
+A sample code will look something like the following:
+
+```golang
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	evaluation "go.flipt.io/flipt/flipt-client-go"
+)
+
+func main() {
+	evaluationClient := evaluation.NewClient([]string{"default"})
+
+	evalCtx := map[string]string{
+		"fizz": "buzz",
+	}
+
+	evalCtxBytes, err := json.Marshal(evalCtx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	variantEvaluationResponse, err := evaluationClient.Variant(context.Background(), &evaluation.EvaluationRequest{
+		NamespaceKey: "default",
+		FlagKey:      "flag1",
+		EntityId:     "someentity",
+		Context:      string(evalCtxBytes),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(variantEvaluationResponse)
+}
+```

--- a/sdk/client/go/flipt-client-go/evaluation.go
+++ b/sdk/client/go/flipt-client-go/evaluation.go
@@ -1,0 +1,100 @@
+package evaluation
+
+/*
+#cgo LDFLAGS: -L. -lengine
+#include <stdlib.h>
+#include <string.h>
+
+void* initialize_engine(char** namespaces);
+
+char* variant(void* engine, char* evaluation_request);
+
+char* boolean(void* engine, char* evaluation_request);
+
+void destroy_engine(void* engine);
+*/
+import "C"
+import (
+	"context"
+	"encoding/json"
+	"unsafe"
+)
+
+// Client wraps the functionality of making variant and boolean evaluation of Flipt feature flags
+// using an engine that is compiled to a dynamic linking library.
+type Client struct {
+	engine unsafe.Pointer
+}
+
+// NewClient constructs an Client.
+func NewClient(namespaces []string) *Client {
+	ns := make([]*C.char, 0, len(namespaces))
+
+	for _, namespace := range namespaces {
+		ns = append(ns, C.CString(namespace))
+	}
+
+	// Free the memory of the C Strings that were created to initialize the engine.
+	defer func() {
+		for _, n := range ns {
+			C.free(unsafe.Pointer(n))
+		}
+	}()
+
+	nsPtr := (**C.char)(unsafe.Pointer(&ns[0]))
+
+	eng := C.initialize_engine(nsPtr)
+
+	return &Client{
+		engine: eng,
+	}
+}
+
+// Variant makes an evaluation on a variant flag using the allocated Rust engine.
+func (e *Client) Variant(_ context.Context, evaluationRequest *EvaluationRequest) (*VariantEvaluationResponse, error) {
+	ereq, err := json.Marshal(evaluationRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	variant := C.variant(e.engine, C.CString(string(ereq)))
+	defer C.free(unsafe.Pointer(variant))
+
+	b := C.GoBytes(unsafe.Pointer(variant), (C.int)(C.strlen(variant)))
+
+	var ver *VariantEvaluationResponse
+
+	if err := json.Unmarshal(b, &ver); err != nil {
+		return nil, err
+	}
+
+	return ver, nil
+}
+
+// Boolean makes an evaluation on a boolean flag using the allocated Rust engine.
+func (e *Client) Boolean(_ context.Context, evaluationRequest *EvaluationRequest) (*BooleanEvaluationResponse, error) {
+	ereq, err := json.Marshal(evaluationRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	boolean := C.boolean(e.engine, C.CString(string(ereq)))
+	defer C.free(unsafe.Pointer(boolean))
+
+	b := C.GoBytes(unsafe.Pointer(boolean), (C.int)(C.strlen(boolean)))
+
+	var ber *BooleanEvaluationResponse
+
+	if err := json.Unmarshal(b, &ber); err != nil {
+		return nil, err
+	}
+
+	return ber, nil
+}
+
+// Close cleans up the allocated engine as it was initialized in the constructor.
+func (e *Client) Close() error {
+	// Destroy the engine to clean up allocated memory on dynamic library side.
+	C.destroy_engine(e.engine)
+	return nil
+}

--- a/sdk/client/go/flipt-client-go/evaluation.go
+++ b/sdk/client/go/flipt-client-go/evaluation.go
@@ -27,12 +27,8 @@ type Client struct {
 }
 
 // NewClient constructs an Client.
-func NewClient(namespaces []string) *Client {
-	ns := make([]*C.char, 0, len(namespaces))
-
-	for _, namespace := range namespaces {
-		ns = append(ns, C.CString(namespace))
-	}
+func NewClient(namespace string) *Client {
+	ns := []*C.char{C.CString(namespace)}
 
 	// Free the memory of the C Strings that were created to initialize the engine.
 	defer func() {

--- a/sdk/client/go/flipt-client-go/go.mod
+++ b/sdk/client/go/flipt-client-go/go.mod
@@ -1,0 +1,3 @@
+module go.flipt.io/flipt/flipt-client-go
+
+go 1.21.3

--- a/sdk/client/go/flipt-client-go/models.go
+++ b/sdk/client/go/flipt-client-go/models.go
@@ -1,0 +1,27 @@
+package evaluation
+
+type EvaluationRequest struct {
+	NamespaceKey string `json:"namespace_key"`
+	FlagKey      string `json:"flag_key"`
+	EntityId     string `json:"entity_id"`
+	Context      string `json:"context"`
+}
+
+type VariantEvaluationResponse struct {
+	Match                 bool     `json:"match"`
+	SegmentKeys           []string `json:"segment_keys"`
+	Reason                string   `json:"reason"`
+	FlagKey               string   `json:"flag_key"`
+	VariantKey            string   `json:"variant_key"`
+	VariantAttachment     string   `json:"variant_attachment"`
+	RequestDurationMillis float64  `json:"request_duration_millis"`
+	Timestamp             string   `json:"timestamp"`
+}
+
+type BooleanEvaluationResponse struct {
+	Enabled               bool    `json:"enabled"`
+	FlagKey               string  `json:"flag_key"`
+	Reason                string  `json:"reason"`
+	RequestDurationMillis float64 `json:"request_duration_millis"`
+	Timestamp             string  `json:"timestamp"`
+}

--- a/sdk/client/python/README.md
+++ b/sdk/client/python/README.md
@@ -1,6 +1,6 @@
 ## Flipt Client Python
 
-This directory contains the Python source code for a Flipt evaluation client using FFI to make calls to a core built in Rust.
+The `flipt-client-python` directory contains the Python source code for a Flipt evaluation client using FFI to make calls to a core built in Rust.
 
 ### Instructions
 
@@ -25,4 +25,3 @@ flipt_evaluation_client = FliptEvaluationClient(namespaces=["default", "another-
 
 variant_response = flipt_evaluation_client.variant(namespace_key="default", flag_key="flag1", entity_id="entity", context={"this": "context"})
 ```
-


### PR DESCRIPTION
This PR introduces the `flipt-client-go` for embedding a dynamic library written with the Rust core for flipt evaluations.

Completes FLI-675