### PR TITLE
chore: improve git tag for nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Git Tag
         run: |
-          echo "GORELEASER_CURRENT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
+          echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match='v[0-9]*' `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
 
       - name: GoReleaser (Nightly) Build
         uses: goreleaser/goreleaser-action@v5
@@ -134,7 +134,7 @@ jobs:
 
       - name: Git Tag
         run: |
-          echo "GORELEASER_CURRENT_TAG=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
+          echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match='v[0-9]*' `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
 
       - name: GoReleaser (Nightly) Release
         uses: goreleaser/goreleaser-action@v5


### PR DESCRIPTION
Currently
>  ⨯ release failed after 0s                  error=failed to parse tag 'sdk/go/v0.10.0' as semver: Invalid S

https://github.com/flipt-io/flipt/actions/runs/7777238935/job/21205299888#step:11:35