### PR TITLE
fix(ui/token): show search input if it contains user's input

### DIFF
--- a/ui/src/components/tokens/TokenTable.tsx
+++ b/ui/src/components/tokens/TokenTable.tsx
@@ -226,7 +226,7 @@ export default function TokenTable(props: TokenTableProps) {
 
   return (
     <>
-      {tokens.length >= searchThreshold && (
+      {(tokens.length >= searchThreshold || filter != '') && (
         <Searchbox className="mb-6" value={filter ?? ''} onChange={setFilter} />
       )}
       <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">


### PR DESCRIPTION
User may use search to delete the token and after deletion we still want to have the search input so user could get back other token. Before user faced the empty table and no search input.

Fixes: #2436