### PR TITLE
feat: incorporate error handling from Rust core over FFI to clients

### DIFF
--- a/sdk/client/engine/src/lib.rs
+++ b/sdk/client/engine/src/lib.rs
@@ -71,8 +71,41 @@ impl Engine {
     }
 }
 
-fn result_to_json_ptr<T: Serialize>(result: T) -> *mut c_char {
-    let json_string = serde_json::to_string(&result).unwrap();
+#[derive(Serialize)]
+struct FFIResponse<T> where T: Serialize {
+    response_code: ResponseCode,
+    result: Option<T>,
+    error_message: Option<String>,
+}
+
+#[derive(Serialize)]
+enum ResponseCode {
+    #[serde(rename = "success")]
+    Success,
+    #[serde(rename = "failure")]
+    Failure
+}
+
+impl<T> From<Result<T, Whatever>> for FFIResponse<T> where T: Serialize {
+    fn from(value: Result<T, Whatever>) -> Self {
+        match value {
+            Ok(result) => FFIResponse{
+                response_code: ResponseCode::Success,
+                result: Some(result),
+                error_message: None,
+            },
+            Err(e) => FFIResponse{
+                response_code: ResponseCode::Failure,
+                result: None,
+                error_message: Some(e.to_string()),
+            },
+        }
+    }
+}
+
+fn result_to_json_ptr<T: Serialize>(result: Result<T, Whatever>) -> *mut c_char {
+    let ffi_response: FFIResponse<T>  = result.into();
+    let json_string = serde_json::to_string(&ffi_response).unwrap();
     CString::new(json_string).unwrap().into_raw()
 }
 
@@ -119,9 +152,8 @@ pub unsafe extern "C" fn variant(
     let e = get_engine(engine_ptr).unwrap();
     let e_req = get_evaluation_request(evaluation_request);
 
-    let variant_response = e.variant(&e_req).unwrap();
 
-    result_to_json_ptr(variant_response)
+    result_to_json_ptr(e.variant(&e_req))
 }
 
 /// # Safety
@@ -135,9 +167,8 @@ pub unsafe extern "C" fn boolean(
     let e = get_engine(engine_ptr).unwrap();
     let e_req = get_evaluation_request(evaluation_request);
 
-    let boolean_response = e.boolean(&e_req).unwrap();
 
-    result_to_json_ptr(boolean_response)
+    result_to_json_ptr(e.boolean(&e_req))
 }
 
 unsafe fn get_evaluation_request(

--- a/sdk/client/engine/src/lib.rs
+++ b/sdk/client/engine/src/lib.rs
@@ -72,30 +72,36 @@ impl Engine {
 }
 
 #[derive(Serialize)]
-struct FFIResponse<T> where T: Serialize {
-    response_code: ResponseCode,
+struct FFIResponse<T>
+where
+    T: Serialize,
+{
+    status: Status,
     result: Option<T>,
     error_message: Option<String>,
 }
 
 #[derive(Serialize)]
-enum ResponseCode {
+enum Status {
     #[serde(rename = "success")]
     Success,
     #[serde(rename = "failure")]
-    Failure
+    Failure,
 }
 
-impl<T> From<Result<T, Whatever>> for FFIResponse<T> where T: Serialize {
+impl<T> From<Result<T, Whatever>> for FFIResponse<T>
+where
+    T: Serialize,
+{
     fn from(value: Result<T, Whatever>) -> Self {
         match value {
-            Ok(result) => FFIResponse{
-                response_code: ResponseCode::Success,
+            Ok(result) => FFIResponse {
+                status: Status::Success,
                 result: Some(result),
                 error_message: None,
             },
-            Err(e) => FFIResponse{
-                response_code: ResponseCode::Failure,
+            Err(e) => FFIResponse {
+                status: Status::Failure,
                 result: None,
                 error_message: Some(e.to_string()),
             },
@@ -104,7 +110,7 @@ impl<T> From<Result<T, Whatever>> for FFIResponse<T> where T: Serialize {
 }
 
 fn result_to_json_ptr<T: Serialize>(result: Result<T, Whatever>) -> *mut c_char {
-    let ffi_response: FFIResponse<T>  = result.into();
+    let ffi_response: FFIResponse<T> = result.into();
     let json_string = serde_json::to_string(&ffi_response).unwrap();
     CString::new(json_string).unwrap().into_raw()
 }
@@ -152,7 +158,6 @@ pub unsafe extern "C" fn variant(
     let e = get_engine(engine_ptr).unwrap();
     let e_req = get_evaluation_request(evaluation_request);
 
-
     result_to_json_ptr(e.variant(&e_req))
 }
 
@@ -166,7 +171,6 @@ pub unsafe extern "C" fn boolean(
 ) -> *const c_char {
     let e = get_engine(engine_ptr).unwrap();
     let e_req = get_evaluation_request(evaluation_request);
-
 
     result_to_json_ptr(e.boolean(&e_req))
 }

--- a/sdk/client/go/README.md
+++ b/sdk/client/go/README.md
@@ -39,7 +39,9 @@ import (
 )
 
 func main() {
-	evaluationClient := evaluation.NewClient("default")
+	// You can initialize the client with an namespace using "WithNamespace", otherwise
+	// it will target the default namespace.
+	evaluationClient := evaluation.NewClient(evaluation.WithNamespace("staging"))
 
 	evalCtx := map[string]string{
 		"fizz": "buzz",

--- a/sdk/client/go/README.md
+++ b/sdk/client/go/README.md
@@ -50,7 +50,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	variantEvaluationResponse, err := evaluationClient.Variant(context.Background(), &evaluation.EvaluationRequest{
+	variantResult, err := evaluationClient.Variant(context.Background(), &evaluation.EvaluationRequest{
 		NamespaceKey: "default",
 		FlagKey:      "flag1",
 		EntityId:     "someentity",
@@ -60,6 +60,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println(variantEvaluationResponse)
+	fmt.Println(variantResult)
 }
 ```

--- a/sdk/client/go/README.md
+++ b/sdk/client/go/README.md
@@ -39,7 +39,7 @@ import (
 )
 
 func main() {
-	// You can initialize the client with an namespace using "WithNamespace", otherwise
+	// You can initialize the client with a namespace using "WithNamespace", otherwise
 	// it will target the default namespace.
 	evaluationClient := evaluation.NewClient(evaluation.WithNamespace("staging"))
 

--- a/sdk/client/go/README.md
+++ b/sdk/client/go/README.md
@@ -31,7 +31,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 
@@ -43,25 +42,13 @@ func main() {
 	// it will target the default namespace.
 	evaluationClient := evaluation.NewClient(evaluation.WithNamespace("staging"))
 
-	evalCtx := map[string]string{
+	variantResult, err := evaluationClient.Variant(context.Background(), "flag1", "someentity", map[string]string{
 		"fizz": "buzz",
-	}
-
-	evalCtxBytes, err := json.Marshal(evalCtx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	variantResult, err := evaluationClient.Variant(context.Background(), &evaluation.EvaluationRequest{
-		NamespaceKey: "default",
-		FlagKey:      "flag1",
-		EntityId:     "someentity",
-		Context:      string(evalCtxBytes),
 	})
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Println(variantResult)
+	fmt.Println(*variantResult.Result)
 }
 ```

--- a/sdk/client/go/flipt-client-go/evaluation.go
+++ b/sdk/client/go/flipt-client-go/evaluation.go
@@ -66,8 +66,18 @@ func WithNamespace(namespace string) clientOption {
 }
 
 // Variant makes an evaluation on a variant flag using the allocated Rust engine.
-func (e *Client) Variant(_ context.Context, evaluationRequest *EvaluationRequest) (*VariantResult, error) {
-	ereq, err := json.Marshal(evaluationRequest)
+func (e *Client) Variant(_ context.Context, flagKey, entityID string, evalContext map[string]string) (*VariantResult, error) {
+	eb, err := json.Marshal(evalContext)
+	if err != nil {
+		return nil, err
+	}
+
+	ereq, err := json.Marshal(evaluationRequest{
+		NamespaceKey: e.namespace,
+		FlagKey:      flagKey,
+		EntityId:     entityID,
+		Context:      string(eb),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -87,8 +97,18 @@ func (e *Client) Variant(_ context.Context, evaluationRequest *EvaluationRequest
 }
 
 // Boolean makes an evaluation on a boolean flag using the allocated Rust engine.
-func (e *Client) Boolean(_ context.Context, evaluationRequest *EvaluationRequest) (*BooleanResult, error) {
-	ereq, err := json.Marshal(evaluationRequest)
+func (e *Client) Boolean(_ context.Context, flagKey, entityID string, evalContext map[string]string) (*BooleanResult, error) {
+	eb, err := json.Marshal(evalContext)
+	if err != nil {
+		return nil, err
+	}
+
+	ereq, err := json.Marshal(evaluationRequest{
+		NamespaceKey: e.namespace,
+		FlagKey:      flagKey,
+		EntityId:     entityID,
+		Context:      string(eb),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/client/go/flipt-client-go/evaluation.go
+++ b/sdk/client/go/flipt-client-go/evaluation.go
@@ -47,7 +47,7 @@ func NewClient(namespace string) *Client {
 }
 
 // Variant makes an evaluation on a variant flag using the allocated Rust engine.
-func (e *Client) Variant(_ context.Context, evaluationRequest *EvaluationRequest) (*VariantEvaluationResponse, error) {
+func (e *Client) Variant(_ context.Context, evaluationRequest *EvaluationRequest) (*VariantResult, error) {
 	ereq, err := json.Marshal(evaluationRequest)
 	if err != nil {
 		return nil, err
@@ -58,17 +58,17 @@ func (e *Client) Variant(_ context.Context, evaluationRequest *EvaluationRequest
 
 	b := C.GoBytes(unsafe.Pointer(variant), (C.int)(C.strlen(variant)))
 
-	var ver *VariantEvaluationResponse
+	var vr *VariantResult
 
-	if err := json.Unmarshal(b, &ver); err != nil {
+	if err := json.Unmarshal(b, &vr); err != nil {
 		return nil, err
 	}
 
-	return ver, nil
+	return vr, nil
 }
 
 // Boolean makes an evaluation on a boolean flag using the allocated Rust engine.
-func (e *Client) Boolean(_ context.Context, evaluationRequest *EvaluationRequest) (*BooleanEvaluationResponse, error) {
+func (e *Client) Boolean(_ context.Context, evaluationRequest *EvaluationRequest) (*BooleanResult, error) {
 	ereq, err := json.Marshal(evaluationRequest)
 	if err != nil {
 		return nil, err
@@ -79,13 +79,13 @@ func (e *Client) Boolean(_ context.Context, evaluationRequest *EvaluationRequest
 
 	b := C.GoBytes(unsafe.Pointer(boolean), (C.int)(C.strlen(boolean)))
 
-	var ber *BooleanEvaluationResponse
+	var br *BooleanResult
 
-	if err := json.Unmarshal(b, &ber); err != nil {
+	if err := json.Unmarshal(b, &br); err != nil {
 		return nil, err
 	}
 
-	return ber, nil
+	return br, nil
 }
 
 // Close cleans up the allocated engine as it was initialized in the constructor.

--- a/sdk/client/go/flipt-client-go/evaluation.go
+++ b/sdk/client/go/flipt-client-go/evaluation.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Client wraps the functionality of making variant and boolean evaluation of Flipt feature flags
-// using an engine that is compiled to a dynamic linking library.
+// using an engine that is compiled to a dynamically linked library.
 type Client struct {
 	engine    unsafe.Pointer
 	namespace string

--- a/sdk/client/go/flipt-client-go/models.go
+++ b/sdk/client/go/flipt-client-go/models.go
@@ -27,13 +27,13 @@ type BooleanEvaluationResponse struct {
 }
 
 type VariantResult struct {
-	ResponseCode string                     `json:"response_code"`
+	Status       string                     `json:"status"`
 	Result       *VariantEvaluationResponse `json:"result,omitempty"`
-	Error        string                     `json:"error_message,omitempty"`
+	ErrorMessage string                     `json:"error_message,omitempty"`
 }
 
 type BooleanResult struct {
-	ResponseCode string                     `json:"response_code"`
+	Status       string                     `json:"status"`
 	Result       *BooleanEvaluationResponse `json:"result,omitempty"`
 	ErrorMessage string                     `json:"error_message,omitempty"`
 }

--- a/sdk/client/go/flipt-client-go/models.go
+++ b/sdk/client/go/flipt-client-go/models.go
@@ -25,3 +25,15 @@ type BooleanEvaluationResponse struct {
 	RequestDurationMillis float64 `json:"request_duration_millis"`
 	Timestamp             string  `json:"timestamp"`
 }
+
+type VariantResult struct {
+	ResponseCode string                     `json:"response_code"`
+	Result       *VariantEvaluationResponse `json:"result,omitempty"`
+	Error        string                     `json:"error_message,omitempty"`
+}
+
+type BooleanResult struct {
+	ResponseCode string                     `json:"response_code"`
+	Result       *BooleanEvaluationResponse `json:"result,omitempty"`
+	ErrorMessage string                     `json:"error_message,omitempty"`
+}

--- a/sdk/client/go/flipt-client-go/models.go
+++ b/sdk/client/go/flipt-client-go/models.go
@@ -1,6 +1,6 @@
 package evaluation
 
-type EvaluationRequest struct {
+type evaluationRequest struct {
 	NamespaceKey string `json:"namespace_key"`
 	FlagKey      string `json:"flag_key"`
 	EntityId     string `json:"entity_id"`

--- a/sdk/client/python/README.md
+++ b/sdk/client/python/README.md
@@ -21,7 +21,8 @@ In your Python code you can import this client and use it as so:
 ```python
 from flipt_client_python import FliptEvaluationClient
 
-flipt_evaluation_client = FliptEvaluationClient(namespaces=["default", "another-namespace"])
+# namespace_key is optional here and will have a value of "default" if not specified
+flipt_evaluation_client = FliptEvaluationClient(namespace="staging")
 
 variant_result = flipt_evaluation_client.variant(namespace_key="default", flag_key="flag1", entity_id="entity", context={"fizz": "buzz"})
 

--- a/sdk/client/python/README.md
+++ b/sdk/client/python/README.md
@@ -24,7 +24,7 @@ from flipt_client_python import FliptEvaluationClient
 # namespace_key is optional here and will have a value of "default" if not specified
 flipt_evaluation_client = FliptEvaluationClient(namespace="staging")
 
-variant_result = flipt_evaluation_client.variant(namespace_key="default", flag_key="flag1", entity_id="entity", context={"fizz": "buzz"})
+variant_result = flipt_evaluation_client.variant(flag_key="flag1", entity_id="entity", context={"fizz": "buzz"})
 
 print(variant_result)
 ```

--- a/sdk/client/python/README.md
+++ b/sdk/client/python/README.md
@@ -23,5 +23,7 @@ from flipt_client_python import FliptEvaluationClient
 
 flipt_evaluation_client = FliptEvaluationClient(namespaces=["default", "another-namespace"])
 
-variant_response = flipt_evaluation_client.variant(namespace_key="default", flag_key="flag1", entity_id="entity", context={"this": "context"})
+variant_result = flipt_evaluation_client.variant(namespace_key="default", flag_key="flag1", entity_id="entity", context={"fizz": "buzz"})
+
+print(variant_result)
 ```

--- a/sdk/client/python/flipt-client-python/flipt_client_python/__init__.py
+++ b/sdk/client/python/flipt-client-python/flipt_client_python/__init__.py
@@ -15,6 +15,8 @@ class FliptEvaluationClient:
         if engine_library_path is None:
             raise Exception("ENGINE_LIB_PATH not set")
 
+        self.namespace_key = namespace
+
         self.ffi_core = ctypes.CDLL(engine_library_path)
 
         self.ffi_core.initialize_engine.restype = ctypes.c_void_p
@@ -37,12 +39,12 @@ class FliptEvaluationClient:
         if hasattr(self, "engine") and self.engine is not None:
             self.ffi_core.destroy_engine(self.engine)
 
-    def variant(
-        self, namespace_key: str, flag_key: str, entity_id: str, context: dict
-    ) -> VariantResult:
+    def variant(self, flag_key: str, entity_id: str, context: dict) -> VariantResult:
         response = self.ffi_core.variant(
             self.engine,
-            serialize_evaluation_request(namespace_key, flag_key, entity_id, context),
+            serialize_evaluation_request(
+                self.namespace_key, flag_key, entity_id, context
+            ),
         )
 
         bytes_returned = ctypes.c_char_p(response).value
@@ -51,12 +53,12 @@ class FliptEvaluationClient:
 
         return variant_result
 
-    def boolean(
-        self, namespace_key: str, flag_key: str, entity_id: str, context: dict
-    ) -> BooleanResult:
+    def boolean(self, flag_key: str, entity_id: str, context: dict) -> BooleanResult:
         response = self.ffi_core.boolean(
             self.engine,
-            serialize_evaluation_request(namespace_key, flag_key, entity_id, context),
+            serialize_evaluation_request(
+                self.namespace_key, flag_key, entity_id, context
+            ),
         )
 
         bytes_returned = ctypes.c_char_p(response).value

--- a/sdk/client/python/flipt-client-python/flipt_client_python/__init__.py
+++ b/sdk/client/python/flipt-client-python/flipt_client_python/__init__.py
@@ -3,9 +3,9 @@ import json
 import os
 
 from .models import (
-    BooleanEvaluationResponse,
+    BooleanResult,
     EvaluationRequest,
-    VariantEvaluationResponse,
+    VariantResult,
 )
 
 
@@ -33,11 +33,11 @@ class FliptEvaluationClient:
 
     def __del__(self):
         if hasattr(self, "engine") and self.engine is not None:
-            self.destroy_engine(self.engine)
+            self.ffi_core.destroy_engine(self.engine)
 
     def variant(
         self, namespace_key: str, flag_key: str, entity_id: str, context: dict
-    ) -> VariantEvaluationResponse:
+    ) -> VariantResult:
         response = self.ffi_core.variant(
             self.engine,
             serialize_evaluation_request(namespace_key, flag_key, entity_id, context),
@@ -45,15 +45,13 @@ class FliptEvaluationClient:
 
         bytes_returned = ctypes.c_char_p(response).value
 
-        variant_evaluation_response = VariantEvaluationResponse.parse_raw(
-            bytes_returned
-        )
+        variant_result = VariantResult.parse_raw(bytes_returned)
 
-        return variant_evaluation_response
+        return variant_result
 
     def boolean(
         self, namespace_key: str, flag_key: str, entity_id: str, context: dict
-    ) -> BooleanEvaluationResponse:
+    ) -> BooleanResult:
         response = self.ffi_core.boolean(
             self.engine,
             serialize_evaluation_request(namespace_key, flag_key, entity_id, context),
@@ -61,11 +59,9 @@ class FliptEvaluationClient:
 
         bytes_returned = ctypes.c_char_p(response).value
 
-        boolean_evaluation_response = BooleanEvaluationResponse.parse_raw(
-            bytes_returned
-        )
+        boolean_result = BooleanResult.parse_raw(bytes_returned)
 
-        return boolean_evaluation_response
+        return boolean_result
 
 
 def serialize_evaluation_request(

--- a/sdk/client/python/flipt-client-python/flipt_client_python/__init__.py
+++ b/sdk/client/python/flipt-client-python/flipt_client_python/__init__.py
@@ -10,7 +10,7 @@ from .models import (
 
 
 class FliptEvaluationClient:
-    def __init__(self, namespaces: list[str]):
+    def __init__(self, namespace: str = "default"):
         engine_library_path = os.environ.get("ENGINE_LIB_PATH")
         if engine_library_path is None:
             raise Exception("ENGINE_LIB_PATH not set")
@@ -26,8 +26,10 @@ class FliptEvaluationClient:
         self.ffi_core.boolean.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
         self.ffi_core.boolean.restype = ctypes.c_char_p
 
-        ns = (ctypes.c_char_p * len(namespaces))()
-        ns[:] = [s.encode("utf-8") for s in namespaces]
+        namespace_list = [namespace]
+
+        ns = (ctypes.c_char_p * len(namespace_list))()
+        ns[:] = [s.encode("utf-8") for s in namespace_list]
 
         self.engine = self.ffi_core.initialize_engine(ns)
 

--- a/sdk/client/python/flipt-client-python/flipt_client_python/models.py
+++ b/sdk/client/python/flipt-client-python/flipt_client_python/models.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
 
 class EvaluationRequest(BaseModel):
@@ -26,3 +26,15 @@ class BooleanEvaluationResponse(BaseModel):
     reason: str
     request_duration_millis: float
     timestamp: str
+
+
+class VariantResult(BaseModel):
+    response_code: str
+    result: Optional[VariantEvaluationResponse] = None
+    error_message: Optional[str] = None
+
+
+class BooleanResult(BaseModel):
+    response_code: str
+    result: Optional[BooleanEvaluationResponse] = None
+    error_message: Optional[str] = None

--- a/sdk/client/python/flipt-client-python/flipt_client_python/models.py
+++ b/sdk/client/python/flipt-client-python/flipt_client_python/models.py
@@ -29,12 +29,12 @@ class BooleanEvaluationResponse(BaseModel):
 
 
 class VariantResult(BaseModel):
-    response_code: str
+    status: str
     result: Optional[VariantEvaluationResponse] = None
     error_message: Optional[str] = None
 
 
 class BooleanResult(BaseModel):
-    response_code: str
+    status: str
     result: Optional[BooleanEvaluationResponse] = None
     error_message: Optional[str] = None


### PR DESCRIPTION
There inevitably will be errors upon user input for evaluations. This change will return such errors to the caller in an enveloped structure that contains a `ResponseCode`, and an optional Result (Boolean, Variant) and error message.

Completes FLI-689