### PR TITLE
feat: add JWT aware UI and revise metadata for audit events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
         run: mage dagger:run "test:unit"
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.1.0
 
   test-darwin:
     name: "Tests (Go - Darwin)"

--- a/internal/server/audit/audit.go
+++ b/internal/server/audit/audit.go
@@ -151,11 +151,11 @@ func decodeToEvent(kvs []attribute.KeyValue) (*Event, error) {
 		case eventTimestampKey:
 			e.Timestamp = kv.Value.AsString()
 		case eventMetadataActorKey:
-			var actor *Actor
+			var actor Actor
 			if err := json.Unmarshal([]byte(kv.Value.AsString()), &actor); err != nil {
 				return nil, err
 			}
-			e.Metadata.Actor = actor
+			e.Metadata.Actor = &actor
 		case eventPayloadKey:
 			var payload interface{}
 			if err := json.Unmarshal([]byte(kv.Value.AsString()), &payload); err != nil {

--- a/internal/server/audit/audit.go
+++ b/internal/server/audit/audit.go
@@ -151,7 +151,7 @@ func decodeToEvent(kvs []attribute.KeyValue) (*Event, error) {
 		case eventTimestampKey:
 			e.Timestamp = kv.Value.AsString()
 		case eventMetadataActorKey:
-			var actor map[string]string
+			var actor *Actor
 			if err := json.Unmarshal([]byte(kv.Value.AsString()), &actor); err != nil {
 				return nil, err
 			}
@@ -172,9 +172,17 @@ func decodeToEvent(kvs []attribute.KeyValue) (*Event, error) {
 	return e, nil
 }
 
+type Actor struct {
+	Authentication string `json:"authentication,omitempty"`
+	IP             string `json:"ip,omitempty"`
+	Email          string `json:"email,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Picture        string `json:"picture,omitempty"`
+}
+
 // Metadata holds information of what metadata an event will contain.
 type Metadata struct {
-	Actor map[string]string `json:"actor,omitempty"`
+	Actor *Actor `json:"actor,omitempty"`
 }
 
 // Sink is the abstraction for various audit sink configurations
@@ -258,7 +266,7 @@ func (s *SinkSpanExporter) SendAudits(ctx context.Context, es []Event) error {
 }
 
 // NewEvent is the constructor for an audit event.
-func NewEvent(eventType Type, action Action, actor map[string]string, payload interface{}) *Event {
+func NewEvent(eventType Type, action Action, actor *Actor, payload interface{}) *Event {
 	return &Event{
 		Version: eventVersion,
 		Action:  action,

--- a/internal/server/audit/audit_test.go
+++ b/internal/server/audit/audit_test.go
@@ -70,9 +70,9 @@ func TestSinkSpanExporter(t *testing.T) {
 			e := NewEvent(
 				c.fType,
 				c.action,
-				map[string]string{
-					"authentication": "token",
-					"ip":             "127.0.0.1",
+				&Actor{
+					Authentication: "token",
+					IP:             "127.0.0.1",
 				}, &Flag{
 					Key:         "this-flag",
 					Name:        "this-flag",

--- a/internal/server/auth/middleware/grpc/middleware.go
+++ b/internal/server/auth/middleware/grpc/middleware.go
@@ -198,14 +198,18 @@ func JWTAuthenticationInterceptor(logger *zap.Logger, validator jwt.Validator, e
 		}
 
 		metadata := map[string]string{}
-		for _, fields := range [][2]string{
-			{"email", "email"},
-			{"sub", "sub"},
-			{"picture", "image"},
-			{"name", "name"},
-		} {
-			if v, ok := jwtClaims[fields[1]]; ok {
-				metadata[fmt.Sprintf("io.flipt.auth.jwt.%s", fields[0])] = fmt.Sprintf("%v", v)
+
+		userClaims, ok := jwtClaims["user"].(map[string]interface{})
+		if ok {
+			for _, fields := range [][2]string{
+				{"email", "email"},
+				{"sub", "sub"},
+				{"image", "picture"},
+				{"name", "name"},
+			} {
+				if v, ok := userClaims[fields[0]]; ok {
+					metadata[fmt.Sprintf("io.flipt.auth.jwt.%s", fields[1])] = fmt.Sprintf("%v", v)
+				}
 			}
 		}
 

--- a/internal/server/auth/server_test.go
+++ b/internal/server/auth/server_test.go
@@ -38,8 +38,8 @@ func TestActorFromContext(t *testing.T) {
 
 	actor := auth.ActorFromContext(ctx)
 
-	require.Equal(t, actor["ip"], ipAddress)
-	require.Equal(t, actor["authentication"], authentication)
+	assert.Equal(t, ipAddress, actor.IP)
+	assert.Equal(t, authentication, actor.Authentication)
 }
 
 func TestServer(t *testing.T) {

--- a/internal/server/middleware/grpc/middleware_test.go
+++ b/internal/server/middleware/grpc/middleware_test.go
@@ -2227,7 +2227,7 @@ func TestAuthMetadataAuditUnaryInterceptor(t *testing.T) {
 	ctx = authmiddlewaregrpc.ContextWithAuthentication(ctx, &authrpc.Authentication{
 		Method: authrpc.Method_METHOD_OIDC,
 		Metadata: map[string]string{
-			"email": "example@flipt.com",
+			"io.flipt.auth.oidc.email": "example@flipt.com",
 		},
 	})
 
@@ -2238,8 +2238,8 @@ func TestAuthMetadataAuditUnaryInterceptor(t *testing.T) {
 	span.End()
 
 	event := exporterSpy.GetEvents()[0]
-	assert.Equal(t, event.Metadata.Actor["email"], "example@flipt.com")
-	assert.Equal(t, event.Metadata.Actor["authentication"], "oidc")
+	assert.Equal(t, "example@flipt.com", event.Metadata.Actor.Email)
+	assert.Equal(t, "oidc", event.Metadata.Actor.Authentication)
 }
 
 func TestAuditUnaryInterceptor_CreateToken(t *testing.T) {

--- a/ui/src/components/SessionProvider.tsx
+++ b/ui/src/components/SessionProvider.tsx
@@ -2,12 +2,13 @@ import { createContext, useEffect, useMemo } from 'react';
 import { getAuthSelf, getInfo } from '~/data/api';
 import { useLocalStorage } from '~/data/hooks/storage';
 import { IAuthGithubInternal } from '~/types/auth/Github';
+import { IAuthJWTInternal } from '~/types/auth/JWT';
 import { IAuthOIDCInternal } from '~/types/auth/OIDC';
 
 type Session = {
   required: boolean;
   authenticated: boolean;
-  self?: IAuthOIDCInternal | IAuthGithubInternal;
+  self?: IAuthOIDCInternal | IAuthGithubInternal | IAuthJWTInternal;
 };
 
 interface SessionContextType {
@@ -43,7 +44,8 @@ export default function SessionProvider({
       }
 
       try {
-        const self: IAuthOIDCInternal | IAuthOIDCInternal = await getAuthSelf();
+        const self: IAuthOIDCInternal | IAuthOIDCInternal | IAuthJWTInternal =
+          await getAuthSelf();
         session = {
           authenticated: true,
           required: true,

--- a/ui/src/components/SessionProvider.tsx
+++ b/ui/src/components/SessionProvider.tsx
@@ -44,7 +44,7 @@ export default function SessionProvider({
       }
 
       try {
-        const self: IAuthOIDCInternal | IAuthOIDCInternal | IAuthJWTInternal =
+        const self: IAuthOIDCInternal | IAuthGithubInternal | IAuthJWTInternal =
           await getAuthSelf();
         session = {
           authenticated: true,

--- a/ui/src/components/header/UserProfile.tsx
+++ b/ui/src/components/header/UserProfile.tsx
@@ -5,11 +5,15 @@ import { expireAuthSelf } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSession } from '~/data/hooks/session';
 import { IAuthMethodGithubMetadata } from '~/types/auth/Github';
+import { IAuthMethodJWTMetadata } from '~/types/auth/JWT';
 import { IAuthMethodOIDCMetadata } from '~/types/auth/OIDC';
 import { cls } from '~/utils/helpers';
 
 type UserProfileProps = {
-  metadata?: IAuthMethodOIDCMetadata | IAuthMethodGithubMetadata;
+  metadata?:
+    | IAuthMethodOIDCMetadata
+    | IAuthMethodGithubMetadata
+    | IAuthMethodJWTMetadata;
 };
 
 export default function UserProfile(props: UserProfileProps) {
@@ -39,6 +43,11 @@ export default function UserProfile(props: UserProfileProps) {
       }
       if (metadata['io.flipt.auth.oidc.preferred_username']) {
         login = metadata['io.flipt.auth.oidc.preferred_username'];
+      }
+    } else if ('io.flipt.auth.jwt.name' in metadata) {
+      name = metadata['io.flipt.auth.jwt.name'] ?? 'User';
+      if (metadata['io.flipt.auth.jwt.picture']) {
+        imgURL = metadata['io.flipt.auth.jwt.picture'];
       }
     }
   }

--- a/ui/src/types/Auth.ts
+++ b/ui/src/types/Auth.ts
@@ -3,7 +3,8 @@ export interface IAuthMethod {
     | 'METHOD_TOKEN'
     | 'METHOD_OIDC'
     | 'METHOD_GITHUB'
-    | 'METHOD_KUBERNETES';
+    | 'METHOD_KUBERNETES'
+    | 'METHOD_JWT';
   enabled: boolean;
   sessionCompatible: boolean;
   metadata: { [key: string]: any };

--- a/ui/src/types/auth/JWT.ts
+++ b/ui/src/types/auth/JWT.ts
@@ -1,0 +1,19 @@
+import { IAuth, IAuthMethod } from '~/types/Auth';
+
+export interface IAuthMethodJWT extends IAuthMethod {
+  method: 'METHOD_JWT';
+  metadata: {
+    authorize_url: string;
+    callback_url: string;
+  };
+}
+
+export interface IAuthMethodJWTMetadata {
+  'io.flipt.auth.jwt.email'?: string;
+  'io.flipt.auth.jwt.name'?: string;
+  'io.flipt.auth.jwt.picture'?: string;
+}
+
+export interface IAuthJWTInternal extends IAuth {
+  metadata: IAuthMethodJWTMetadata;
+}


### PR DESCRIPTION
Add JWT auth changes for a user to be able to view their JWT auth information in the browser and also change event structure to create an actual structure for Actor information.

⚠️ **BREAKING CHANGE**

The `Actor` field in the event payload is changing. This will affect downstream consumers who are consuming webhooks from webhook templates. This is in favor of a more type safe way of expressing "Actor".