### PR TITLE
test(cue): add failing case for attachment array support

### DIFF
--- a/internal/cue/flipt.cue
+++ b/internal/cue/flipt.cue
@@ -31,7 +31,7 @@ close({
 	key:          string & =~"^.+$"
 	name?:        string & =~"^.+$"
 	description?: string
-	attachment:   {...} | *null
+	attachment:   {...} | [...] | *null
 }
 
 #RuleSegment: {

--- a/internal/cue/testdata/valid.yaml
+++ b/internal/cue/testdata/valid.yaml
@@ -10,6 +10,15 @@ flags:
   - key: flipt
     name: flipt
     description: I'm a description.
+  - key: withAttachmentObject
+    name: With Attachment Object
+    attachment:
+      an: Object
+  - key: withAttachmentArray
+    name: With Attachment Array
+    attachment:
+      - an
+      - array
   rules:
   - segment: internal-users
     distributions:


### PR DESCRIPTION
Fixes #2421

This makes the CUE schema more permissive and accepts arrays, as well as objects under variant attachments.