### PR TITLE
feat: Cloud Authn

### DIFF
--- a/build/testing/cli.go
+++ b/build/testing/cli.go
@@ -409,7 +409,7 @@ exit $?`,
 		}
 
 		// now there are four including local copy of remote name
-		container, err = assertExec(ctx, container, flipt("bundle", "list"),
+		_, err = assertExec(ctx, container, flipt("bundle", "list"),
 			stdout(matches(`DIGEST[\s]+REPO[\s]+TAG[\s]+CREATED`)),
 			stdout(matches(`[a-f0-9]{7}[\s]+mybundle[\s]+latest[\s]+[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}`)),
 			stdout(matches(`[a-f0-9]{7}[\s]+mybundle[\s]+[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}`)),
@@ -418,6 +418,10 @@ exit $?`,
 		if err != nil {
 			return err
 		}
+	}
+
+	{
+		// TODO: add tests for flipt cloud commands
 	}
 
 	return nil

--- a/build/testing/testdata/cli.txt
+++ b/build/testing/testdata/cli.txt
@@ -12,6 +12,7 @@ $ flipt --config /path/to/config.yml migrate
 
 Available Commands:
   bundle      Manage Flipt bundles
+  cloud       Interact with Flipt Cloud
   config      Manage Flipt configuration
   evaluate    Evaluate a flag
   export      Export Flipt data to file/stdout

--- a/cmd/flipt/cloud.go
+++ b/cmd/flipt/cloud.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"go.flipt.io/flipt/internal/cmd/cloud"
+	"go.flipt.io/flipt/internal/cmd/util"
+	"golang.org/x/sync/errgroup"
+)
+
+type cloudCommand struct {
+	url string
+}
+
+type cloudAuth struct {
+	Token string `json:"token"`
+}
+
+func newCloudCommand() *cobra.Command {
+	cloud := &cloudCommand{}
+
+	cmd := &cobra.Command{
+		Use:   "cloud",
+		Short: "Interact with Flipt Cloud",
+	}
+
+	cmd.PersistentFlags().StringVarP(&cloud.url, "url", "u", "https://flipt.cloud", "Flipt Cloud URL")
+
+	authCmd := &cobra.Command{
+		Use:   "auth [flags]",
+		Short: "Authenticate with Flipt Cloud",
+		RunE:  cloud.auth,
+		Args:  cobra.NoArgs,
+	}
+
+	cmd.AddCommand(authCmd)
+	return cmd
+}
+
+func (c *cloudCommand) auth(cmd *cobra.Command, args []string) error {
+	done := make(chan struct{})
+	const callbackURL = "http://localhost:8080/cloud/auth/callback"
+
+	ok, err := util.PromptConfirm("Open browser to authenticate with Flipt Cloud?", false)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return nil
+	}
+
+	flow, err := cloud.InitFlow()
+	if err != nil {
+		return fmt.Errorf("initializing flow: %w", err)
+	}
+
+	var (
+		g           errgroup.Group
+		ctx, cancel = context.WithCancel(cmd.Context())
+	)
+
+	defer cancel()
+
+	cloudAuthFile := filepath.Join(userConfigDir, "cloud.json")
+
+	g.Go(func() error {
+		tok, err := flow.Wait(ctx)
+		if err != nil {
+			return fmt.Errorf("waiting for token: %w", err)
+		}
+
+		cloudAuth := cloudAuth{
+			Token: tok,
+		}
+
+		cloudAuthBytes, err := json.Marshal(cloudAuth)
+		if err != nil {
+			return fmt.Errorf("marshalling cloud auth token: %w", err)
+		}
+
+		if err := os.WriteFile(cloudAuthFile, cloudAuthBytes, 0600); err != nil {
+			return fmt.Errorf("writing cloud auth token: %w", err)
+		}
+
+		fmt.Println("\n✅ Authenticated with Flipt Cloud!\nYou can now run commands that require cloud authentication.")
+
+		return nil
+	})
+
+	g.Go(func() error {
+		if err := flow.StartServer(nil); !errors.Is(err, net.ErrClosed) {
+			return fmt.Errorf("starting server: %w", err)
+		}
+		close(done)
+		return nil
+	})
+
+	g.Go(func() error {
+		select {
+		case <-done:
+			cancel()
+		case <-ctx.Done():
+			if err := flow.Close(); !errors.Is(err, context.Canceled) {
+				return err
+			}
+		}
+		return nil
+	})
+
+	browserParams := cloud.BrowserParams{
+		RedirectURL: callbackURL,
+	}
+
+	g.Go(func() error {
+		url, err := flow.BrowserURL(fmt.Sprintf("%s/login/device", c.url), browserParams)
+		if err != nil {
+			return fmt.Errorf("creating browser URL: %w", err)
+		}
+		return util.OpenBrowser(url)
+	})
+
+	return g.Wait()
+}

