### PR TITLE
chore: rm zap logger from cli commands

### DIFF
--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.flipt.io/flipt/internal/ext"
 	"go.flipt.io/flipt/rpc/flipt"
-	"go.uber.org/zap"
 )
 
 type exportCommand struct {
@@ -42,14 +41,14 @@ func newExportCommand() *cobra.Command {
 		&export.address,
 		"address", "a",
 		"",
-		"address of remote Flipt instance to export from (defaults to direct DB export if not supplied)",
+		"address of Flipt instance (defaults to direct DB export if not supplied).",
 	)
 
 	cmd.Flags().StringVarP(
 		&export.token,
 		"token", "t",
 		"",
-		"client token used to authenticate access to remote Flipt instance when exporting.",
+		"client token used to authenticate access to Flipt instance.",
 	)
 
 	cmd.Flags().StringVarP(
@@ -86,15 +85,12 @@ func newExportCommand() *cobra.Command {
 func (c *exportCommand) run(cmd *cobra.Command, _ []string) error {
 	var (
 		// default to stdout
-		out    io.Writer = os.Stdout
-		logger           = zap.Must(zap.NewDevelopment())
-		enc              = ext.EncodingYML
+		out io.Writer = os.Stdout
+		enc           = ext.EncodingYML
 	)
 
 	// export to file
 	if c.filename != "" {
-		logger.Debug("exporting", zap.String("destination_path", c.filename))
-
 		fi, err := os.Create(c.filename)
 		if err != nil {
 			return fmt.Errorf("creating output file: %w", err)

--- a/cmd/flipt/import.go
+++ b/cmd/flipt/import.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"go.flipt.io/flipt/internal/ext"
 	"go.flipt.io/flipt/internal/storage/sql"
-	"go.uber.org/zap"
 )
 
 type importCommand struct {
@@ -47,14 +46,14 @@ func newImportCommand() *cobra.Command {
 		&importCmd.address,
 		"address", "a",
 		"",
-		"address of remote Flipt instance to import into (defaults to direct DB import if not supplied)",
+		"address of Flipt instance (defaults to direct DB import if not supplied).",
 	)
 
 	cmd.Flags().StringVarP(
 		&importCmd.token,
 		"token", "t",
 		"",
-		"client token used to authenticate access to remote Flipt instance when importing.",
+		"client token used to authenticate access to Flipt instance.",
 	)
 
 	cmd.Flags().StringVar(&providedConfigFile, "config", "", "path to config file")
@@ -63,9 +62,8 @@ func newImportCommand() *cobra.Command {
 
 func (c *importCommand) run(cmd *cobra.Command, args []string) error {
 	var (
-		in     io.Reader = os.Stdin
-		logger           = zap.Must(zap.NewDevelopment())
-		enc              = ext.EncodingYML
+		in  io.Reader = os.Stdin
+		enc           = ext.EncodingYML
 	)
 
 	if !c.importStdin {
@@ -79,8 +77,6 @@ func (c *importCommand) run(cmd *cobra.Command, args []string) error {
 		}
 
 		f := filepath.Clean(importFilename)
-
-		logger.Debug("importing", zap.String("source_path", f))
 
 		fi, err := os.Open(f)
 		if err != nil {
@@ -117,7 +113,6 @@ func (c *importCommand) run(cmd *cobra.Command, args []string) error {
 
 	// drop tables if specified
 	if c.dropBeforeImport {
-		logger.Debug("dropping tables")
 
 		migrator, err := sql.NewMigrator(*cfg, logger)
 		if err != nil {


### PR DESCRIPTION
- make cli command option descriptions consistent
- rm zap logger from non `server` commands

## TODO

- [ ] Document CLI 'styleguide' for new commands