### PR TITLE
fix(cue): get error position using error path

### DIFF
--- a/internal/cue/validate.go
+++ b/internal/cue/validate.go
@@ -139,7 +139,7 @@ OUTER:
 
 		// next we walk the selector back from the deapest path until
 		// we select something that exists in the document
-		for i := len(selectors) - 1; i > -1; i-- {
+		for i := len(selectors); i > 0; i-- {
 			selectors = selectors[:i]
 			val := yv.LookupPath(cue.MakePath(selectors...))
 

--- a/internal/cue/validate_test.go
+++ b/internal/cue/validate_test.go
@@ -127,5 +127,7 @@ func TestValidate_Extended(t *testing.T) {
 
 	assert.Equal(t, `flags.1.description: incomplete value =~"^.+$"`, ferr.Message)
 	assert.Equal(t, "testdata/valid.yaml", ferr.Location.File)
-	assert.Equal(t, 2, ferr.Location.Line) // TODO: why 2?
+	// location of the start of the boolean flag
+	// which lacks a description
+	assert.Equal(t, 30, ferr.Location.Line)
 }

--- a/internal/storage/fs/snapshot_test.go
+++ b/internal/storage/fs/snapshot_test.go
@@ -46,9 +46,9 @@ func TestSnapshotFromFS_Invalid(t *testing.T) {
 		{
 			path: "testdata/invalid/namespace",
 			err: errors.Join(
-				cue.Error{Message: "namespace: 2 errors in empty disjunction:", Location: cue.Location{File: "features.json", Line: 0}},
-				cue.Error{Message: "namespace: conflicting values 1 and \"default\" (mismatched types int and string)", Location: cue.Location{File: "features.json", Line: 3}},
-				cue.Error{Message: "namespace: conflicting values 1 and string (mismatched types int and string)", Location: cue.Location{File: "features.json", Line: 3}},
+				cue.Error{Message: "namespace: 2 errors in empty disjunction:", Location: cue.Location{File: "features.json", Line: 1}},
+				cue.Error{Message: "namespace: conflicting values 1 and \"default\" (mismatched types int and string)", Location: cue.Location{File: "features.json", Line: 1}},
+				cue.Error{Message: "namespace: conflicting values 1 and string (mismatched types int and string)", Location: cue.Location{File: "features.json", Line: 1}},
 			),
 		},
 	} {


### PR DESCRIPTION
This is a PR on https://github.com/flipt-io/flipt/pull/2697

This attempts to walk through the path selector in the error, using it as an index into the source document.
It is an attempt to use the path to find the first found position and use that in the error context.