### PR TITLE
fix(ui): stop removing upper case letters in keys

### DIFF
--- a/ui/src/utils/helpers.ts
+++ b/ui/src/utils/helpers.ts
@@ -24,7 +24,7 @@ export function titleCase(str: string) {
 }
 
 export function stringAsKey(str: string) {
-  return str.toLowerCase().split(/\s+/).join('-');
+  return str.split(/\s+/).join('-');
 
   // // Auto generated keys  should not begin or end in a hyphen
   // if (temp.charAt(0) == "-") {


### PR DESCRIPTION
Fixes #2789 

Remove the call for `toLowerCase()` from the stringAsKey function as upper-case letters are acceptable in keys.