### PR TITLE
chore: add test to catch invalid struct tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/hashicorp/cap v0.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/iancoleman/strcase v0.3.0
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/libsql/libsql-client-go v0.0.0-20230917132930-48c310b27e7b
 	github.com/magefile/mage v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -384,6 +384,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1507,19 +1507,19 @@ func validateStructTags(t *testing.T, tags map[string]map[string]string, tType r
 		// Validate the `json` struct tag.
 		jsonTag, ok := fieldTags["json"]
 		if ok {
-			require.True(t, isCamelCase(jsonTag), "json tag for field %s.%s should be camelCase", tName, fieldName)
+			require.True(t, isCamelCase(jsonTag), "json tag for field '%s.%s' should be camelCase but is '%s'", tName, fieldName, jsonTag)
 		}
 
 		// Validate the `mapstructure` struct tag.
 		mapstructureTag, ok := fieldTags["mapstructure"]
 		if ok {
-			require.True(t, isSnakeCase(mapstructureTag), "mapstructure tag for field %s.%s should be snake_case", tName, fieldName)
+			require.True(t, isSnakeCase(mapstructureTag), "mapstructure tag for field '%s.%s' should be snake_case but is '%s'", tName, fieldName, mapstructureTag)
 		}
 
 		// Validate the `yaml` struct tag.
 		yamlTag, ok := fieldTags["yaml"]
 		if ok {
-			require.True(t, isSnakeCase(yamlTag), "yaml tag for field %s.%s should be snake_case", tName, fieldName)
+			require.True(t, isSnakeCase(yamlTag), "yaml tag for field '%s.%s' should be snake_case but is '%s'", tName, fieldName, yamlTag)
 		}
 
 		// recursively validate the struct tags for all sub-structs.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iancoleman/strcase"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1474,4 +1475,95 @@ func TestGetConfigFile(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+var (
+	// add any struct tags to match their camelCase equivalents here.
+	camelCaseMatchers = map[string]string{
+		"requireTLS":   "requireTLS",
+		"discoveryURL": "discoveryURL",
+	}
+)
+
+func TestStructTags(t *testing.T) {
+	configType := reflect.TypeOf(Config{})
+	configTags := getStructTags(configType)
+
+	for k, v := range camelCaseMatchers {
+		strcase.ConfigureAcronym(k, v)
+	}
+
+	// Validate the struct tags for the Config struct.
+	// recursively validate the struct tags for all sub-structs.
+	validateStructTags(t, configTags, configType)
+}
+
+func validateStructTags(t *testing.T, tags map[string]map[string]string, tType reflect.Type) {
+	for fieldName, fieldTags := range tags {
+		fieldType, ok := tType.FieldByName(fieldName)
+		require.True(t, ok, "field %s not found in type %s", fieldName, tType.Name())
+
+		// Validate the `json` struct tag.
+		jsonTag, ok := fieldTags["json"]
+		if ok {
+			require.True(t, isCamelCase(jsonTag), "json tag for field %s should be camelCase", fieldName)
+		}
+
+		// Validate the `mapstructure` struct tag.
+		mapstructureTag, ok := fieldTags["mapstructure"]
+		if ok {
+			require.True(t, isSnakeCase(mapstructureTag), "mapstructure tag for field %s should be snake_case", fieldName)
+		}
+
+		// Validate the `yaml` struct tag.
+		yamlTag, ok := fieldTags["yaml"]
+		if ok {
+			require.True(t, isSnakeCase(yamlTag), "yaml tag for field %s should be snake_case", fieldName)
+		}
+
+		// recursively validate the struct tags for all sub-structs.
+		if fieldType.Type.Kind() == reflect.Struct {
+			validateStructTags(t, getStructTags(fieldType.Type), fieldType.Type)
+		}
+	}
+}
+
+func isCamelCase(s string) bool {
+	return s == strcase.ToLowerCamel(s)
+}
+
+func isSnakeCase(s string) bool {
+	return s == strcase.ToSnake(s)
+}
+
+func getStructTags(t reflect.Type) map[string]map[string]string {
+	tags := make(map[string]map[string]string)
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Get the field name.
+		fieldName := field.Name
+
+		// Get the field tags.
+		fieldTags := make(map[string]string)
+		for _, tag := range []string{"json", "mapstructure", "yaml"} {
+			tagValue := field.Tag.Get(tag)
+			if tagValue == "-" {
+				fieldTags[tag] = "skip"
+				continue
+			}
+			values := strings.Split(tagValue, ",")
+			if len(values) > 1 {
+				tagValue = values[0]
+			}
+			if tagValue != "" {
+				fieldTags[tag] = tagValue
+			}
+		}
+
+		tags[fieldName] = fieldTags
+	}
+
+	return tags
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1499,26 +1499,27 @@ func TestStructTags(t *testing.T) {
 }
 
 func validateStructTags(t *testing.T, tags map[string]map[string]string, tType reflect.Type) {
+	tName := tType.Name()
 	for fieldName, fieldTags := range tags {
 		fieldType, ok := tType.FieldByName(fieldName)
-		require.True(t, ok, "field %s not found in type %s", fieldName, tType.Name())
+		require.True(t, ok, "field %s not found in type %s", fieldName, tName)
 
 		// Validate the `json` struct tag.
 		jsonTag, ok := fieldTags["json"]
 		if ok {
-			require.True(t, isCamelCase(jsonTag), "json tag for field %s should be camelCase", fieldName)
+			require.True(t, isCamelCase(jsonTag), "json tag for field %s.%s should be camelCase", tName, fieldName)
 		}
 
 		// Validate the `mapstructure` struct tag.
 		mapstructureTag, ok := fieldTags["mapstructure"]
 		if ok {
-			require.True(t, isSnakeCase(mapstructureTag), "mapstructure tag for field %s should be snake_case", fieldName)
+			require.True(t, isSnakeCase(mapstructureTag), "mapstructure tag for field %s.%s should be snake_case", tName, fieldName)
 		}
 
 		// Validate the `yaml` struct tag.
 		yamlTag, ok := fieldTags["yaml"]
 		if ok {
-			require.True(t, isSnakeCase(yamlTag), "yaml tag for field %s should be snake_case", fieldName)
+			require.True(t, isSnakeCase(yamlTag), "yaml tag for field %s.%s should be snake_case", tName, fieldName)
 		}
 
 		// recursively validate the struct tags for all sub-structs.


### PR DESCRIPTION
Re: #3034 

ℹ️ this shows how the test would have caught #3034 , we should rebase this test on that branch or main once it gets merged in for this test to pass

Adds a test to hopefully catch any incorrect struct tag values:

```
  /Users/markphelps/workspace/flipt/internal/config/config_test.go:1515: 
       Error Trace:	/Users/markphelps/workspace/flipt/internal/config/config_test.go:1515
        	            		/Users/markphelps/workspace/flipt/internal/config/config_test.go:1526
        	            		/Users/markphelps/workspace/flipt/internal/config/config_test.go:1498
       Error:      	Should be true
       Test:       	TestStructTags
       Messages:   	mapstructure tag for field 'TracingConfig.SamplingRatio' should be snake_case but is 'samplingRatio'