### PR TITLE
fix(ui): increase z index for Slideover and Modal

### DIFF
--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -12,7 +12,7 @@ export default function Modal(props: ModalProps) {
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={setOpen}>
+      <Dialog as="div" className="relative z-20" onClose={setOpen}>
         <Transition.Child
           as={Fragment}
           enter="ease-out duration-200"

--- a/ui/src/components/Slideover.tsx
+++ b/ui/src/components/Slideover.tsx
@@ -14,7 +14,7 @@ const SlideOver = forwardRef((props: SlideOverProps, ref: any) => {
     <Transition.Root show={open} as={Fragment}>
       <Dialog
         as="div"
-        className="relative z-10"
+        className="relative z-20"
         onClose={setOpen}
         initialFocus={ref}
       >


### PR DESCRIPTION
In #2725 there were changes to z-index of header and Slideover and Modal is behind the header. It's visible in creating new token/namespace or in any modal dialog