### PR TITLE
chore(build/testing): disable cockroachdb logging

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,6 +10,10 @@ env:
   GO_VERSION: "1.21"
   DAGGER_VERSION: "0.9.5"
 
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   cli:
     name: CLI Integration Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,10 @@ env:
   GO_VERSION: "1.21"
   DAGGER_VERSION: "0.9.5"
 
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   test:
     name: "Tests (Go)"

--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -322,7 +322,7 @@ func withCockroach(fn testCaseFn) testCaseFn {
 				WithEnvVariable("COCKROACH_DATABASE", "defaultdb").
 				WithEnvVariable("UNIQUE", uuid.New().String()).
 				WithExposedPort(26257).
-				WithExec([]string{"start-single-node", "--insecure", "--log-dir="}).
+				WithExec([]string{"start-single-node", "--single-node", "--insecure", "--store=type=mem,size=0.7Gb", "--accept-sql-without-tls", "--logtostderr=ERROR"}).
 				AsService()),
 			conf,
 		)

--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -322,7 +322,7 @@ func withCockroach(fn testCaseFn) testCaseFn {
 				WithEnvVariable("COCKROACH_DATABASE", "defaultdb").
 				WithEnvVariable("UNIQUE", uuid.New().String()).
 				WithExposedPort(26257).
-				WithExec([]string{"start-single-node", "--insecure"}).
+				WithExec([]string{"start-single-node", "--insecure", "--log-dir="}).
 				AsService()),
 			conf,
 		)

--- a/examples/database/cockroachdb/docker-compose.yml
+++ b/examples/database/cockroachdb/docker-compose.yml
@@ -7,14 +7,20 @@ services:
       - flipt_network
     ports:
      - "26257:26257"
-    command: start-single-node --insecure
+    command: start-single-node --insecure --accept-sql-without-tls --single-node
     volumes:
      - "${PWD}/data:/cockroach/cockroach-data"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]
+      interval: 3s
+      timeout: 3s
+      retries: 5
 
   flipt:
     build: .
     depends_on:
-      - crdb
+      crdb:
+        condition: service_healthy
     ports:
       - "8080:8080"
     networks:
@@ -23,7 +29,7 @@ services:
       - FLIPT_DB_URL=cockroach://root@crdb:26257/defaultdb?sslmode=disable
       - FLIPT_LOG_LEVEL=debug
       - FLIPT_META_TELEMETRY_ENABLED=false
-    command: ["./tmp/wait-for-it.sh", "crdb:26257", "--", "./flipt", "--force-migrate"]
+    command: ["/flipt", "--force-migrate"]
 
 networks:
   flipt_network:

--- a/go.work.sum
+++ b/go.work.sum
@@ -1403,6 +1403,7 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.m
 github.com/opencontainers/runtime-spec v1.0.3-0.20220825212826-86290f6a00fb/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-spec v1.1.0-rc.1 h1:wHa9jroFfKGQqFHj0I1fMRKLl0pfj+ynAqBxo3v6u9w=
 github.com/opencontainers/runtime-spec v1.1.0-rc.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.1.0-rc.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626 h1:DmNGcqH3WDbV5k8OJ+esPWbqUOX5rMLR2PMvziDMJi0=
 github.com/opencontainers/runtime-tools v0.9.1-0.20221107090550-2e043c6bd626/go.mod h1:BRHJJd0E+cx42OybVYSgUvZmU0B8P9gZuRXlZUP7TKI=


### PR DESCRIPTION
Comparing and contrasting this approach to https://github.com/flipt-io/flipt/pull/2747

This just disables logging for cockroach (at-least I am hoping it does based on the docs).
https://www.cockroachlabs.com/docs/v23.2/configure-logs

The other approach works, but adds over 2 minutes to each build clearing out 10GB of space before starting.