### PR TITLE
Zaid Auth Internship Challenge 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ tmp
 __debug_bin
 *.tar
 
+package-lock.json
+package.json
+
 Brewfile.lock.json
 *.key
 build/hack/out/

--- a/config/local.yml
+++ b/config/local.yml
@@ -4,16 +4,16 @@
 log:
   level: DEBUG
 
-# authentication:
-#   required: true
-#   session:
-#     domain: "localhost:8080"
-#     secure: false
-#   methods:
-#     basic:
-#       enabled: true
-#       username: "admin"
-#       bcrypt_password: "$2y$05$Djg.k2WHG.1vsHyttxkhce20Y1ZKP3DGOlJnlxa41KWTs8MoKytmK"
+authentication:
+  required: true
+  session:
+    domain: "localhost:8080"
+    secure: false
+  methods:
+    basic:
+      enabled: true
+      username: "admin"
+      bcrypt_password: "$2y$05$Djg.k2WHG.1vsHyttxkhce20Y1ZKP3DGOlJnlxa41KWTs8MoKytmK"
 
 cors:
   enabled: true

--- a/ui/src/app/auth/Login.tsx
+++ b/ui/src/app/auth/Login.tsx
@@ -197,7 +197,7 @@ function InnerLogin() {
                 Login to Flipt
               </h2>
             </div>
-            <div className="mt-8">
+            <div className="mt-4">
               <div className="px-4 py-8 sm:px-10">
                 <div className="text-center">
                   <LoginForm />

--- a/ui/src/app/auth/Login.tsx
+++ b/ui/src/app/auth/Login.tsx
@@ -17,7 +17,7 @@ import ErrorNotification from '~/components/notifications/ErrorNotification';
 import { useError } from '~/data/hooks/error';
 import { useSession } from '~/data/hooks/session';
 import { IAuthMethod } from '~/types/Auth';
-
+import LoginForm from './LoginForm';
 interface ILoginProvider {
   displayName: string;
   icon: IconDefinition;
@@ -197,9 +197,11 @@ function InnerLogin() {
                 Login to Flipt
               </h2>
             </div>
-            <div className="mt-8 max-w-sm sm:mx-auto sm:w-full md:max-w-lg">
+            <div className="mt-8">
               <div className="px-4 py-8 sm:px-10">
-                <InnerLoginButtons />
+                <div className="text-center">
+                  <LoginForm />
+                </div>
               </div>
             </div>
           </div>

--- a/ui/src/app/auth/LoginForm.tsx
+++ b/ui/src/app/auth/LoginForm.tsx
@@ -51,6 +51,10 @@ function LoginForm() {
     setModalOpen(false);
   };
 
+  const capitalizeFirstLetter = (string: string) => {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  };
+
   const isFormIncomplete = !formData.username || !formData.password;
 
   return (
@@ -59,7 +63,7 @@ function LoginForm() {
         onClick={() => setModalOpen(true)}
         className="text-white bg-purple-500 rounded px-4 py-2 font-bold hover:bg-purple-700"
       >
-        Login
+        Login with Basic Authentication
       </button>
 
       <Modal open={modalOpen} setOpen={setModalOpen}>
@@ -95,7 +99,11 @@ function LoginForm() {
               className="border-purple-400 w-full rounded border p-2 focus:border-purple-500 focus:outline-none"
             />
           </div>
-          {loginError && <div className="text-red-500 mb-3">{loginError}</div>}
+          {loginError && (
+            <div className="text-red-500 mb-3">
+              {capitalizeFirstLetter(loginError)}
+            </div>
+          )}
           {loginSuccess && (
             <div className="text-green-500 mb-3">{loginSuccess}</div>
           )}

--- a/ui/src/app/auth/LoginForm.tsx
+++ b/ui/src/app/auth/LoginForm.tsx
@@ -97,7 +97,7 @@ function LoginForm() {
           </div>
           {loginError && <div className="text-red-500 mb-3">{loginError}</div>}
           {loginSuccess && (
-            <div className="text-gteen-500 mb-3">{loginSuccess}</div>
+            <div className="text-green-500 mb-3">{loginSuccess}</div>
           )}
           <div className="flex justify-center gap-4 text-center">
             <button

--- a/ui/src/app/auth/LoginForm.tsx
+++ b/ui/src/app/auth/LoginForm.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import Modal from '~/components/Modal';
+
+function LoginForm() {
+  const [formData, setFormData] = useState({
+    username: '',
+    password: ''
+  });
+
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleInputChange = (e: { target: { name: any; value: any } }) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+  };
+
+  const handleSubmit = async (e: { preventDefault: () => void }) => {
+    e.preventDefault();
+
+    const response = await fetch('/auth/v1/method/basic/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(formData)
+    });
+
+    if (response.ok) {
+      // Authentication successful
+    } else {
+      // Authentication failed
+    }
+  };
+
+  const openModal = () => {
+    setModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setModalOpen(false);
+  };
+  const isFormIncomplete = !formData.username || !formData.password;
+
+  return (
+    <>
+      <button
+        onClick={() => setModalOpen(true)}
+        className="text-white bg-purple-500 rounded px-4 py-2 font-bold hover:bg-purple-700"
+      >
+        Login
+      </button>
+
+      <Modal open={modalOpen} setOpen={setModalOpen}>
+        <form onSubmit={handleSubmit} className="p-4">
+          <div className="flex items-center justify-between">
+            <h2 className="mb-4 text-2xl font-semibold">Login</h2>
+            <button
+              onClick={() => setModalOpen(false)}
+              className="text-gray-800 bg-gray-200 rounded-full p-2 hover:bg-gray-300"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="mb-4">
+            <label htmlFor="username" className="text-gray-700 block font-bold">
+              Username
+            </label>
+            <input
+              type="text"
+              id="username"
+              name="username"
+              value={formData.username}
+              onChange={handleInputChange}
+              required
+              className="border-gray-400 w-full rounded border p-2 focus:border-purple-500 focus:outline-none"
+            />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="password" className="text-gray-700 block font-bold">
+              Password
+            </label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              value={formData.password}
+              onChange={handleInputChange}
+              required
+              className="border-gray-400 w-full rounded border p-2 focus:border-purple-500 focus:outline-none"
+            />
+          </div>
+          <div className="text-center">
+            <button
+              type="submit"
+              className={`text-white rounded px-4 py-2 font-bold ${
+                isFormIncomplete
+                  ? 'bg-gray-400 cursor-not-allowed hover:bg-gray-400'
+                  : 'bg-purple-500 hover:bg-purple-700'
+              }`}
+              disabled={isFormIncomplete}
+              title={
+                isFormIncomplete
+                  ? 'Fill in username and password to submit'
+                  : ''
+              }
+            >
+              Login
+            </button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}
+
+export default LoginForm;

--- a/ui/src/app/auth/LoginForm.tsx
+++ b/ui/src/app/auth/LoginForm.tsx
@@ -8,6 +8,8 @@ function LoginForm() {
   });
 
   const [modalOpen, setModalOpen] = useState(false);
+  const [loginError, setLoginError] = useState('');
+  const [loginSuccess, setLoginSuccess] = useState('');
 
   const handleInputChange = (e: { target: { name: any; value: any } }) => {
     const { name, value } = e.target;
@@ -16,19 +18,29 @@ function LoginForm() {
 
   const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
+    setLoginError('');
 
-    const response = await fetch('/auth/v1/method/basic/login', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(formData)
-    });
+    try {
+      const response = await fetch(
+        'http://localhost:8080/auth/v1/method/basic/login',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify(formData)
+        }
+      );
 
-    if (response.ok) {
-      // Authentication successful
-    } else {
-      // Authentication failed
+      if (response.ok) {
+        setLoginSuccess('Success!🎉');
+      } else {
+        const errorData = await response.json();
+        setLoginError(errorData.message || 'Failed to log in.');
+      }
+    } catch (error) {
+      console.error('Network or server error:', error);
+      setLoginError('Network error or server is unreachable.');
     }
   };
 
@@ -54,12 +66,6 @@ function LoginForm() {
         <form onSubmit={handleSubmit} className="p-4">
           <div className="flex items-center justify-between">
             <h2 className="mb-4 text-2xl font-semibold">Login</h2>
-            <button
-              onClick={() => setModalOpen(false)}
-              className="text-gray-800 bg-gray-200 rounded-full p-2 hover:bg-gray-300"
-            >
-              &times;
-            </button>
           </div>
           <div className="mb-4">
             <label htmlFor="username" className="text-gray-700 block font-bold">
@@ -72,7 +78,7 @@ function LoginForm() {
               value={formData.username}
               onChange={handleInputChange}
               required
-              className="border-gray-400 w-full rounded border p-2 focus:border-purple-500 focus:outline-none"
+              className="border-purple-400 w-full rounded border p-2 focus:border-purple-500 focus:outline-none"
             />
           </div>
           <div className="mb-4">
@@ -86,9 +92,13 @@ function LoginForm() {
               value={formData.password}
               onChange={handleInputChange}
               required
-              className="border-gray-400 w-full rounded border p-2 focus:border-purple-500 focus:outline-none"
+              className="border-purple-400 w-full rounded border p-2 focus:border-purple-500 focus:outline-none"
             />
           </div>
+          {loginError && <div className="text-red-500 mb-3">{loginError}</div>}
+          {loginSuccess && (
+            <div className="text-gteen-500 mb-3">{loginSuccess}</div>
+          )}
           <div className="text-center">
             <button
               type="submit"
@@ -105,6 +115,17 @@ function LoginForm() {
               }
             >
               Login
+            </button>
+          </div>
+          <div className="text-center">
+            <button
+              type="submit"
+              className={
+                'bg-white-500 hover:bg-white-700 text-purple-500 border-purple-500 rounded px-4 py-2 font-bold'
+              }
+              onClick={() => setModalOpen(false)}
+            >
+              Cancel
             </button>
           </div>
         </form>

--- a/ui/src/app/auth/LoginForm.tsx
+++ b/ui/src/app/auth/LoginForm.tsx
@@ -6,7 +6,6 @@ function LoginForm() {
     username: '',
     password: ''
   });
-
   const [modalOpen, setModalOpen] = useState(false);
   const [loginError, setLoginError] = useState('');
   const [loginSuccess, setLoginSuccess] = useState('');
@@ -19,6 +18,7 @@ function LoginForm() {
   const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault();
     setLoginError('');
+    setLoginSuccess('');
 
     try {
       const response = await fetch(
@@ -44,13 +44,13 @@ function LoginForm() {
     }
   };
 
-  const openModal = () => {
-    setModalOpen(true);
-  };
-
   const closeModal = () => {
+    setLoginError('');
+    setLoginSuccess('');
+    setFormData({ username: '', password: '' });
     setModalOpen(false);
   };
+
   const isFormIncomplete = !formData.username || !formData.password;
 
   return (
@@ -99,12 +99,12 @@ function LoginForm() {
           {loginSuccess && (
             <div className="text-gteen-500 mb-3">{loginSuccess}</div>
           )}
-          <div className="text-center">
+          <div className="flex justify-center gap-4 text-center">
             <button
               type="submit"
               className={`text-white rounded px-4 py-2 font-bold ${
                 isFormIncomplete
-                  ? 'bg-gray-400 cursor-not-allowed hover:bg-gray-400'
+                  ? 'bg-purple-300 cursor-not-allowed hover:bg-purple-400'
                   : 'bg-purple-500 hover:bg-purple-700'
               }`}
               disabled={isFormIncomplete}
@@ -116,14 +116,11 @@ function LoginForm() {
             >
               Login
             </button>
-          </div>
-          <div className="text-center">
+
             <button
-              type="submit"
-              className={
-                'bg-white-500 hover:bg-white-700 text-purple-500 border-purple-500 rounded px-4 py-2 font-bold'
-              }
-              onClick={() => setModalOpen(false)}
+              type="button"
+              className="hover:bg-white-700 text-purple-500 border-purple-500 rounded border px-4 py-2 font-bold hover:border-purple-700"
+              onClick={closeModal}
             >
               Cancel
             </button>


### PR DESCRIPTION
### Description
This pull request adds support for basic authentication to the Flipt UI, allowing users to log in with a username and password. The changes ensure users can securely manage their feature flags within the application.

### Key Features
- A new login page that prompts for a username and password.
- Form validation to ensure both fields are filled out before submission.
- The login button on the main page opens a model to reveal the login form.
- An authentication request is sent to the backend API upon form submission.
- User feedback for successful logins and descriptive error messages for failed attempts.

### How to Test the Feature
- Ensure the backend API is running and configured for basic authentication.
- Start the Flipt UI and navigate to the login page at http://localhost:8080. (my UI was actually running on http://localhost:5173)
- This should then redirect you automatically to http://localhost:8080/#/login. (again in my case it was http://localhost:5173/#/login)
- Before entering a username or password, you will see the 'Login' button is disabled. If you hover over it, a popup will make it clear to the user that both fields need to be filled in
- Enter the username and password (use admin and password for testing).
- Click on the 'Login' button to authenticate.
- Observe the feedback - either a success message or an error message.
