### PR TITLE
fix: invalid trace log level schema

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -231,7 +231,7 @@ import "strings"
 		user?:     string
 	})
 
-	_#lower: ["debug", "error", "fatal", "info", "panic", "trace", "warn"]
+	_#lower: ["debug", "error", "fatal", "info", "panic", "warn"]
 	_#all: _#lower + [for x in _#lower {strings.ToUpper(x)}]
 	#log: {
 		file?:       string

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -825,8 +825,6 @@
             "INFO",
             "PANIC",
             "panic",
-            "trace",
-            "TRACE",
             "warn",
             "WARN"
           ]


### PR DESCRIPTION
Re: https://github.com/flipt-io/flipt/discussions/2943

Removes invalid 'trace' level from schemas