### PR TITLE
fix(ui): remove h-screen from default classes for Loading component

### DIFF
--- a/ui/src/components/Loading.tsx
+++ b/ui/src/components/Loading.tsx
@@ -10,7 +10,7 @@ export default function Loading(props: LoadingProps) {
 
   return (
     <div
-      className={cls('flex h-screen items-center justify-center', {
+      className={cls('flex items-center justify-center', {
         'h-screen': fullScreen
       })}
     >


### PR DESCRIPTION
In #2506 I put extra `h-screen` in wrong place.