### PR TITLE
feat(otlp): account for service name in environment variable

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -157,14 +157,20 @@ func NewGRPCServer(
 
 	logger.Debug("store enabled", zap.Stringer("store", store))
 
+	traceResource, err := resource.New(ctx, resource.WithSchemaURL(semconv.SchemaURL), resource.WithAttributes(
+		semconv.ServiceNameKey.String("flipt"),
+		semconv.ServiceVersionKey.String(info.Version),
+	),
+		resource.WithFromEnv(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	// Initialize tracingProvider regardless of configuration. No extraordinary resources
 	// are consumed, or goroutines initialized until a SpanProcessor is registered.
 	var tracingProvider = tracesdk.NewTracerProvider(
-		tracesdk.WithResource(resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("flipt"),
-			semconv.ServiceVersionKey.String(info.Version),
-		)),
+		tracesdk.WithResource(traceResource),
 		tracesdk.WithSampler(tracesdk.AlwaysSample()),
 	)
 


### PR DESCRIPTION
We want to account for users to potentially change the service name of what is reported in their spans.

This change allows for the `OTEL_SERVICE_NAME` environment variable to be respected.

Fixes: #2773
Completes FLI-844