### PR TITLE
fix(cfg): default config outputs first INFO log regardless of FLIPT_LOG_LEVEL

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -67,8 +67,12 @@ var (
 )
 
 func loggerConfig(encoding zapcore.EncoderConfig) zap.Config {
+	level, err := zap.ParseAtomicLevel(os.Getenv(config.EnvPrefix + "_LOG_LEVEL"))
+	if err != nil {
+		level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	}
 	return zap.Config{
-		Level:            zap.NewAtomicLevelAt(zap.InfoLevel),
+		Level:            level,
 		Development:      false,
 		Encoding:         "console",
 		EncoderConfig:    encoding,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ import (
 )
 
 const Version = "1.0"
+const EnvPrefix = "FLIPT"
 
 var DecodeHooks = []mapstructure.DecodeHookFunc{
 	mapstructure.StringToTimeDurationHookFunc(),
@@ -75,7 +76,7 @@ func Dir() (string, error) {
 
 func Load(path string) (*Result, error) {
 	v := viper.New()
-	v.SetEnvPrefix("FLIPT")
+	v.SetEnvPrefix(EnvPrefix)
 	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 


### PR DESCRIPTION
I would say that it's more chicken and egg problem. Viper is loading the configuration after the logger says that there is no configuration file. 

fixes #2531