### PR TITLE
Add entityId to clickhouse analytics

### DIFF
--- a/config/migrations/clickhouse/3_alter_add_entity_id.up.sql
+++ b/config/migrations/clickhouse/3_alter_add_entity_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE flipt_counter_analytics ADD COLUMN entity_id Nullable(String) AFTER evaluation_value;

--- a/internal/server/analytics/clickhouse/mutation.go
+++ b/internal/server/analytics/clickhouse/mutation.go
@@ -16,10 +16,10 @@ func (c *Client) IncrementFlagEvaluationCounts(ctx context.Context, responses []
 	}
 
 	valuePlaceHolders := make([]string, 0, len(responses))
-	valueArgs := make([]interface{}, 0, len(responses)*9)
+	valueArgs := make([]interface{}, 0, len(responses)*10)
 
 	for _, response := range responses {
-		valuePlaceHolders = append(valuePlaceHolders, "(toDateTime(?, 'UTC'),?,?,?,?,?,?,?,?)")
+		valuePlaceHolders = append(valuePlaceHolders, "(toDateTime(?, 'UTC'),?,?,?,?,?,?,?,?,?)")
 		valueArgs = append(valueArgs, response.Timestamp.Format(time.DateTime))
 		valueArgs = append(valueArgs, counterAnalyticsName)
 		valueArgs = append(valueArgs, response.NamespaceKey)
@@ -28,6 +28,7 @@ func (c *Client) IncrementFlagEvaluationCounts(ctx context.Context, responses []
 		valueArgs = append(valueArgs, response.Reason)
 		valueArgs = append(valueArgs, response.Match)
 		valueArgs = append(valueArgs, response.EvaluationValue)
+		valueArgs = append(valueArgs, response.EntityId)
 		valueArgs = append(valueArgs, 1)
 	}
 

--- a/internal/server/analytics/sink.go
+++ b/internal/server/analytics/sink.go
@@ -25,6 +25,7 @@ type EvaluationResponse struct {
 	Match           *bool     `json:"match,omitempty"`
 	EvaluationValue *string   `json:"evaluationValue,omitempty"`
 	Timestamp       time.Time `json:"timestamp,omitempty"`
+	EntityId        string    `json:"entityId,omitempty"`
 }
 
 // AnalyticsSinkSpanExporter implements SpanExporter.

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -137,6 +137,7 @@ func EvaluationUnaryInterceptor(analyticsEnabled bool) grpc.UnaryServerIntercept
 								Reason:          r.GetReason().String(),
 								Timestamp:       r.GetTimestamp().AsTime(),
 								EvaluationValue: variantKey,
+								EntityId:        evaluationRequest.EntityId,
 							},
 						}
 
@@ -162,6 +163,7 @@ func EvaluationUnaryInterceptor(analyticsEnabled bool) grpc.UnaryServerIntercept
 								Timestamp:       r.GetTimestamp().AsTime(),
 								Match:           nil,
 								EvaluationValue: &evaluationValue,
+								EntityId:        evaluationRequest.EntityId,
 							},
 						}
 
@@ -195,6 +197,7 @@ func EvaluationUnaryInterceptor(analyticsEnabled bool) grpc.UnaryServerIntercept
 									Reason:          variantResponse.GetReason().String(),
 									Timestamp:       variantResponse.Timestamp.AsTime(),
 									EvaluationValue: variantKey,
+									EntityId:        batchEvaluationRequest.Requests[idx].EntityId,
 								})
 							case evaluation.EvaluationResponseType_BOOLEAN_EVALUATION_RESPONSE_TYPE:
 								booleanResponse := response.GetBooleanResponse()
@@ -207,6 +210,7 @@ func EvaluationUnaryInterceptor(analyticsEnabled bool) grpc.UnaryServerIntercept
 									Timestamp:       booleanResponse.Timestamp.AsTime(),
 									Match:           nil,
 									EvaluationValue: &evaluationValue,
+									EntityId:        batchEvaluationRequest.Requests[idx].EntityId,
 								})
 							}
 						}

--- a/internal/storage/sql/migrator.go
+++ b/internal/storage/sql/migrator.go
@@ -24,7 +24,7 @@ var expectedVersions = map[Driver]uint{
 	Postgres:    12,
 	MySQL:       11,
 	CockroachDB: 9,
-	Clickhouse:  2,
+	Clickhouse:  3,
 }
 
 // Migrator is responsible for migrating the database schema


### PR DESCRIPTION
When using percentage rollout, we need to know evaluation result by entityId.