### PR TITLE
chore: try to fix nightly build tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,9 @@
 
 project_name: flipt
 
+git:
+  tag_sort: semver
+
 monorepo:
   tag_prefix: v
 


### PR DESCRIPTION
It seems goreleaser is getting the wrong tag when building nightly image

Going to try this setting from goreleaser: https://goreleaser.com/customization/git/#semver-sorting