### PR TITLE
fix(gh): hack to clear up a little extra disk space

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -62,6 +62,16 @@ jobs:
             "import/export",
           ]
     steps:
+      - run: |
+          du -d 1 /
+
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
+          du -d 1 /
+
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5


### PR DESCRIPTION
This is a bandaid, but thought I would give it a try to buy us some time:
https://github.com/actions/runner-images/issues/2840

Let's see if this gets the ITs to start passing. I wonder if this has something to do with the ever growing number of cases added. Maybe cockroach puts a lot of logs out, and I know we're copying those to disk.