### PR TITLE
deprecate(config): mark authentication.exclude.metadata as deprecated

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -232,7 +232,6 @@ func NewGRPCServer(
 	)
 
 	skipAuthIfExcluded(fliptsrv, cfg.Authentication.Exclude.Management)
-	skipAuthIfExcluded(metasrv, cfg.Authentication.Exclude.Metadata)
 	skipAuthIfExcluded(evalsrv, cfg.Authentication.Exclude.Evaluation)
 
 	var checker *audit.Checker

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -181,6 +181,14 @@ func (c *AuthenticationConfig) validate() error {
 	return nil
 }
 
+func (c *AuthenticationConfig) deprecations(v *viper.Viper) []deprecated {
+	if v.Get("authentication.exclude.metadata") != nil {
+		return []deprecated{deprecateAuthenticationExcludeMetdata}
+	}
+
+	return nil
+}
+
 func getHostname(rawurl string) (string, error) {
 	if !strings.Contains(rawurl, "://") {
 		rawurl = "http://" + rawurl

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -251,6 +251,19 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			name: "deprecated autentication excluding metadata",
+			path: "./testdata/deprecated/authentication_excluding_metadata.yml",
+			expected: func() *Config {
+				cfg := Default()
+				cfg.Authentication.Required = true
+				cfg.Authentication.Exclude.Metadata = true
+				return cfg
+			},
+			warnings: []string{
+				"\"authentication.exclude.metadata\" is deprecated and will be removed in a future release. This feature never worked as intended. Metadata can no longer be excluded from authentication (when required).",
+			},
+		},
+		{
 			name: "cache no backend set",
 			path: "./testdata/cache/default.yml",
 			expected: func() *Config {

--- a/internal/config/deprecations.go
+++ b/internal/config/deprecations.go
@@ -8,8 +8,11 @@ import (
 type deprecated string
 
 var (
+	deprecateAuthenticationExcludeMetdata deprecated = "authentication.exclude.metadata"
 	// fields that are deprecated along with their messages
-	deprecatedFields = map[deprecated]string{}
+	deprecatedFields = map[deprecated]string{
+		deprecateAuthenticationExcludeMetdata: "This feature never worked as intended. Metadata can no longer be excluded from authentication (when required).",
+	}
 )
 
 const (

--- a/internal/config/testdata/deprecated/authentication_excluding_metadata.yml
+++ b/internal/config/testdata/deprecated/authentication_excluding_metadata.yml
@@ -1,0 +1,4 @@
+authentication:
+  required: true
+  exclude:
+    metadata: true


### PR DESCRIPTION
Supports https://github.com/flipt-io/flipt/issues/2643

This capability never worked. So this PR marks it deprecated and stops is from actually disabling authentication for metadata when auth is required.