### PR TITLE
feat(validate): add ability to further constrain schema

### DIFF
--- a/internal/storage/fs/object/store.go
+++ b/internal/storage/fs/object/store.go
@@ -162,7 +162,7 @@ func (s *SnapshotStore) build(ctx context.Context) (*storagefs.Snapshot, error) 
 		))
 	}
 
-	return storagefs.SnapshotFromFiles(s.logger, files...)
+	return storagefs.SnapshotFromFiles(s.logger, files)
 }
 
 func (s *SnapshotStore) getIndex(ctx context.Context) (*storagefs.FliptIndex, error) {

--- a/internal/storage/fs/oci/store.go
+++ b/internal/storage/fs/oci/store.go
@@ -89,7 +89,7 @@ func (s *SnapshotStore) update(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	snap, err := storagefs.SnapshotFromFiles(s.logger, resp.Files...)
+	snap, err := storagefs.SnapshotFromFiles(s.logger, resp.Files)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This is in response to a discussion had with our friends at Paradigm.

The request was:
```
Hi team, given we have flipt validate is there perhaps a way to force some fields to be mandatory?
In our case description is required or we won't have people  outside of developers knowing what that flag actually does.
```

We leverage CUE under the hood to power `flipt validate` and this is driven by our flipt feature CUE schema:
https://github.com/flipt-io/flipt/blob/de980017bc20f1f298c9030bfd1dea98d31fea28/internal/cue/flipt.cue#L1-L20

This proposed change adds the ability to extend this schema with your own valid subset of this schema.
```console
flipt validate -e extended.cue features.json
```

Taking the original request to be able to make e.g. description required, this could be achieved with the following extensions to the base schema (in extended.cue):
```cue
#Flag: {
	description: =~"^.+$"
}
```

This adds to the existing `#Flag` definition and says that description is required (drops the `?`) and that is must be a non-empty string (matches the regexp `=~"^.+$"`).
Taking the following JSON example in a file named `features.json`:
```json
{
  "flags": [{"key": "foo", "name": "Foo"}]
}
```

Without the extended CUE definition, `flipt validate` will pass:
```console
➜  flipt validate features.json
➜  echo $?
0
```

However, by passing in the extended CUE definition via `-e` (short for `--extra-schema`) we can add the restrictions:
```console
➜  flipt validate -e extended.cue features.json
Validation failed!

- Message  : flags.0.description: incomplete value =~"^.+$"
  File     : features.json
  Line     : 2
```