### PR TITLE
test(integration): add failing case for rules with no distributions

### DIFF
--- a/build/testing/integration/readonly/readonly_test.go
+++ b/build/testing/integration/readonly/readonly_test.go
@@ -117,7 +117,7 @@ func TestReadOnly(t *testing.T) {
 				NamespaceKey: namespace,
 			})
 			require.NoError(t, err)
-			require.Len(t, flags.Flags, 56)
+			require.Len(t, flags.Flags, 57)
 
 			flag := flags.Flags[0]
 			assert.Equal(t, namespace, flag.NamespaceKey)
@@ -160,7 +160,7 @@ func TestReadOnly(t *testing.T) {
 					nextPage = flags.NextPageToken
 				}
 
-				require.Len(t, found, 56)
+				require.Len(t, found, 57)
 			})
 		})
 

--- a/build/testing/integration/readonly/readonly_test.go
+++ b/build/testing/integration/readonly/readonly_test.go
@@ -553,7 +553,7 @@ func TestReadOnly(t *testing.T) {
 					require.NoError(t, err)
 
 					assert.Equal(t, true, response.Match)
-					assert.Equal(t, "flag_001", response.FlagKey)
+					assert.Equal(t, "flag_no_distributions", response.FlagKey)
 					assert.Equal(t, evaluation.EvaluationReason_MATCH_EVALUATION_REASON, response.Reason)
 					assert.Contains(t, response.SegmentKeys, "segment_001")
 				})

--- a/build/testing/integration/readonly/readonly_test.go
+++ b/build/testing/integration/readonly/readonly_test.go
@@ -540,6 +540,23 @@ func TestReadOnly(t *testing.T) {
 
 					require.Nil(t, result)
 				})
+
+				t.Run("match no distributions", func(t *testing.T) {
+					response, err := sdk.Evaluation().Variant(ctx, &evaluation.EvaluationRequest{
+						NamespaceKey: namespace,
+						FlagKey:      "flag_no_distributions",
+						EntityId:     "some-fixed-entity-id",
+						Context: map[string]string{
+							"in_segment": "segment_001",
+						},
+					})
+					require.NoError(t, err)
+
+					assert.Equal(t, true, response.Match)
+					assert.Equal(t, "flag_001", response.FlagKey)
+					assert.Equal(t, evaluation.EvaluationReason_MATCH_EVALUATION_REASON, response.Reason)
+					assert.Contains(t, response.SegmentKeys, "segment_001")
+				})
 			})
 
 			t.Run("Boolean", func(t *testing.T) {

--- a/build/testing/integration/readonly/readonly_test.go
+++ b/build/testing/integration/readonly/readonly_test.go
@@ -145,7 +145,7 @@ func TestReadOnly(t *testing.T) {
 
 					if flags.NextPageToken == "" {
 						// ensure last page contains 3 entries (boolean and disabled)
-						assert.Len(t, flags.Flags, 6)
+						assert.Len(t, flags.Flags, 7)
 
 						found = append(found, flags.Flags...)
 

--- a/build/testing/integration/readonly/testdata/main/default.yaml
+++ b/build/testing/integration/readonly/testdata/main/default.yaml
@@ -15636,6 +15636,16 @@ flags:
     distributions:
     - variant: variant_001
       rollout: 100
+- key: flag_no_distributions
+  name: FLAG_NO_DISTRIBUTIONS
+  type: VARIANT_FLAG_TYPE
+  description: Flag no distributions
+  enabled: true
+  variants:
+  - key: variant_001
+    name: VARIANT_001
+  rules:
+  - segment: segment_001
 segments:
 - key: segment_001
   name: SEGMENT_001

--- a/build/testing/integration/readonly/testdata/main/production.yaml
+++ b/build/testing/integration/readonly/testdata/main/production.yaml
@@ -15637,6 +15637,16 @@ flags:
     distributions:
     - variant: variant_001
       rollout: 100
+- key: flag_no_distributions
+  name: FLAG_NO_DISTRIBUTIONS
+  type: VARIANT_FLAG_TYPE
+  description: Flag no distributions
+  enabled: true
+  variants:
+  - key: variant_001
+    name: VARIANT_001
+  rules:
+  - segment: segment_001
 segments:
 - key: segment_001
   name: SEGMENT_001

--- a/internal/storage/fs/snapshot.go
+++ b/internal/storage/fs/snapshot.go
@@ -717,7 +717,7 @@ func (ss *Snapshot) GetEvaluationRules(ctx context.Context, flag storage.Resourc
 func (ss *Snapshot) GetEvaluationDistributions(ctx context.Context, rule storage.IDRequest) ([]*storage.EvaluationDistribution, error) {
 	dists, ok := ss.evalDists[rule.ID]
 	if !ok {
-		return nil, errs.ErrNotFoundf("rule %q", rule.ID)
+		return []*storage.EvaluationDistribution{}, nil
 	}
 
 	return dists, nil

--- a/internal/storage/fs/snapshot_test.go
+++ b/internal/storage/fs/snapshot_test.go
@@ -603,22 +603,27 @@ func (fis *FSIndexSuite) TestGetEvaluationDistributions() {
 	t := fis.T()
 
 	testCases := []struct {
-		name                string
-		namespace           string
-		flagKey             string
-		expectedVariantName string
+		name      string
+		namespace string
+		flagKey   string
+		count     int
 	}{
 		{
-			name:                "Sandbox",
-			namespace:           "sandbox",
-			flagKey:             "sandbox-flag",
-			expectedVariantName: "sandbox-variant",
+			name:      "Sandbox",
+			namespace: "sandbox",
+			flagKey:   "sandbox-flag",
+			count:     1,
 		},
 		{
-			name:                "Production",
-			namespace:           "production",
-			flagKey:             "prod-flag",
-			expectedVariantName: "prod-variant",
+			name:      "Production",
+			namespace: "production",
+			flagKey:   "prod-flag",
+			count:     1,
+		},
+		{
+			name:      "Production No Distributions",
+			namespace: "production",
+			flagKey:   "no-distributions",
 		},
 	}
 
@@ -632,8 +637,7 @@ func (fis *FSIndexSuite) TestGetEvaluationDistributions() {
 
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.expectedVariantName, dist[0].VariantKey)
-			assert.Equal(t, float32(100), dist[0].Rollout)
+			assert.Len(t, dist, tc.count)
 		})
 	}
 }

--- a/internal/storage/fs/testdata/valid/explicit_index/prod/prod.features.yml
+++ b/internal/storage/fs/testdata/valid/explicit_index/prod/prod.features.yml
@@ -42,12 +42,14 @@ flags:
     threshold:
       percentage: 50
       value: true
-- key: redemptory
-  name: redemptory
+- key: no-distributions
+  name: No Distributions
   description: description
   enabled: true
   variants:
   - key: flipt-flag
+  rules:
+  - segment: segment1
 - key: animalculine
   name: animalculine
   description: description


### PR DESCRIPTION
Fixes #3076 

See failing test case:
```
    readonly_test.go:553: 
        	Error Trace:	/src/build/testing/integration/readonly/readonly_test.go:553
        	Error:      	Received unexpected error:
        	            	rpc error: code = NotFound desc = rule "12c38328-8077-4629-ade9-a4831db41279" not found
        	Test:       	TestReadOnly/[Protocol_"grpc";_Namespace_"default";_Authentication_K8sAuth]/Evaluation/Variant/match_no_distributions
```

This fixes `GetEvaluationDistributions` to retun an empty set, instead of rule not found when a rule is defined with no distirbutions.