### PR TITLE
chore(ui): minor fix for datetime constraint label

### DIFF
--- a/ui/src/components/segments/ConstraintForm.tsx
+++ b/ui/src/components/segments/ConstraintForm.tsx
@@ -184,7 +184,9 @@ function ConstraintValueDateTimeInput(props: ConstraintInputProps) {
               className="text-gray-300 -ml-1 h-4 w-4 group-hover:text-gray-400"
               aria-hidden="true"
             />
-            <span className="ml-1">{timezone}</span>
+            <span className="ml-1">
+              {timezone === Timezone.UTC ? 'UTC' : 'Local'}
+            </span>
           </Link>
         </span>
       </div>


### PR DESCRIPTION
make the constraint datettime form look a little nicer vs lowercase timezones

![CleanShot 2023-11-14 at 14 04 44@2x](https://github.com/flipt-io/flipt/assets/209477/8ee43758-f96b-4ddb-98b8-510709d8017e)
![CleanShot 2023-11-14 at 14 04 27@2x](https://github.com/flipt-io/flipt/assets/209477/b6a57052-aff1-449f-8f0c-81355d418864)
