### PR TITLE
chore/fix(cmd): dont omit 'enabled' in evaluate cli if false

### DIFF
--- a/cmd/flipt/doc.go
+++ b/cmd/flipt/doc.go
@@ -23,7 +23,7 @@ func newDocCommand() *cobra.Command {
 				return fmt.Errorf("failed to create docs directory: %w", err)
 			}
 
-			if err := doc.GenMarkdownTree(cmd.Root(), "./tmp/docs"); err != nil {
+			if err := doc.GenMarkdownTree(cmd.Root(), path); err != nil {
 				return fmt.Errorf("failed to generate docs: %w", err)
 			}
 

--- a/cmd/flipt/doc.go
+++ b/cmd/flipt/doc.go
@@ -23,7 +23,13 @@ func newDocCommand() *cobra.Command {
 				return fmt.Errorf("failed to create docs directory: %w", err)
 			}
 
-			return doc.GenMarkdownTree(cmd.Root(), "./tmp/docs")
+			if err := doc.GenMarkdownTree(cmd.Root(), "./tmp/docs"); err != nil {
+				return fmt.Errorf("failed to generate docs: %w", err)
+			}
+
+			fmt.Printf("Documentation generated in: %s\n", path)
+
+			return nil
 		},
 	}
 }

--- a/cmd/flipt/evaluate.go
+++ b/cmd/flipt/evaluate.go
@@ -145,7 +145,7 @@ func (c *evaluateCommand) run(cmd *cobra.Command, args []string) error {
 
 type booleanEvaluateResponse struct {
 	FlagKey               string    `json:"flag_key,omitempty"`
-	Enabled               bool      `json:"enabled,omitempty"`
+	Enabled               bool      `json:"enabled"`
 	Reason                string    `json:"reason,omitempty"`
 	RequestID             string    `json:"request_id,omitempty"`
 	RequestDurationMillis float64   `json:"request_duration_millis,omitempty"`
@@ -154,7 +154,7 @@ type booleanEvaluateResponse struct {
 
 type variantEvaluationResponse struct {
 	FlagKey               string    `json:"flag_key,omitempty"`
-	Match                 bool      `json:"match,omitempty"`
+	Match                 bool      `json:"match"`
 	Reason                string    `json:"reason,omitempty"`
 	VariantKey            string    `json:"variant_key,omitempty"`
 	VariantAttachment     string    `json:"variant_attachment,omitempty"`


### PR DESCRIPTION
- Don't omit `false` values of `enabled` from `evaluate` response
- Print output dir where CLI docs are generated after running command