### PR TITLE
chore: add deploy to koyeb button; simplify integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ Try the latest version of Flipt for yourself.
     <a href="https://railway.app/template/dz-JCO" alt="Deploy to Railway">
       <img width="150" alt="Deploy to Railway" src="https://railway.app/button.svg" />
     </a>
+    <a href="https://app.koyeb.com/deploy?type=docker&image=docker.flipt.io/flipt/flipt&ports=8080;http;/&name=flipt-demo" alt="Deploy to Koyeb">
+      <img width="150" alt="Deploy to Koyeb" src="https://www.koyeb.com/static/images/deploy/button.svg" />
+    </a>
 </div>
 
 ### Sandbox
@@ -249,8 +252,6 @@ Flipt exposes two different APIs for performing server-side evaluation:
 
 Flipt is equipped with a fully functional GRPC API. GRPC is a high-performance, low-latency, binary protocol that is used by many large-scale companies such as Google, Netflix, and more.
 
-#### GRPC SDKs
-
 See our [GRPC Server SDK documentation](https://www.flipt.io/docs/integration/server/grpc) for the latest information.
 
 #### REST
@@ -259,20 +260,11 @@ Flipt is equipped with a fully functional REST API. The Flipt UI is completely b
 
 The [Flipt REST API](https://www.flipt.io/docs/reference/overview) can also be used with any language that can make HTTP requests.
 
-#### REST SDKs
-
-> [!NOTE]
-> We will be revamping our current REST SDKs in the coming weeks to simplify the API and make them easier to use. If you have any feedback on the current REST SDKs, please open an issue in the respective repository.
-
 See our [REST Server SDK documentation](https://www.flipt.io/docs/integration/server/rest) for the latest information.
 
 ### Client Side Evaluation
 
 Client-side evaluation is a great way to reduce the number of requests that your application needs to make to Flipt. This is done by retrieving all of the feature flags that your application needs to evaluate and then evaluating them locally.
-
-For more information on client-side evaluation, check out our [client-side evaluation documentation](https://www.flipt.io/docs/integration/client).
-
-#### Client Side SDKs
 
 See our [Client SDK documentation](https://www.flipt.io/docs/integration/client) for the latest information.
 


### PR DESCRIPTION
Been trying out Koyeb, its pretty nice. Adding a deploy to Koyeb button <https://www.koyeb.com/docs/build-and-deploy/deploy-to-koyeb-button> and simplifying the integration section of README