### PR TITLE
fix(cloud): improve shutdown logging

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -439,7 +439,9 @@ func run(ctx context.Context, logger *zap.Logger, cfg *config.Config) error {
 
 			logger.Info("cloud tunnel established", zap.String("address", fmt.Sprintf("https://%s", tunnel)))
 
-			if err := tunnelServer.DialAndServe(ctx, addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			if err := tunnelServer.DialAndServe(ctx, addr); err != nil &&
+				!errors.Is(err, http.ErrServerClosed) &&
+				!errors.Is(err, context.Canceled) {
 				return fmt.Errorf("creating cloud tunnel server: %w", err)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	go.flipt.io/flipt/errors v1.19.3
 	go.flipt.io/flipt/rpc/flipt v1.38.0
 	go.flipt.io/flipt/sdk/go v0.11.0
-	go.flipt.io/reverst v0.1.4
+	go.flipt.io/reverst v0.1.5
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.51.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.51.0
 	go.opentelemetry.io/contrib/propagators/autoprop v0.50.0

--- a/go.sum
+++ b/go.sum
@@ -742,8 +742,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yusufpapurcu/wmi v1.2.3 h1:E1ctvB7uKFMOJw3fdOW32DwGE9I7t++CRUEMKvFoFiw=
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
-go.flipt.io/reverst v0.1.4 h1:JC5NG5bYmWxYpunDYWTZZK6tpV+Lpi3b1/K7SmA7hBI=
-go.flipt.io/reverst v0.1.4/go.mod h1:SS5IqAgnPKWqEHq67p+G9Dsdyp+bQ3teh0LhyxnjKW4=
+go.flipt.io/reverst v0.1.5 h1:Riaq61rndAssPYEFUF6BnvauzDXcw+pXamHc3rrENH8=
+go.flipt.io/reverst v0.1.5/go.mod h1:SS5IqAgnPKWqEHq67p+G9Dsdyp+bQ3teh0LhyxnjKW4=
 go.mongodb.org/mongo-driver v1.11.4/go.mod h1:PTSz5yu21bkT/wXpkS7WR5f0ddqw5quethTUn9WM+2g=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=


### PR DESCRIPTION
This:
- Upgrades to reverst 0.1.5 so that context canceled propagates through.
- Updates the tunnel so that it returns `nil` in the face of context.Canceled.