### PR TITLE
fix(ui): clean redux cache when namespace or flag is deleted

### DIFF
--- a/ui/src/app/flags/rolloutsApi.ts
+++ b/ui/src/app/flags/rolloutsApi.ts
@@ -1,7 +1,15 @@
+import { FullTagDescription } from '@reduxjs/toolkit/dist/query/endpointDefinitions';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { IRollout, IRolloutBase, IRolloutList } from '~/types/Rollout';
 
 import { baseQuery } from '~/utils/redux-rtk';
+
+export const rolloutTag = (arg: {
+  namespaceKey: string;
+  flagKey: string;
+}): FullTagDescription<'Rollout'> => {
+  return { type: 'Rollout', id: arg.namespaceKey + '/' + arg.flagKey };
+};
 
 export const rolloutsApi = createApi({
   reducerPath: 'rollouts',
@@ -15,9 +23,7 @@ export const rolloutsApi = createApi({
     >({
       query: ({ namespaceKey, flagKey }) =>
         `/namespaces/${namespaceKey}/flags/${flagKey}/rollouts`,
-      providesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rollout', id: namespaceKey + '/' + flagKey }
-      ]
+      providesTags: (_result, _error, arg) => [rolloutTag(arg)]
     }),
     // delete the rollout
     deleteRollout: builder.mutation<
@@ -30,9 +36,7 @@ export const rolloutsApi = createApi({
           method: 'DELETE'
         };
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rollout', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [rolloutTag(arg)]
     }),
     // create the rollout
     createRollout: builder.mutation<
@@ -50,9 +54,7 @@ export const rolloutsApi = createApi({
           body: values
         };
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rollout', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [rolloutTag(arg)]
     }),
     // update the rollout
     updateRollout: builder.mutation<
@@ -71,9 +73,7 @@ export const rolloutsApi = createApi({
           body: values
         };
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rollout', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [rolloutTag(arg)]
     }),
     // reorder the rollouts
     orderRollouts: builder.mutation<
@@ -125,9 +125,7 @@ export const rolloutsApi = createApi({
           patchResult.undo();
         }
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rollout', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [rolloutTag(arg)]
     })
   })
 });

--- a/ui/src/app/flags/rulesApi.ts
+++ b/ui/src/app/flags/rulesApi.ts
@@ -1,8 +1,16 @@
+import { FullTagDescription } from '@reduxjs/toolkit/dist/query/endpointDefinitions';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { IDistributionBase } from '~/types/Distribution';
 import { IRule, IRuleBase, IRuleList } from '~/types/Rule';
 
 import { baseQuery } from '~/utils/redux-rtk';
+
+export const ruleTag = (arg: {
+  namespaceKey: string;
+  flagKey: string;
+}): FullTagDescription<'Rule'> => {
+  return { type: 'Rule', id: arg.namespaceKey + '/' + arg.flagKey };
+};
 
 export const rulesApi = createApi({
   reducerPath: 'rules',
@@ -16,9 +24,7 @@ export const rulesApi = createApi({
     >({
       query: ({ namespaceKey, flagKey }) =>
         `/namespaces/${namespaceKey}/flags/${flagKey}/rules`,
-      providesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rule', id: namespaceKey + '/' + flagKey }
-      ]
+      providesTags: (_result, _error, arg) => [ruleTag(arg)]
     }),
     // create a new rule
     createRule: builder.mutation<
@@ -59,9 +65,7 @@ export const rulesApi = createApi({
         }
         return { data: rule };
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rule', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [ruleTag(arg)]
     }),
     // delete the rule
     deleteRule: builder.mutation<
@@ -74,9 +78,7 @@ export const rulesApi = createApi({
           method: 'DELETE'
         };
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rule', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [ruleTag(arg)]
     }),
     // update the rule
     updateRule: builder.mutation<
@@ -95,9 +97,7 @@ export const rulesApi = createApi({
           body: values
         };
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rule', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [ruleTag(arg)]
     }),
     // reorder the rules
     orderRules: builder.mutation<
@@ -149,9 +149,7 @@ export const rulesApi = createApi({
           patchResult.undo();
         }
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rule', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [ruleTag(arg)]
     }),
     // update the dustribution
     updateDistribution: builder.mutation<
@@ -171,9 +169,7 @@ export const rulesApi = createApi({
           body: values
         };
       },
-      invalidatesTags: (_result, _error, { namespaceKey, flagKey }) => [
-        { type: 'Rule', id: namespaceKey + '/' + flagKey }
-      ]
+      invalidatesTags: (_result, _error, arg) => [ruleTag(arg)]
     })
   })
 });