--- a/cmd/flipt/cloud.go
+++ b/cmd/flipt/cloud.go
@@ -33,18 +33,18 @@ func newCloudCommand() *cobra.Command {
 
 	cmd.PersistentFlags().StringVarP(&cloud.url, "url", "u", "https://flipt.cloud", "Flipt Cloud URL")
 
-	authCmd := &cobra.Command{
-		Use:   "auth [flags]",
+	loginCmd := &cobra.Command{
+		Use:   "login [flags]",
 		Short: "Authenticate with Flipt Cloud",
-		RunE:  cloud.auth,
+		RunE:  cloud.login,
 		Args:  cobra.NoArgs,
 	}
 
-	cmd.AddCommand(authCmd)
+	cmd.AddCommand(loginCmd)
 	return cmd
 }
 
-func (c *cloudCommand) auth(cmd *cobra.Command, args []string) error {
+func (c *cloudCommand) login(cmd *cobra.Command, args []string) error {
 	done := make(chan struct{})
 
 	ok, err := util.PromptConfirm("Open browser to authenticate with Flipt Cloud?", false)

--- a/cmd/flipt/cloud.go
+++ b/cmd/flipt/cloud.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 
@@ -96,7 +96,7 @@ func (c *cloudCommand) auth(cmd *cobra.Command, args []string) error {
 	})
 
 	g.Go(func() error {
-		if err := flow.StartServer(nil); !errors.Is(err, net.ErrClosed) {
+		if err := flow.StartServer(nil); !errors.Is(err, http.ErrServerClosed) {
 			return fmt.Errorf("starting server: %w", err)
 		}
 		close(done)

--- a/cmd/flipt/cloud.go
+++ b/cmd/flipt/cloud.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -95,7 +95,7 @@ func (c *cloudCommand) auth(cmd *cobra.Command, args []string) error {
 	})
 
 	g.Go(func() error {
-		if err := flow.StartServer(nil); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		if err := flow.StartServer(nil); err != nil && !errors.Is(err, net.ErrClosed) {
 			return fmt.Errorf("starting server: %w", err)
 		}
 		close(done)

--- a/cmd/flipt/config.go
+++ b/cmd/flipt/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
+	"go.flipt.io/flipt/internal/cmd/util"
 	"go.flipt.io/flipt/internal/config"
 	"gopkg.in/yaml.v2"
 )
@@ -45,13 +46,11 @@ func (c *initCommand) run(cmd *cobra.Command, args []string) error {
 		// check if file exists
 		if _, err := os.Stat(file); err == nil {
 			// file exists
-			prompt := &survey.Confirm{
-				Message: "File exists. Overwrite?",
-			}
-			if err := survey.AskOne(prompt, &ack); err != nil {
+			overwrite, err := util.PromptConfirm("File exists. Overwrite?", false)
+			if err != nil {
 				return err
 			}
-			if !ack {
+			if !overwrite {
 				return nil
 			}
 		} else if !os.IsNotExist(err) {

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -386,6 +386,7 @@ func run(ctx context.Context, logger *zap.Logger, cfg *config.Config) error {
 				Handler:       httpServer.Handler,
 				Authenticator: client.BearerAuthenticator(cfg.Server.Cloud.Authentication.ApiKey),
 				TLSConfig: &tls.Config{
+					MinVersion: tls.VersionTLS13,
 					NextProtos: []string{protocol.Name},
 					ServerName: orgHost,
 				},

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -149,6 +149,7 @@ func exec() error {
 	rootCmd.AddCommand(newDocCommand())
 	rootCmd.AddCommand(newBundleCommand())
 	rootCmd.AddCommand(newEvaluateCommand())
+	rootCmd.AddCommand(newCloudCommand())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -271,7 +271,7 @@ import "strings"
 		grpc_conn_max_age_grace?: =~#duration
 		cloud?: {
 			enabled?: bool | *false
-			address?: string | *"https://flipt.cloud"
+			address?: string | *"flipt.cloud"
 			authentication?: {
 				api_key?: string
 			}

--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -269,6 +269,16 @@ import "strings"
 		grpc_conn_max_idle_time?: =~#duration
 		grpc_conn_max_age?:       =~#duration
 		grpc_conn_max_age_grace?: =~#duration
+		cloud?: {
+			enabled?: bool | *false
+			address?: string | *"https://flipt.cloud"
+			authentication?: {
+				api_key?: string
+			}
+			port?:    int | *8443
+			organization?:  string
+			instance?:  string
+		}
 	}
 
 	#metrics: {

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -928,6 +928,39 @@
         "grpc_conn_max_age_grace": {
           "type": "string",
           "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$"
+        },
+        "cloud": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false
+            },
+            "address": {
+              "type": "string",
+              "default": "flipt.cloud"
+            },
+            "authentication": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "api_key": {
+                  "type": "string"
+                }
+              }
+            },
+            "port": {
+              "type": "integer",
+              "default": 8443
+            },
+            "organization": {
+              "type": "string"
+            },
+            "instance": {
+              "type": "string"
+            }
+          }
         }
       },
       "required": [],

--- a/go.work.sum
+++ b/go.work.sum
@@ -205,6 +205,7 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
@@ -268,6 +269,7 @@ github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/checkpoint-restore/go-criu/v4 v4.1.0/go.mod h1:xUQBLp4RLc5zJtWY++yjOoMoB5lihDt7fai+75m+rGw=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -674,8 +676,10 @@ github.com/jackc/pgtype v1.14.0 h1:y+xUdabmyMkJLyApYuPj38mW+aAIqCe5uuBB51rH3Vw=
 github.com/jackc/pgtype v1.14.0/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76IqCA4=
 github.com/jackc/pgx/v4 v4.18.1 h1:YP7G1KABtKpB5IHrO9vYwSrCOhs7p3uqhvhhQBptya0=
 github.com/jackc/pgx/v4 v4.18.1/go.mod h1:FydWkUyadDmdNH/mHnGob881GawxeEm7TcMCzkb+qQE=
+github.com/jackc/pgx/v5 v5.3.1/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
 github.com/jackc/puddle v1.1.3 h1:JnPg/5Q9xVJGfjsO5CPUOjnJps1JaRUm8I9FXVCFK94=
-github.com/jackc/puddle v1.3.0 h1:eHK/5clGOatcjX3oWGBO/MpxpbHzSwud5EWTSCI+MX0=
+github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
+github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
 github.com/jcmturner/gofork v1.7.6/go.mod h1:1622LH6i/EZqLloHfE7IeZ0uEJwMSUyQ/nDd82IeqRo=
@@ -923,6 +927,7 @@ github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiB
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.2.0/go.mod h1:WkKB1DnNtvsMlDmQ50sgwowDJV/hGbJSOvJoEXs1AJQ=
 github.com/sagikazarmark/crypt v0.17.0/go.mod h1:SMtHTvdmsZMuY/bpZoqokSoChIrcJ/epOxZN58PbZDg=
+github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/internal/cmd/cloud/local_server.go
+++ b/internal/cmd/cloud/local_server.go
@@ -68,7 +68,7 @@ func (s *localServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	params := r.URL.Query()
 	s.resultChan <- TokenResponse{
-		Token: params.Get("token"),
+		Token: params.Get("id_token"),
 		State: params.Get("state"),
 	}
 

--- a/internal/cmd/cloud/local_server.go
+++ b/internal/cmd/cloud/local_server.go
@@ -1,0 +1,85 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+)
+
+// TokenResponse represents the token received by the local server's callback handler.
+type TokenResponse struct {
+	Token string
+	State string
+}
+
+// bindLocalServer initializes a LocalServer that will listen on a randomly available TCP port.
+func bindLocalServer() (*localServer, error) {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	return &localServer{
+		listener:   listener,
+		resultChan: make(chan TokenResponse, 1),
+	}, nil
+}
+
+type localServer struct {
+	CallbackPath     string
+	WriteSuccessHTML func(w io.Writer)
+
+	resultChan chan (TokenResponse)
+	listener   net.Listener
+}
+
+func (s *localServer) Port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+func (s *localServer) Close() error {
+	return s.listener.Close()
+}
+
+func (s *localServer) Serve() error {
+	return http.Serve(s.listener, s)
+}
+
+func (s *localServer) Wait(ctx context.Context) (TokenResponse, error) {
+	select {
+	case <-ctx.Done():
+		return TokenResponse{}, ctx.Err()
+	case code := <-s.resultChan:
+		return code, nil
+	}
+}
+
+// ServeHTTP implements http.Handler.
+func (s *localServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.CallbackPath != "" && r.URL.Path != s.CallbackPath {
+		w.WriteHeader(404)
+		return
+	}
+	defer func() {
+		_ = s.Close()
+	}()
+
+	params := r.URL.Query()
+	s.resultChan <- TokenResponse{
+		Token: params.Get("token"),
+		State: params.Get("state"),
+	}
+
+	w.Header().Add("content-type", "text/html")
+	if s.WriteSuccessHTML != nil {
+		s.WriteSuccessHTML(w)
+	} else {
+		defaultSuccessHTML(w)
+	}
+}
+
+func defaultSuccessHTML(w io.Writer) {
+	fmt.Fprintf(w, "<p>You may now close this page and return to the client app.</p>")
+}

--- a/internal/cmd/cloud/local_server.go
+++ b/internal/cmd/cloud/local_server.go
@@ -73,17 +73,17 @@ func (s *localServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = s.Close()
 	}()
 
-	params := r.URL.Query()
-	s.resultChan <- TokenResponse{
-		Token: params.Get("id_token"),
-		State: params.Get("state"),
-	}
-
 	w.Header().Add("content-type", "text/html")
 	if s.WriteSuccessHTML != nil {
 		s.WriteSuccessHTML(w)
 	} else {
 		defaultSuccessHTML(w)
+	}
+
+	params := r.URL.Query()
+	s.resultChan <- TokenResponse{
+		Token: params.Get("id_token"),
+		State: params.Get("state"),
 	}
 }
 

--- a/internal/cmd/cloud/web_flow.go
+++ b/internal/cmd/cloud/web_flow.go
@@ -31,11 +31,6 @@ func InitFlow() (*Flow, error) {
 	}, nil
 }
 
-// BrowserParams are GET query parameters for initiating the web flow.
-type BrowserParams struct {
-	RedirectURL string
-}
-
 // BrowserURL appends GET query parameters to baseURL and returns the url that the user should
 // navigate to in their web browser.
 func (f *Flow) BrowserURL(baseURL string) (string, error) {

--- a/internal/cmd/cloud/web_flow.go
+++ b/internal/cmd/cloud/web_flow.go
@@ -23,7 +23,7 @@ func InitFlow() (*Flow, error) {
 		return nil, err
 	}
 
-	state, _ := randomString(20)
+	state := randomString(20)
 
 	return &Flow{
 		server: server,
@@ -38,8 +38,10 @@ type BrowserParams struct {
 
 // BrowserURL appends GET query parameters to baseURL and returns the url that the user should
 // navigate to in their web browser.
-func (f *Flow) BrowserURL(baseURL string, params BrowserParams) (string, error) {
-	ru, err := url.Parse(params.RedirectURL)
+func (f *Flow) BrowserURL(baseURL string) (string, error) {
+	const callbackURL = "http://localhost:8080/cloud/auth/callback"
+
+	ru, err := url.Parse(callbackURL)
 	if err != nil {
 		return "", err
 	}
@@ -65,12 +67,6 @@ func (f *Flow) Close() error {
 	return f.server.Close()
 }
 
-// WaitOptions specifies parameters to exchange the access token for.
-type WaitOptions struct {
-	// ClientSecret is the app client secret value.
-	ClientSecret string
-}
-
 // Wait blocks until the browser flow has completed and returns the access token.
 func (f *Flow) Wait(ctx context.Context) (string, error) {
 	resp, err := f.server.Wait(ctx)
@@ -84,11 +80,11 @@ func (f *Flow) Wait(ctx context.Context) (string, error) {
 	return resp.Token, nil
 }
 
-func randomString(length int) (string, error) {
+func randomString(length int) string {
 	b := make([]byte, length/2)
 	_, err := rand.Read(b)
 	if err != nil {
-		return "", err
+		panic(err)
 	}
-	return hex.EncodeToString(b), nil
+	return hex.EncodeToString(b)
 }

--- a/internal/cmd/cloud/web_flow.go
+++ b/internal/cmd/cloud/web_flow.go
@@ -1,0 +1,94 @@
+package cloud
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+)
+
+// Flow holds the state for the steps of our OAuth-like Web Application flow.
+type Flow struct {
+	server *localServer
+	state  string
+}
+
+// InitFlow creates a new Flow instance by detecting a locally available port number.
+func InitFlow() (*Flow, error) {
+	server, err := bindLocalServer()
+	if err != nil {
+		return nil, err
+	}
+
+	state, _ := randomString(20)
+
+	return &Flow{
+		server: server,
+		state:  state,
+	}, nil
+}
+
+// BrowserParams are GET query parameters for initiating the web flow.
+type BrowserParams struct {
+	RedirectURL string
+}
+
+// BrowserURL appends GET query parameters to baseURL and returns the url that the user should
+// navigate to in their web browser.
+func (f *Flow) BrowserURL(baseURL string, params BrowserParams) (string, error) {
+	ru, err := url.Parse(params.RedirectURL)
+	if err != nil {
+		return "", err
+	}
+
+	ru.Host = fmt.Sprintf("%s:%d", ru.Hostname(), f.server.Port())
+	f.server.CallbackPath = ru.Path
+
+	q := url.Values{}
+	q.Set("redirect_url", ru.String())
+	q.Set("state", f.state)
+
+	return fmt.Sprintf("%s?%s", baseURL, q.Encode()), nil
+}
+
+// StartServer starts the localhost server and blocks until it has received the web redirect. The
+// writeSuccess function can be used to render a HTML page to the user upon completion.
+func (f *Flow) StartServer(writeSuccess func(io.Writer)) error {
+	f.server.WriteSuccessHTML = writeSuccess
+	return f.server.Serve()
+}
+
+func (f *Flow) Close() error {
+	return f.server.Close()
+}
+
+// WaitOptions specifies parameters to exchange the access token for.
+type WaitOptions struct {
+	// ClientSecret is the app client secret value.
+	ClientSecret string
+}
+
+// Wait blocks until the browser flow has completed and returns the access token.
+func (f *Flow) Wait(ctx context.Context) (string, error) {
+	resp, err := f.server.Wait(ctx)
+	if err != nil {
+		return "", err
+	}
+	if resp.State != f.state {
+		return "", errors.New("state mismatch")
+	}
+
+	return resp.Token, nil
+}
+
+func randomString(length int) (string, error) {
+	b := make([]byte, length/2)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/cmd/util/browser.go
+++ b/internal/cmd/util/browser.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// OpenBrowser opens the specified URL in the default browser of the user.
+func OpenBrowser(url string) error {
+	var (
+		cmd  string
+		args []string
+	)
+
+	fmt.Printf("Attempting to open your browser...\nIf this does not work, please navigate to: %q\n", url)
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	default: // "linux", "freebsd", "openbsd", "netbsd"
+		cmd = "xdg-open"
+	}
+
+	args = append(args, url)
+	return exec.Command(cmd, args...).Start()
+}

--- a/internal/cmd/util/prompt.go
+++ b/internal/cmd/util/prompt.go
@@ -1,0 +1,58 @@
+package util
+
+import (
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+// PromptPlaintext prompts a user to input plain text
+func PromptPlaintext(message string, defaultVal string) (string, error) {
+	var (
+		prompt = survey.Input{
+			Message: message,
+			Default: defaultVal,
+		}
+
+		value string
+	)
+
+	if err := survey.AskOne(&prompt, &value, survey.WithValidator(survey.Required)); err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(value), nil
+
+}
+
+// PromptPassword prompts a user to input a hidden field
+func PromptPassword(message string) (string, error) {
+	var (
+		prompt = &survey.Password{Message: message}
+
+		password string
+	)
+
+	if err := survey.AskOne(prompt, &password, survey.WithValidator(survey.Required)); err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(password), nil
+}
+
+func PromptConfirm(message string, defaultVal bool) (bool, error) {
+	var (
+		prompt = &survey.Confirm{
+			Message: message,
+			Default: defaultVal,
+		}
+
+		value bool
+	)
+
+	if err := survey.AskOne(prompt, &value); err != nil {
+		return false, err
+	}
+
+	return value, nil
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -119,7 +119,7 @@ func (c *CloudAuthenticationConfig) validate() error {
 func (c *CloudConfig) setDefaults(v *viper.Viper) error {
 	v.SetDefault("server.cloud", map[string]any{
 		"enabled": false,
-		"address": "flipt.cloud",
+		"address": "https://flipt.cloud",
 		"port":    8443,
 	})
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -119,7 +119,7 @@ func (c *CloudAuthenticationConfig) validate() error {
 func (c *CloudConfig) setDefaults(v *viper.Viper) error {
 	v.SetDefault("server.cloud", map[string]any{
 		"enabled": false,
-		"address": "https://flipt.cloud",
+		"address": "flipt.cloud",
 		"port":    8443,
 	})
 


### PR DESCRIPTION
Fixes: FLI-958

Adds cloud auth command

```
/bin/flipt cloud --url="http://localhost:3000" auth
```

![CleanShot 2024-05-01 at 10 51 51](https://github.com/flipt-io/flipt/assets/209477/5aae1736-d77f-4e46-bb93-8e58250d79ec)
