### PR TITLE
chore: try to fix previous tag for good

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Git Tag
         run: |
-          echo "GORELEASER_PREVIOUS_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
+          echo "GORELEASER_CURRENT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
 
       - name: GoReleaser (Nightly) Build
         uses: goreleaser/goreleaser-action@v5
@@ -75,7 +75,7 @@ jobs:
           version: latest
           args: release --clean --nightly -f .goreleaser.${{ matrix.name }}.yml
         env:
-          GORELEASER_PREVIOUS_TAG: ${{ env.GORELEASER_PREVIOUS_TAG }}
+          GORELEASER_CURRENT_TAG: ${{ env.GORELEASER_CURRENT_TAG }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANALYTICS_KEY: ${{ secrets.ANALYTICS_KEY }}
@@ -134,7 +134,7 @@ jobs:
 
       - name: Git Tag
         run: |
-          echo "GORELEASER_PREVIOUS_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
+          echo "GORELEASER_CURRENT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
 
       - name: GoReleaser (Nightly) Release
         uses: goreleaser/goreleaser-action@v5
@@ -143,7 +143,7 @@ jobs:
           version: latest
           args: release --nightly -f .goreleaser.nightly.yml
         env:
-          GORELEASER_PREVIOUS_TAG: ${{ env.GORELEASER_PREVIOUS_TAG }}
+          GORELEASER_CURRENT_TAG: ${{ env.GORELEASER_CURRENT_TAG }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Prep Build
         run: mage prep
 
+      - name: Git Tag
+        run: |
+          echo "GORELEASER_PREVIOUS_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
+
       - name: GoReleaser (Nightly) Build
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -71,6 +75,7 @@ jobs:
           version: latest
           args: release --clean --nightly -f .goreleaser.${{ matrix.name }}.yml
         env:
+          GORELEASER_PREVIOUS_TAG: ${{ env.GORELEASER_PREVIOUS_TAG }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANALYTICS_KEY: ${{ secrets.ANALYTICS_KEY }}
@@ -127,6 +132,10 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
+      - name: Git Tag
+        run: |
+          echo "GORELEASER_PREVIOUS_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
+
       - name: GoReleaser (Nightly) Release
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -134,6 +143,7 @@ jobs:
           version: latest
           args: release --nightly -f .goreleaser.nightly.yml
         env:
+          GORELEASER_PREVIOUS_TAG: ${{ env.GORELEASER_PREVIOUS_TAG }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Re: https://discord.com/channels/960634591000014878/1191792891203424338/1196576871643619359

It seems goreleaser uses `git describe` to get the 'previous tag'. for some reason, this seems to be incorrect in our `main` branch / for snapshot builds. maybe because of how we do tagging off of `release/*` branches?

Anyways, setting `GORELEASER_CURRENT_TAG` env var overrides this, and we can get the correct latest tag using `git rev-list` magic