### PR TITLE
fix: dont return error on parsing values at eval time

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1437,6 +1437,7 @@ github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vq
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2 h1:g+4J5sZg6osfvEfkRZxJ1em0VT95/UOZgi/l7zi1/oE=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517 h1:zpIH83+oKzcpryru8ceC6BxnoG8TBrhgAvRg8obzup0=

--- a/internal/server/evaluation/legacy_evaluator.go
+++ b/internal/server/evaluation/legacy_evaluator.go
@@ -369,19 +369,19 @@ func matchesNumber(c storage.EvaluationConstraint, v string) (bool, error) {
 
 	n, err := strconv.ParseFloat(v, 64)
 	if err != nil {
-		return false, errs.ErrInvalidf("parsing number from %q", v)
+		return false, nil
 	}
 
 	if c.Operator == flipt.OpIsOneOf {
 		values := []float64{}
 		if err := json.Unmarshal([]byte(c.Value), &values); err != nil {
-			return false, errs.ErrInvalidf("Invalid value for constraint %q", c.Value)
+			return false, nil
 		}
 		return slices.Contains(values, n), nil
 	} else if c.Operator == flipt.OpIsNotOneOf {
 		values := []float64{}
 		if err := json.Unmarshal([]byte(c.Value), &values); err != nil {
-			return false, errs.ErrInvalidf("Invalid value for constraint %q", c.Value)
+			return false, nil
 		}
 		return !slices.Contains(values, n), nil
 	}
@@ -389,7 +389,7 @@ func matchesNumber(c storage.EvaluationConstraint, v string) (bool, error) {
 	// TODO: we should consider parsing this at creation time since it doesn't change and it doesnt make sense to allow invalid constraint values
 	value, err := strconv.ParseFloat(c.Value, 64)
 	if err != nil {
-		return false, errs.ErrInvalidf("parsing number from %q", c.Value)
+		return false, nil
 	}
 
 	switch c.Operator {
@@ -425,7 +425,7 @@ func matchesBool(c storage.EvaluationConstraint, v string) (bool, error) {
 
 	value, err := strconv.ParseBool(v)
 	if err != nil {
-		return false, errs.ErrInvalidf("parsing boolean from %q", v)
+		return false, nil
 	}
 
 	switch c.Operator {
@@ -453,12 +453,12 @@ func matchesDateTime(c storage.EvaluationConstraint, v string) (bool, error) {
 
 	d, err := tryParseDateTime(v)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 
 	value, err := tryParseDateTime(c.Value)
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 
 	switch c.Operator {

--- a/internal/server/evaluation/legacy_evaluator_test.go
+++ b/internal/server/evaluation/legacy_evaluator_test.go
@@ -480,14 +480,13 @@ func Test_matchesNumber(t *testing.T) {
 		)
 
 		t.Run(tt.name, func(t *testing.T) {
-			match, err := matchesNumber(constraint, value)
+			match := matchesNumber(constraint, value)
 
 			if failedParse {
-				assert.Nil(t, err)
+				assert.False(t, match)
 				return
 			}
 
-			assert.NoError(t, err)
 			assert.Equal(t, wantMatch, match)
 		})
 	}
@@ -602,14 +601,13 @@ func Test_matchesBool(t *testing.T) {
 		)
 
 		t.Run(tt.name, func(t *testing.T) {
-			match, err := matchesBool(constraint, value)
+			match := matchesBool(constraint, value)
 
 			if failedParse {
-				assert.Nil(t, err)
+				assert.False(t, match)
 				return
 			}
 
-			assert.NoError(t, err)
 			assert.Equal(t, wantMatch, match)
 		})
 	}
@@ -836,14 +834,13 @@ func Test_matchesDateTime(t *testing.T) {
 		)
 
 		t.Run(tt.name, func(t *testing.T) {
-			match, err := matchesDateTime(constraint, value)
+			match := matchesDateTime(constraint, value)
 
 			if failedParse {
-				assert.Nil(t, err)
+				assert.False(t, match)
 				return
 			}
 
-			assert.NoError(t, err)
 			assert.Equal(t, wantMatch, match)
 		})
 	}


### PR DESCRIPTION
Fixes: #2910

Change: Don't return errors when parsing values at evaluation time, simply skip/return no match

## TODO

- [ ] replicate in rust evaluator