### PR TITLE
fix: jsonschema to correctly validate key|keys in rollout segment

### DIFF
--- a/core/validation/flipt.json
+++ b/core/validation/flipt.json
@@ -27,10 +27,15 @@
     "rolloutSegment": {
       "type": "object",
       "properties": {
+        "key": {
+          "type": "string",
+          "pattern": "^[-_,A-Za-z0-9]+$"
+        },
         "keys": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "pattern": "^[-_,A-Za-z0-9]+$"
           }
         },
         "operator": {
@@ -44,8 +49,29 @@
         }
       },
       "required": [
-        "keys",
         "value"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "key"
+          ],
+          "not": {
+            "required": [
+              "keys"
+            ]
+          }
+        },
+        {
+          "required": [
+            "keys"
+          ],
+          "not": {
+            "required": [
+              "key"
+            ]
+          }
+        }
       ]
     },
     "rolloutThreshold": {


### PR DESCRIPTION
Correctly validate both cases for rollout segment in the JSON schema:
```
    rollouts:
      - segment:
          key: Single-Constraint
          value: false
      - segment:
          keys:
            - Single-Constraint
            - Any-Constraint-Segment
          value: false
```