### PR TITLE
fix: running Flipt under reverse proxy with subpath

### DIFF
--- a/examples/proxy/nginx.conf
+++ b/examples/proxy/nginx.conf
@@ -1,8 +1,5 @@
 server {
     listen 80;
-    gzip on;
-    gzip_static on;
-    gzip_types text/plain text/css application/json text/javascript;
     location / {
         add_header Content-Type text/html;
         return 200 '<html><body style="text-align:center"><a href="/flipt/">Go to Flipt</a></body></html>';
@@ -13,21 +10,9 @@ server {
         proxy_set_header   Host             $host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-        proxy_set_header   Accept-Encoding "";
         proxy_buffering on;
-        gzip on;
 
         # rewrite
         rewrite ^/flipt/(.*) /$1 break;
-
-        # modify response
-        sub_filter_once off;
-        sub_filter_types text/javascript text/html;
-        sub_filter "/favicon.svg" "/flipt/favicon.svg";
-        sub_filter "assets/" "flipt/assets/";
-        sub_filter "/api/v1" "/flipt/api/v1";
-        sub_filter "/auth/v1" "/flipt/auth/v1";
-        sub_filter "/evaluate/v1" "/flipt/evaluate/v1";
-        sub_filter "/meta" "/flipt/meta";
     }
 }

--- a/ui/src/app/auth/authApi.ts
+++ b/ui/src/app/auth/authApi.ts
@@ -1,10 +1,11 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { authURL } from '~/data/api';
 import { IAuthMethodList } from '~/types/Auth';
 
 export const authProvidersApi = createApi({
   reducerPath: 'providers',
   baseQuery: fetchBaseQuery({
-    baseUrl: '/auth/v1'
+    baseUrl: authURL
   }),
   tagTypes: ['Provider'],
   endpoints: (builder) => ({

--- a/ui/src/app/tokens/tokensApi.ts
+++ b/ui/src/app/tokens/tokensApi.ts
@@ -1,4 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { authURL } from '~/data/api';
 import {
   IAuthTokenBase,
   IAuthTokenInternalList,
@@ -10,7 +11,7 @@ import { customFetchFn } from '~/utils/redux-rtk';
 export const tokensApi = createApi({
   reducerPath: 'tokens',
   baseQuery: fetchBaseQuery({
-    baseUrl: '/auth/v1',
+    baseUrl: authURL,
     fetchFn: customFetchFn
   }),
   tagTypes: ['Token'],

--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { FlagType } from '~/types/Flag';
 
-export const apiURL = '/api/v1';
-export const authURL = '/auth/v1';
-export const evaluateURL = '/evaluate/v1';
-export const metaURL = '/meta';
+export const apiURL = 'api/v1';
+export const authURL = 'auth/v1';
+export const evaluateURL = 'evaluate/v1';
+export const metaURL = 'meta';
 
 const csrfTokenHeaderKey = 'x-csrf-token';
 const sessionKey = 'session';

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -6,6 +6,7 @@ const fliptAddr = process.env.FLIPT_ADDRESS ?? 'http://localhost:8080';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
fixes #2723

Per [vite configuration](https://vitejs.dev/config/shared-options.html#base )`base` could be empty for embedded deployment.