### PR TITLE
feat(fs/git): add support for a directory scope

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -131,16 +131,16 @@ import "strings"
 	}
 
 	#cors: {
-		enabled?:         bool | *false
+		enabled?: bool | *false
 		allowed_origins?: [...] | string | *["*"]
 		allowed_headers?: [...string] | string | *[
-					"Accept",
-					"Authorization",
-					"Content-Type",
-					"X-CSRF-Token",
-					"X-Fern-Language",
-					"X-Fern-SDK-Name",
-					"X-Fern-SDK-Version",
+			"Accept",
+			"Authorization",
+			"Content-Type",
+			"X-CSRF-Token",
+			"X-Fern-Language",
+			"X-Fern-SDK-Name",
+			"X-Fern-SDK-Version",
 		]
 	}
 
@@ -157,6 +157,7 @@ import "strings"
 		git?: {
 			repository:         string
 			ref?:               string | *"main"
+			directory?:         string
 			poll_interval?:     =~#duration | *"30s"
 			ca_cert_path?:      string
 			ca_cert_bytes?:     string
@@ -209,7 +210,7 @@ import "strings"
 				username: string
 				password: string
 			}
-			poll_interval?: =~#duration | *"30s"
+			poll_interval?:    =~#duration | *"30s"
 			manifest_version?: "1.0" | *"1.1"
 		}
 	}
@@ -231,7 +232,7 @@ import "strings"
 	})
 
 	_#lower: ["debug", "error", "fatal", "info", "panic", "trace", "warn"]
-	_#all: _#lower + [ for x in _#lower {strings.ToUpper(x)}]
+	_#all: _#lower + [for x in _#lower {strings.ToUpper(x)}]
 	#log: {
 		file?:       string
 		encoding?:   *"console" | "json"

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -558,6 +558,9 @@
               "type": "string",
               "default": "main"
             },
+            "directory": {
+              "type": "string"
+            },
             "ca_cert_path": {
               "type": "string"
             },

--- a/go.work.sum
+++ b/go.work.sum
@@ -255,6 +255,7 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -727,6 +727,23 @@ func TestLoad(t *testing.T) {
 			},
 		},
 		{
+			name: "git config provided with directory",
+			path: "./testdata/storage/git_provided_with_directory.yml",
+			expected: func() *Config {
+				cfg := Default()
+				cfg.Storage = StorageConfig{
+					Type: GitStorageType,
+					Git: &Git{
+						Ref:          "main",
+						Repository:   "git@github.com:foo/bar.git",
+						Directory:    "baz",
+						PollInterval: 30 * time.Second,
+					},
+				}
+				return cfg
+			},
+		},
+		{
 			name:    "git repository not provided",
 			path:    "./testdata/storage/invalid_git_repo_not_specified.yml",
 			wantErr: errors.New("git repository must be specified"),

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -146,6 +146,7 @@ type Local struct {
 type Git struct {
 	Repository      string         `json:"repository,omitempty" mapstructure:"repository" yaml:"repository,omitempty"`
 	Ref             string         `json:"ref,omitempty" mapstructure:"ref" yaml:"ref,omitempty"`
+	Directory       string         `json:"directory,omitempty" mapstructure:"directory" yaml:"directory,omitempty"`
 	CaCertBytes     string         `json:"-" mapstructure:"ca_cert_bytes" yaml:"-" `
 	CaCertPath      string         `json:"-" mapstructure:"ca_cert_path" yaml:"-" `
 	InsecureSkipTLS bool           `json:"-" mapstructure:"insecure_skip_tls" yaml:"-"`

--- a/internal/config/testdata/storage/git_provided_with_directory.yml
+++ b/internal/config/testdata/storage/git_provided_with_directory.yml
@@ -1,0 +1,5 @@
+storage:
+  type: git
+  git:
+    repository: "git@github.com:foo/bar.git"
+    directory: "baz"

--- a/internal/storage/fs/git/testdata/subdir/.flipt.yml
+++ b/internal/storage/fs/git/testdata/subdir/.flipt.yml
@@ -1,0 +1,3 @@
+version: "1.0"
+include:
+- "alternative.yml"

--- a/internal/storage/fs/git/testdata/subdir/alternative.yml
+++ b/internal/storage/fs/git/testdata/subdir/alternative.yml
@@ -1,0 +1,5 @@
+namespace: "alternative"
+flags:
+- key: otherflag
+  name: Other Flag
+

--- a/internal/storage/fs/store/store.go
+++ b/internal/storage/fs/store/store.go
@@ -38,6 +38,7 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (_ st
 				storagefs.WithInterval(cfg.Storage.Git.PollInterval),
 			),
 			git.WithInsecureTLS(cfg.Storage.Git.InsecureSkipTLS),
+			git.WithDirectory(cfg.Storage.Git.Directory),
 		}
 
 		if cfg.Storage.Git.CaCertBytes != "" {


### PR DESCRIPTION
Supports https://github.com/flipt-io/flipt-server-sdks/issues/158

This adds support for users specifying a `directory` context with the `git` type storage backend.
When declared the backend will perform its flag state location process rooted from the defined directory.

This would allow folks to deploy Flipt multiple times over the same repository for e.g. different environments.
Environments can then be modelled as directories instead of namespaces or branches in this situation.

## TODO
- [ ] Update docs