### PR TITLE
fix(ui): allow dot in the key of variant

### DIFF
--- a/ui/src/components/flags/VariantForm.tsx
+++ b/ui/src/components/flags/VariantForm.tsx
@@ -16,11 +16,11 @@ import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
-import { jsonValidation, keyValidation } from '~/data/validations';
+import { jsonValidation, keyWithDotValidation } from '~/data/validations';
 import { IVariant, IVariantBase } from '~/types/Variant';
 
 const variantValidationSchema = Yup.object({
-  key: keyValidation,
+  key: keyWithDotValidation,
   attachment: jsonValidation
 });
 

--- a/ui/src/data/validation.test.ts
+++ b/ui/src/data/validation.test.ts
@@ -19,7 +19,6 @@ describe('contextValidation', () => {
   });
 });
 
-
 describe('keyWithDotValidation', () => {
   it('should accept key with dot', () => {
     const result = keyWithDotValidation.isValidSync('2.0');

--- a/ui/src/data/validation.test.ts
+++ b/ui/src/data/validation.test.ts
@@ -1,4 +1,4 @@
-import { contextValidation } from './validations';
+import { contextValidation, keyWithDotValidation } from './validations';
 
 describe('contextValidation', () => {
   it('should accept valid input', () => {
@@ -15,6 +15,18 @@ describe('contextValidation', () => {
     let result = contextValidation.isValidSync('1');
     expect(result).toEqual(false);
     result = contextValidation.isValidSync('true');
+    expect(result).toEqual(false);
+  });
+});
+
+
+describe('keyWithDotValidation', () => {
+  it('should accept key with dot', () => {
+    const result = keyWithDotValidation.isValidSync('2.0');
+    expect(result).toEqual(true);
+  });
+  it('should not accept key with invalid values', () => {
+    const result = keyWithDotValidation.isValidSync('key]');
     expect(result).toEqual(false);
   });
 });

--- a/ui/src/data/validations.ts
+++ b/ui/src/data/validations.ts
@@ -10,7 +10,7 @@ export const keyValidation = Yup.string()
 export const keyWithDotValidation = Yup.string()
   .required('Required')
   .matches(
-    /^[-_,A-Za-z0-9\.]+$/,
+    /^[-_,A-Za-z0-9.]+$/,
     'Only letters, numbers, hypens, dots and underscores allowed'
   );
 

--- a/ui/src/data/validations.ts
+++ b/ui/src/data/validations.ts
@@ -7,6 +7,13 @@ export const keyValidation = Yup.string()
     'Only letters, numbers, hypens and underscores allowed'
   );
 
+export const keyWithDotValidation = Yup.string()
+  .required('Required')
+  .matches(
+    /^[-_,A-Za-z0-9\.]+$/,
+    'Only letters, numbers, hypens, dots and underscores allowed'
+  );
+
 export const requiredValidation = Yup.string().required('Required');
 
 export const jsonValidation = Yup.string()


### PR DESCRIPTION
closes #2882

Currently `flipt.cue` doesn't have any restrictions on symbols for `Variant.key` and UI is misaligned here. Is any other symbols should be allowed in UI?