### PR TITLE
fix(ui): prevent multiple analytics requests at once with polling

### DIFF
--- a/ui/src/app/flags/analytics/Analytics.tsx
+++ b/ui/src/app/flags/analytics/Analytics.tsx
@@ -68,7 +68,7 @@ export default function Analytics() {
   const namespace = useSelector(selectCurrentNamespace);
 
   const d = new Date();
-
+  d.setSeconds(0);
   const nowISO = parseISO(d.toISOString());
 
   const getFlagEvaluationCount = useGetFlagEvaluationCountQuery(


### PR DESCRIPTION
Probably it happens because the input dates are changing too often during renders and forces redux rtk to do another fetch.
![output](https://github.com/flipt-io/flipt/assets/19472/d0e5caae-5483-4a1c-a595-bca3d3069c33)
