### PR TITLE
fix: csp headers for formbricks

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -99,10 +99,10 @@ func NewHTTPServer(
 		logger.Debug("CORS enabled", zap.Strings("allowed_origins", cfg.Cors.AllowedOrigins))
 	}
 
-	// TODO: replace with more robust 'mode' detection
-	if !info.IsDevelopment() {
-		r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
-		r.Use(middleware.SetHeader("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src * data:; frame-ancestors 'none';"))
+	// set additional headers enabling the UI to be served securely
+	// ie: Content-Security-Policy, X-Content-Type-Options, etc.
+	for k, v := range ui.AdditionalHeaders() {
+		r.Use(middleware.SetHeader(k, v))
 	}
 
 	r.Use(middleware.RequestID)

--- a/ui/dev.go
+++ b/ui/dev.go
@@ -21,3 +21,7 @@ func FS() (fs.FS, error) {
 		},
 	}, nil
 }
+
+func AdditionalHeaders() map[string]string {
+	return map[string]string{}
+}

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -20,3 +20,10 @@ func FS() (fs.FS, error) {
 
 	return u, nil
 }
+
+func AdditionalHeaders() map[string]string {
+	return map[string]string{
+		"X-Content-Type-Options":  "nosniff",
+		"Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src * data:; frame-ancestors 'none'; connect-src 'self' https://app.formbricks.com; script-src-elem 'self' https://unpkg.com;",
+	}
+}


### PR DESCRIPTION
Fixes CSP issue introduced in #2753 

![CleanShot 2024-02-09 at 20 20 55@2x](https://github.com/flipt-io/flipt/assets/209477/0fb12bfb-45dc-49d8-9ec4-868318584bb3)

Also allows us to catch CSP-related issues in UI testing (ITs) as now we will be setting CSP headers whenever the UI is embedded. 

We cant set these headers when Flipt and UI are running on different ports during development as CSP will block the UI