### PR TITLE
chore: rm Mastadon footer (sorry Mastadon); skip uffizzi workflow on …

### DIFF
--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Build and Push `flipt`
     runs-on: ubuntu-latest
-    if: ${{ github.triggering_actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.action != 'closed') }}
+    if: ${{ github.triggering_actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.action != 'closed') && github.event.pull_request.head.repo.full_name == github.repository }}
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
     steps:
@@ -44,7 +44,7 @@ jobs:
   render-compose-file:
     name: Render Docker Compose File
     runs-on: ubuntu-latest
-    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+    if: ${{ github.triggering_actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs:
       - build
     outputs:
@@ -75,7 +75,7 @@ jobs:
   deploy-uffizzi-preview:
     name: Preview on Uffizzi
     needs: render-compose-file
-    if: ${{ github.triggering_actor != 'dependabot[bot]' }}
+    if: ${{ github.triggering_actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v3
     with:
       compose-file-cache-key: ${{ needs.render-compose-file.outputs.compose-file-cache-key }}
@@ -89,7 +89,7 @@ jobs:
   delete-uffizzi-preview:
     name: Delete Existing Preview
     uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v3
-    if: ${{ github.triggering_actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    if: ${{ github.triggering_actor != 'dependabot[bot]' && github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository }}
     with:
       compose-file-cache-key: ""
       compose-file-cache-path: docker-compose.rendered.yml

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -1,7 +1,6 @@
 import {
   faDiscord,
   faGithub,
-  faMastodon,
   faXTwitter
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -36,11 +35,6 @@ export default function Footer() {
       name: 'Twitter',
       href: 'https://www.twitter.com/flipt_io',
       icon: faXTwitter
-    },
-    {
-      name: 'Mastadon',
-      href: 'https://www.hachyderm.io/@flipt',
-      icon: faMastodon
     },
     {
       name: 'GitHub',


### PR DESCRIPTION
- the preview env service (Uffizzi) wont work on forks because of GitHub auth limitations for forked repos: https://github.com/UffizziCloud/preview-action/issues/80 so this just skips those jobs on PRs from forked repos
- note: we might be able to get around this by using [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target), but I'm not interested with futzing with GH Actions/YAML anymore at the moment 
- This also removes the Mastadon icon/link in the footer since we arent active on there 