### PR TITLE
fix: resolved issues with go-git 5.11.0

### DIFF
--- a/build/internal/cmd/gitea/main.go
+++ b/build/internal/cmd/gitea/main.go
@@ -68,7 +68,7 @@ func main() {
 	fmt.Fprintln(os.Stderr, "Creating Repository from", *testdataDir)
 
 	repo, err := git.InitWithOptions(memory.NewStorage(), workdir, git.InitOptions{
-		DefaultBranch: "main",
+		DefaultBranch: "refs/heads/main",
 	})
 	fatalOnError(err)
 
@@ -126,7 +126,7 @@ func main() {
 	repo.Push(&git.PushOptions{
 		Auth:       &githttp.BasicAuth{Username: "root", Password: "password"},
 		RemoteName: "origin",
-		RefSpecs:   []config.RefSpec{"main:refs/heads/main"},
+		RefSpecs:   []config.RefSpec{"refs/heads/main:refs/heads/main"},
 	})
 	fmt.Fprintln(os.Stderr, "Pushed")
 


### PR DESCRIPTION
go-git added validation for refs and branch refs is not defined correctly.

fixes #2522