### PR TITLE
chore: update changelog for v1.40.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.40.2](https://github.com/flipt-io/flipt/releases/tag/v1.40.2) - 2024-04-23
+
+### Fixed
+
+- `cmd/grpc`: skip eval data service when evaluation API auth excluded (#3018)
+
 ## [v1.40.1](https://github.com/flipt-io/flipt/releases/tag/v1.40.1) - 2024-04-11
 
 ### Changed


### PR DESCRIPTION
This simply brings along the updates for the v1.40.2 changelog into `main`.