### PR TITLE
chore: pin gitea image for ITs for now

### DIFF
--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -204,7 +204,7 @@ func local(ctx context.Context, client *dagger.Client, base, flipt *dagger.Conta
 
 func git(ctx context.Context, client *dagger.Client, base, flipt *dagger.Container, conf testConfig) func() error {
 	gitea := client.Container().
-		From("gitea/gitea:latest").
+		From("gitea/gitea:1.21.1").
 		WithExposedPort(3000).
 		WithExec(nil)
 

--- a/build/testing/test.go
+++ b/build/testing/test.go
@@ -15,7 +15,7 @@ func Unit(ctx context.Context, client *dagger.Client, flipt *dagger.Container) e
 		WithExec(nil)
 
 	gitea := client.Container().
-		From("gitea/gitea:latest").
+		From("gitea/gitea:1.21.1").
 		WithExposedPort(3000).
 		WithExec(nil)
 


### PR DESCRIPTION
There an issue with the `latest` Gitea docker image: https://github.com/go-gitea/gitea/issues/28230

This is causing our fs/git ITs to fail as well. Pinning the version to a known good version for now until ☝🏻 is resolved