### PR TITLE
feat(cli): silence usage on errors

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -109,6 +109,7 @@ func exec() error {
 			CompletionOptions: cobra.CompletionOptions{
 				DisableDefaultCmd: true,
 			},
+			SilenceUsage: true,
 		}
 
 		t   = template.Must(template.New("banner").Parse(bannerTmpl))


### PR DESCRIPTION
This changes the CLI to only output the error, not the entire help docs

## Before

```
workspace/flipt - [main●] » ./bin/flipt --config config/local.yml
Error: loading configuration scopes must contain read:org when allowed_organizations is not empty
Usage:
  flipt <command> <subcommand> [flags]
  flipt [command]

Examples:
$ flipt
$ flipt config init
$ flipt --config /path/to/config.yml migrate


Available Commands:
  bundle      Manage Flipt bundles
  config      Manage Flipt configuration
  export      Export Flipt data to file/stdout
  help        Help about any command
  import      Import Flipt data from file/stdin
```

## After

```
workspace/flipt - [silence-usage●] » ./bin/flipt --config config/local.yml
Error: loading configuration scopes must contain read:org when allowed_organizations is not empty
```