### PR TITLE
chore: add alt attribute after markdownlint upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=dc285028-90ba-436b-9a4a-e0d826a2c986" />
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=dc285028-90ba-436b-9a4a-e0d826a2c986" alt="" />
 
 <p align=center>
     <img src="logo.svg" alt="Flipt" width=275 height=96 />


### PR DESCRIPTION
DavidAnson/markdownlint-cli2-action was bumped from 13 to 14 and linter started to complain about README.md. For some reason it was merged automatically by kodiakhq bot even the action failed.

Refs: #2450