### PR TITLE
refactor(storage): move s3fs to storage/fs/s3 and extract file types

### DIFF
--- a/internal/storage/fs/blob/dir.go
+++ b/internal/storage/fs/blob/dir.go
@@ -1,0 +1,37 @@
+package blob
+
+import (
+	"io"
+	"io/fs"
+)
+
+type Dir struct {
+	*FileInfo
+}
+
+// ensure Dir implements fs.FileInfo
+var _ fs.FileInfo = &Dir{}
+
+func (d *Dir) Stat() (fs.FileInfo, error) {
+	return d.FileInfo, nil
+}
+
+func (d *Dir) Read(p []byte) (n int, err error) {
+	return 0, io.EOF
+}
+
+func (d *Dir) Close() error {
+	return nil
+}
+
+func (d *Dir) IsDir() bool {
+	return true
+}
+
+func (d *Dir) Mode() fs.FileMode {
+	return fs.ModeDir
+}
+
+func NewDir(fileInfo *FileInfo) *Dir {
+	return &Dir{fileInfo}
+}

--- a/internal/storage/fs/blob/dir_test.go
+++ b/internal/storage/fs/blob/dir_test.go
@@ -1,0 +1,24 @@
+package blob
+
+import (
+	"io"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDir(t *testing.T) {
+	fi := &FileInfo{}
+	d := NewDir(fi)
+	s, err := d.Stat()
+	require.NoError(t, err)
+	require.Equal(t, fi, s)
+	require.True(t, d.IsDir())
+	require.Equal(t, fs.ModeDir, d.Mode())
+	n, err := d.Read([]byte{})
+	require.Equal(t, 0, n)
+	require.Error(t, io.EOF, err)
+	require.NoError(t, d.Close())
+
+}

--- a/internal/storage/fs/blob/file.go
+++ b/internal/storage/fs/blob/file.go
@@ -1,0 +1,44 @@
+package blob
+
+import (
+	"io"
+	"io/fs"
+	"time"
+)
+
+type File struct {
+	bucket       string
+	key          string
+	length       int64
+	body         io.ReadCloser
+	lastModified time.Time
+}
+
+// ensure File implements the fs.File interface
+var _ fs.File = &File{}
+
+func (f *File) Stat() (fs.FileInfo, error) {
+	return &FileInfo{
+		name:    f.key,
+		size:    f.length,
+		modTime: f.lastModified,
+	}, nil
+}
+
+func (f *File) Read(p []byte) (int, error) {
+	return f.body.Read(p)
+}
+
+func (f *File) Close() error {
+	return f.body.Close()
+}
+
+func NewFile(bucket string, key string, length int64, body io.ReadCloser, lastModified time.Time) *File {
+	return &File{
+		bucket:       bucket,
+		key:          key,
+		length:       length,
+		body:         body,
+		lastModified: lastModified,
+	}
+}

--- a/internal/storage/fs/blob/file_test.go
+++ b/internal/storage/fs/blob/file_test.go
@@ -1,0 +1,28 @@
+package blob
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFile(t *testing.T) {
+	modTime := time.Now()
+	r := io.NopCloser(strings.NewReader("hello"))
+	f := NewFile("bucket", "f.txt", 5, r, modTime)
+	fi, err := f.Stat()
+	require.NoError(t, err)
+	require.Equal(t, "f.txt", fi.Name())
+	require.Equal(t, int64(5), fi.Size())
+	require.Equal(t, modTime, fi.ModTime())
+	buf := make([]byte, fi.Size())
+	n, err := f.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, []byte("hello"), buf)
+	err = f.Close()
+	require.NoError(t, err)
+}

--- a/internal/storage/fs/blob/fileinfo.go
+++ b/internal/storage/fs/blob/fileinfo.go
@@ -1,0 +1,61 @@
+package blob
+
+import (
+	"io/fs"
+	"time"
+)
+
+// ensure FileInfo implements fs.FileInfo
+var _ fs.FileInfo = &FileInfo{}
+
+// ensure FileInfo implements fs.DirEntry
+var _ fs.DirEntry = &FileInfo{}
+
+type FileInfo struct {
+	name    string
+	size    int64
+	modTime time.Time
+	isDir   bool
+}
+
+func (fi *FileInfo) Name() string {
+	return fi.name
+}
+
+func (fi *FileInfo) Size() int64 {
+	return fi.size
+}
+
+func (fi *FileInfo) Type() fs.FileMode {
+	return 0
+}
+
+func (fi *FileInfo) Mode() fs.FileMode {
+	return fs.ModePerm
+}
+
+func (fi *FileInfo) ModTime() time.Time {
+	return fi.modTime
+}
+
+func (fi *FileInfo) IsDir() bool {
+	return fi.isDir
+}
+func (fi *FileInfo) SetDir(v bool) {
+	fi.isDir = v
+}
+
+func (fi *FileInfo) Sys() any {
+	return nil
+}
+func (fi *FileInfo) Info() (fs.FileInfo, error) {
+	return fi, nil
+}
+
+func NewFileInfo(name string, size int64, modTime time.Time) *FileInfo {
+	return &FileInfo{
+		name:    name,
+		size:    size,
+		modTime: modTime,
+	}
+}

