### PR TITLE
fix(ui/console): monaco web workers don't work

### DIFF
--- a/ui/src/components/console/ContextEditor.tsx
+++ b/ui/src/components/console/ContextEditor.tsx
@@ -1,4 +1,4 @@
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import * as monaco from 'monaco-editor';
 import tmrw from 'monaco-themes/themes/Tomorrow-Night-Bright.json';
 import { useEffect, useRef } from 'react';
 import styles from './ContextEditor.module.css';

--- a/ui/src/components/console/worker.ts
+++ b/ui/src/components/console/worker.ts
@@ -1,21 +1,14 @@
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+
 // @ts-ignore
 self.MonacoEnvironment = {
   getWorker(_, label) {
     switch (label) {
       case 'json':
-        return new Worker(
-          new URL(
-            'monaco-editor/esm/vs/language/json/json.worker.js',
-            import.meta.url
-          )
-        );
+        return new jsonWorker();
       default:
-        return new Worker(
-          new URL(
-            'monaco-editor/esm/vs/editor/editor.worker.js',
-            import.meta.url
-          )
-        );
+        return new editorWorker();
     }
   }
 };


### PR DESCRIPTION
Refs: #2059


BTW,  Monaco has feature to [highlight the code](https://microsoft.github.io/monaco-editor/playground.html?source=v0.44.0#example-creating-the-editor-syntax-highlighting-for-html-elements). We could drop `highlight.js` and replace it with that if needed.