### PR TITLE
feat(authn): allow validation of jwt subject claim

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -82,6 +82,7 @@ import "strings"
 				enabled?: bool | *false
 				validate_claims?: {
 					issuer?: string
+					subject?: string
 					audiences?: [...string]
 				}
 				jwks_url?:        string

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -230,6 +230,9 @@
                     },
                     "issuer": {
                       "type": "string"
+                    },
+                    "subject": {
+                      "type": "string"
                     }
                   }
                 },
@@ -759,7 +762,7 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "type":  {
+                "type": {
                   "type": "string",
                   "enum": ["static", "aws-ecr"],
                   "default": "static"

--- a/internal/cmd/authn.go
+++ b/internal/cmd/authn.go
@@ -234,6 +234,10 @@ func authenticationGRPC(
 				exp.Issuer = authJWT.Method.ValidateClaims.Issuer
 			}
 
+			if authJWT.Method.ValidateClaims.Subject != "" {
+				exp.Subject = authJWT.Method.ValidateClaims.Subject
+			}
+
 			if len(authJWT.Method.ValidateClaims.Audiences) != 0 {
 				exp.Audiences = authJWT.Method.ValidateClaims.Audiences
 			}

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -524,7 +524,7 @@ func (a AuthenticationMethodGithubConfig) info() AuthenticationMethodInfo {
 		RequiresDatabase:  true,
 	}
 
-	var metadata = make(map[string]any)
+	metadata := make(map[string]any)
 
 	metadata["authorize_url"] = "/auth/v1/method/github/authorize"
 	metadata["callback_url"] = "/auth/v1/method/github/callback"
@@ -576,6 +576,8 @@ type AuthenticationMethodJWTConfig struct {
 	ValidateClaims struct {
 		// Issuer is the issuer of the JWT token.
 		Issuer string `json:"-" mapstructure:"issuer" yaml:"issuer,omitempty"`
+		// Subject is the subject of the JWT token.
+		Subject string `json:"-" mapstructure:"subject" yaml:"subject,omitempty"`
 		// Audiences is the audience of the JWT token.
 		Audiences []string `json:"-" mapstructure:"audiences" yaml:"audiences,omitempty"`
 	} `json:"-" mapstructure:"validate_claims" yaml:"validate_claims,omitempty"`

--- a/internal/server/authn/middleware/grpc/middleware_test.go
+++ b/internal/server/authn/middleware/grpc/middleware_test.go
@@ -73,6 +73,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 				claims := map[string]interface{}{
 					"iss": "https://flipt.io/",
 					"aud": "flipt",
+					"sub": "sunglasses",
 					"iat": nowUnix,
 					"exp": futureUnix,
 				}
@@ -85,6 +86,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 			expectedJWT: jwt.Expected{
 				Issuer:    "https://flipt.io/",
 				Audiences: []string{"flipt"},
+				Subject:   "sunglasses",
 			},
 		},
 		{
@@ -135,6 +137,27 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 			},
 			expectedJWT: jwt.Expected{
 				Issuer: "https://flipt.io/",
+			},
+			expectedErr: ErrUnauthenticated,
+		},
+		{
+			name: "invalid subject",
+			metadataFunc: func() metadata.MD {
+				claims := map[string]interface{}{
+					"iss": "https://flipt.io/",
+					"iat": nowUnix,
+					"exp": futureUnix,
+					"sub": "bar",
+				}
+
+				token := oidc.TestSignJWT(t, priv, string(jwt.RS256), claims, []byte("test-key"))
+				return metadata.MD{
+					"Authorization": []string{"JWT " + token},
+				}
+			},
+			expectedJWT: jwt.Expected{
+				Issuer:  "https://flipt.io/",
+				Subject: "flipt",
 			},
 			expectedErr: ErrUnauthenticated,
 		},


### PR DESCRIPTION
Re: #2985 

- Adds support for validating `subject` in JWT claims
- Custom claim validation support will require more work as the [library we use to validate](https://pkg.go.dev/github.com/hashicorp/cap@v0.6.0/jwt#Expected) JWTs does not support custom claim validation so we will need to do it ourselves


/cc @tstraley