--- a/internal/storage/fs/blob/fileinfo_test.go
+++ b/internal/storage/fs/blob/fileinfo_test.go
@@ -1,0 +1,29 @@
+package blob
+
+import (
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileInfo(t *testing.T) {
+	modTime := time.Now()
+	fi := NewFileInfo("f.txt", 100, modTime)
+	require.Equal(t, fs.FileMode(0), fi.Type())
+	require.Equal(t, "f.txt", fi.Name())
+	require.Equal(t, int64(100), fi.Size())
+	require.Equal(t, modTime, fi.ModTime())
+	require.Equal(t, false, fi.isDir)
+	info, err := fi.Info()
+	require.NoError(t, err)
+	require.Equal(t, fi, info)
+	require.Nil(t, fi.Sys())
+}
+
+func TestFileInfoIsDir(t *testing.T) {
+	fi := FileInfo{}
+	fi.SetDir(true)
+	require.Equal(t, true, fi.isDir)
+}

--- a/internal/storage/fs/s3/s3fs.go
+++ b/internal/storage/fs/s3/s3fs.go
@@ -1,8 +1,7 @@
-package s3fs
+package s3
 
 import (
 	"context"
-	"io"
 	"io/fs"
 	"strings"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	flipterrors "go.flipt.io/flipt/errors"
+	"go.flipt.io/flipt/internal/storage/fs/blob"
 	"go.uber.org/zap"
 )
 
@@ -30,7 +30,7 @@ type FS struct {
 	prefix string
 
 	// cached entries
-	dirEntry *Dir
+	dirEntry *blob.Dir
 }
 
 // ensure FS implements fs.FS aka Open
@@ -43,7 +43,7 @@ var _ fs.StatFS = &FS{}
 var _ fs.ReadDirFS = &FS{}
 
 // New creates a FS for the single bucket
-func New(logger *zap.Logger, s3Client S3ClientAPI, bucket string, prefix string) (*FS, error) {
+func NewFS(logger *zap.Logger, s3Client S3ClientAPI, bucket string, prefix string) (*FS, error) {
 	return &FS{
 		logger:   logger,
 		s3Client: s3Client,
@@ -91,13 +91,13 @@ func (f *FS) Open(name string) (fs.File, error) {
 		return nil, pathError
 	}
 
-	return &File{
-		bucket:       f.bucket,
-		key:          name,
-		length:       *output.ContentLength,
-		body:         output.Body,
-		lastModified: *output.LastModified,
-	}, nil
+	return blob.NewFile(
+		f.bucket,
+		name,
+		*output.ContentLength,
+		output.Body,
+		*output.LastModified,
+	), nil
 }
 
 // Stat implements fs.StatFS. For the s3 filesystem, this gets the
@@ -113,14 +113,8 @@ func (f *FS) Stat(name string) (fs.FileInfo, error) {
 			Err:  fs.ErrInvalid,
 		}
 	}
-	dirInfo := &FileInfo{
-		name: name,
-		size: 0,
-	}
-	f.dirEntry = &Dir{
-		FileInfo: dirInfo,
-	}
 
+	f.dirEntry = blob.NewDir(blob.NewFileInfo(name, 0, time.Time{}))
 	// AWS S3 does not store the last modified time for the bucket
 	// anywhere. We'd have to iterate through all the objects to
 	// calculate it, which doesn't seem worth it.
@@ -174,11 +168,11 @@ func (f *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 
 		for i := range output.Contents {
 			c := output.Contents[i]
-			fi := &FileInfo{
-				name:    *c.Key,
-				size:    *c.Size,
-				modTime: *c.LastModified,
-			}
+			fi := blob.NewFileInfo(
+				*c.Key,
+				*c.Size,
+				*c.LastModified,
+			)
 			entries = append(entries, fi)
 		}
 		if !*output.IsTruncated {
@@ -195,100 +189,4 @@ func (f *FS) ReadDir(name string) ([]fs.DirEntry, error) {
 		Path: name,
 		Err:  fs.ErrClosed,
 	}
-}
-
-type Dir struct {
-	*FileInfo
-}
-
-// ensure Dir implements fs.FileInfo
-var _ fs.FileInfo = &Dir{}
-
-func (d *Dir) Stat() (fs.FileInfo, error) {
-	return d.FileInfo, nil
-}
-
-func (d *Dir) Read(p []byte) (n int, err error) {
-	return 0, io.EOF
-}
-
-func (d *Dir) Close() error {
-	return nil
-}
-
-func (d *Dir) IsDir() bool {
-	return true
-}
-
-func (d *Dir) Mode() fs.FileMode {
-	return fs.ModeDir
-}
-
-// ensure FileInfo implements fs.FileInfo
-var _ fs.FileInfo = &FileInfo{}
-
-// ensure FileInfo implements fs.DirEntry
-var _ fs.DirEntry = &FileInfo{}
-
-type FileInfo struct {
-	name    string
-	size    int64
-	modTime time.Time
-}
-
-func (fi *FileInfo) Name() string {
-	return fi.name
-}
-
-func (fi *FileInfo) Size() int64 {
-	return fi.size
-}
-
-func (fi *FileInfo) Type() fs.FileMode {
-	return 0
-}
-
-func (fi *FileInfo) Mode() fs.FileMode {
-	return fs.ModePerm
-}
-
-func (fi *FileInfo) ModTime() time.Time {
-	return fi.modTime
-}
-
-func (fi *FileInfo) IsDir() bool {
-	return false
-}
-
-func (fi *FileInfo) Sys() any {
-	return nil
-}
-func (fi *FileInfo) Info() (fs.FileInfo, error) {
-	return fi, nil
-}
-
-type File struct {
-	bucket       string
-	key          string
-	length       int64
-	body         io.ReadCloser
-	lastModified time.Time
-}
-
-// ensure File implements the fs.File interface
-var _ fs.File = &File{}
-
-func (f *File) Stat() (fs.FileInfo, error) {
-	return &FileInfo{
-		name: f.key,
-		size: f.length,
-	}, nil
-}
-
-func (f *File) Read(p []byte) (int, error) {
-	return f.body.Read(p)
-}
-
-func (f *File) Close() error {
-	return f.body.Close()
 }

--- a/internal/storage/fs/s3/s3fs_test.go
+++ b/internal/storage/fs/s3/s3fs_test.go
@@ -1,4 +1,4 @@
-package s3fs
+package s3
 
 import (
 	"context"
@@ -152,7 +152,7 @@ func Test_FS(t *testing.T) {
 	fakeS3Client := newFakeS3Client()
 	logger := zaptest.NewLogger(t)
 	// run with no prefix, returning all files
-	s3fs, err := New(logger, fakeS3Client, fakeS3Client.bucket, "")
+	s3fs, err := NewFS(logger, fakeS3Client, fakeS3Client.bucket, "")
 	require.NoError(t, err)
 
 	t.Run("Ensure invalid and non existent paths produce an error", func(t *testing.T) {
@@ -224,7 +224,7 @@ func Test_FS_Prefix(t *testing.T) {
 	fakeS3Client := newFakeS3Client()
 	logger := zaptest.NewLogger(t)
 	// run with prefix, returning only prefixed files
-	s3fs, err := New(logger, fakeS3Client, fakeS3Client.bucket, "prefix/")
+	s3fs, err := NewFS(logger, fakeS3Client, fakeS3Client.bucket, "prefix/")
 	require.NoError(t, err)
 
 	t.Run("Ensure invalid and non existent paths produce an error", func(t *testing.T) {

--- a/internal/storage/fs/s3/store.go
+++ b/internal/storage/fs/s3/store.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 
 	"go.flipt.io/flipt/internal/containers"
-	"go.flipt.io/flipt/internal/s3fs"
 	"go.flipt.io/flipt/internal/storage"
 	storagefs "go.flipt.io/flipt/internal/storage/fs"
 	"go.uber.org/zap"
@@ -112,7 +111,7 @@ func WithPollOptions(opts ...containers.Option[storagefs.Poller]) containers.Opt
 
 // Update fetches a new snapshot and swaps it out for the current one.
 func (s *SnapshotStore) update(context.Context) (bool, error) {
-	fs, err := s3fs.New(s.logger, s.s3, s.bucket, s.prefix)
+	fs, err := NewFS(s.logger, s.s3, s.bucket, s.prefix)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Move s3fs to storage/fs/s3 and extract file types into storage/fs/blob package

This is related to work with Azure Blob Storage #2538 