### PR TITLE
test(cleanup): parallelize cleanup method tests

### DIFF
--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -29,7 +29,7 @@ type AuthenticationService struct {
 // NewAuthenticationService constructs and configures a new instance of authentication service.
 func NewAuthenticationService(logger *zap.Logger, lock oplock.Service, store authstorage.Store, config config.AuthenticationConfig) *AuthenticationService {
 	return &AuthenticationService{
-		logger: logger,
+		logger: logger.With(zap.String("service", "authentication cleanup service")),
 		lock:   lock,
 		store:  store,
 		config: config,
@@ -107,6 +107,11 @@ func (s *AuthenticationService) Run(ctx context.Context) {
 
 // Stop signals for the cleanup goroutines to cancel and waits for them to finish.
 func (s *AuthenticationService) Shutdown(ctx context.Context) error {
+	s.logger.Debug("shutting down...")
+	defer func() {
+		s.logger.Debug("shutdown complete")
+	}()
+
 	s.cancel()
 
 	return s.errgroup.Wait()


### PR DESCRIPTION
This parallelizes the `cleanup` suite auth method tests.

Each auth method was being tested in serial. The test consistents of some rather long sleeps, because oplock works around polling and expiry / grace period timestamps. These could probably also be reduced. However, in this PR, I parallelized the tests for each method as the suite of tests was growing each time we added a new authentication method.

This brings the test suite down from ~60s (4 methods * 15 seconds) to a constant ~15s that wont grow with each new method.