--- a/ui/src/app/segments/segmentsApi.ts
+++ b/ui/src/app/segments/segmentsApi.ts
@@ -1,7 +1,14 @@
+import { FullTagDescription } from '@reduxjs/toolkit/dist/query/endpointDefinitions';
 import { createApi } from '@reduxjs/toolkit/query/react';
 import { IConstraintBase } from '~/types/Constraint';
 import { ISegment, ISegmentBase, ISegmentList } from '~/types/Segment';
 import { baseQuery } from '~/utils/redux-rtk';
+
+export const segmentTag = (
+  namespaceKey: string
+): FullTagDescription<'Segment'> => {
+  return { type: 'Segment', id: namespaceKey };
+};
 
 export const segmentsApi = createApi({
   reducerPath: 'segments',
@@ -18,9 +25,9 @@ export const segmentsApi = createApi({
                 type: 'Segment' as const,
                 id: namespaceKey + '/' + key
               })),
-              { type: 'Segment', id: namespaceKey }
+              segmentTag(namespaceKey)
             ]
-          : [{ type: 'Segment', id: namespaceKey }]
+          : [segmentTag(namespaceKey)]
     }),
     // get segment in this namespace
     getSegment: builder.query<
@@ -46,7 +53,7 @@ export const segmentsApi = createApi({
         };
       },
       invalidatesTags: (_result, _error, { namespaceKey, values }) => [
-        { type: 'Segment', id: namespaceKey },
+        segmentTag(namespaceKey),
         { type: 'Segment', id: namespaceKey + '/' + values.key }
       ]
     }),
@@ -62,7 +69,7 @@ export const segmentsApi = createApi({
         };
       },
       invalidatesTags: (_result, _error, { namespaceKey }) => [
-        { type: 'Segment', id: namespaceKey }
+        segmentTag(namespaceKey)
       ]
     }),
     // update the segment in the namespace
@@ -78,7 +85,7 @@ export const segmentsApi = createApi({
         };
       },
       invalidatesTags: (_result, _error, { namespaceKey, segmentKey }) => [
-        { type: 'Segment', id: namespaceKey },
+        segmentTag(namespaceKey),
         { type: 'Segment', id: namespaceKey + '/' + segmentKey }
       ]
     }),
@@ -128,7 +135,7 @@ export const segmentsApi = createApi({
         return { data: undefined };
       },
       invalidatesTags: (_result, _error, { to }) => [
-        { type: 'Segment', id: to.namespaceKey }
+        segmentTag(to.namespaceKey)
       ]
     }),
 

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -10,14 +10,14 @@ import {
   namespacesSlice
 } from '~/app/namespaces/namespacesSlice';
 import { flagsApi } from './app/flags/flagsApi';
-import { rolloutsApi } from './app/flags/rolloutsApi';
-import { rulesApi } from './app/flags/rulesApi';
+import { rolloutTag, rolloutsApi } from './app/flags/rolloutsApi';
+import { ruleTag, rulesApi } from './app/flags/rulesApi';
 import { metaSlice } from './app/meta/metaSlice';
 import {
   preferencesKey,
   preferencesSlice
 } from './app/preferences/preferencesSlice';
-import { segmentsApi } from './app/segments/segmentsApi';
+import { segmentTag, segmentsApi } from './app/segments/segmentsApi';
 import { tokensApi } from './app/tokens/tokensApi';
 import { LoadingStatus } from './types/Meta';
 
@@ -60,6 +60,28 @@ listenerMiddleware.startListening({
   matcher: namespaceApi.endpoints.listNamespaces.matchFulfilled,
   effect: (action, api) => {
     api.dispatch(namespacesSlice.actions.namespacesChanged(action.payload));
+  }
+});
+
+// clean segments cache for deleted namespace
+listenerMiddleware.startListening({
+  matcher: namespaceApi.endpoints.deleteNamespace.matchFulfilled,
+  effect: (action, api) => {
+    api.dispatch(
+      segmentsApi.util.invalidateTags([
+        segmentTag(action.meta.arg.originalArgs)
+      ])
+    );
+  }
+});
+
+// clean rollouts and rules cache for deleted flag
+listenerMiddleware.startListening({
+  matcher: flagsApi.endpoints.deleteFlag.matchFulfilled,
+  effect: (action, api) => {
+    const arg = action.meta.arg.originalArgs;
+    api.dispatch(rolloutsApi.util.invalidateTags([rolloutTag(arg)]));
+    api.dispatch(rulesApi.util.invalidateTags([ruleTag(arg)]));
   }
 });
 


### PR DESCRIPTION
With Redux RTK the UI could show a stale cache in the browser when user deletes a flag or a namespace and immediately recreated it with the same key. For namespace old segments will be displayed and for flags - rollouts or rules depending on flag type.