### PR TITLE
feat: logout redirect to cloud issuer

### DIFF
--- a/cmd/flipt/cloud.go
+++ b/cmd/flipt/cloud.go
@@ -151,7 +151,7 @@ func (c *cloudCommand) login(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("waiting for token: %w", err)
 	}
 
-	if err := flow.Close(); err != nil {
+	if err := flow.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 		return fmt.Errorf("closing flow: %w", err)
 	}
 

--- a/internal/server/authn/middleware/grpc/middleware.go
+++ b/internal/server/authn/middleware/grpc/middleware.go
@@ -212,6 +212,10 @@ func JWTAuthenticationInterceptor(logger *zap.Logger, validator jwt.Validator, e
 			}
 		}
 
+		if iss, ok := jwtClaims["iss"].(string); ok {
+			metadata["io.flipt.auth.jwt.issuer"] = iss
+		}
+
 		auth := &authrpc.Authentication{
 			Method:   authrpc.Method_METHOD_JWT,
 			Metadata: metadata,

--- a/internal/server/authn/middleware/grpc/middleware_test.go
+++ b/internal/server/authn/middleware/grpc/middleware_test.go
@@ -71,7 +71,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 			name: "successful authentication",
 			metadataFunc: func() metadata.MD {
 				claims := map[string]interface{}{
-					"iss": "https://flipt.io/",
+					"iss": "flipt.io",
 					"aud": "flipt",
 					"sub": "sunglasses",
 					"iat": nowUnix,
@@ -84,7 +84,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 				}
 			},
 			expectedJWT: jwt.Expected{
-				Issuer:    "https://flipt.io/",
+				Issuer:    "flipt.io",
 				Audiences: []string{"flipt"},
 				Subject:   "sunglasses",
 			},
@@ -93,7 +93,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 			name: "successful authentication (with custom user claims)",
 			metadataFunc: func() metadata.MD {
 				claims := map[string]interface{}{
-					"iss": "https://flipt.io/",
+					"iss": "flipt.io",
 					"aud": "flipt",
 					"iat": nowUnix,
 					"exp": futureUnix,
@@ -111,7 +111,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 				}
 			},
 			expectedJWT: jwt.Expected{
-				Issuer:    "https://flipt.io/",
+				Issuer:    "flipt.io",
 				Audiences: []string{"flipt"},
 			},
 			expectedMetadata: map[string]string{
@@ -119,13 +119,14 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 				"io.flipt.auth.jwt.email":   "email",
 				"io.flipt.auth.jwt.picture": "image",
 				"io.flipt.auth.jwt.name":    "name",
+				"io.flipt.auth.jwt.issuer":  "flipt.io",
 			},
 		},
 		{
 			name: "invalid issuer",
 			metadataFunc: func() metadata.MD {
 				claims := map[string]interface{}{
-					"iss": "https://foo.com/",
+					"iss": "foo.com",
 					"iat": nowUnix,
 					"exp": futureUnix,
 				}
@@ -136,7 +137,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 				}
 			},
 			expectedJWT: jwt.Expected{
-				Issuer: "https://flipt.io/",
+				Issuer: "flipt.io",
 			},
 			expectedErr: ErrUnauthenticated,
 		},
@@ -144,7 +145,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 			name: "invalid subject",
 			metadataFunc: func() metadata.MD {
 				claims := map[string]interface{}{
-					"iss": "https://flipt.io/",
+					"iss": "flipt.io",
 					"iat": nowUnix,
 					"exp": futureUnix,
 					"sub": "bar",
@@ -156,7 +157,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 				}
 			},
 			expectedJWT: jwt.Expected{
-				Issuer:  "https://flipt.io/",
+				Issuer:  "flipt.io",
 				Subject: "flipt",
 			},
 			expectedErr: ErrUnauthenticated,
@@ -165,7 +166,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 			name: "invalid audience",
 			metadataFunc: func() metadata.MD {
 				claims := map[string]interface{}{
-					"iss": "https://flipt.io/",
+					"iss": "flipt.io",
 					"iat": nowUnix,
 					"exp": futureUnix,
 					"aud": "bar",
@@ -177,7 +178,7 @@ func TestJWTAuthenticationInterceptor(t *testing.T) {
 				}
 			},
 			expectedJWT: jwt.Expected{
-				Issuer:    "https://flipt.io/",
+				Issuer:    "flipt.io",
 				Audiences: []string{"flipt"},
 			},
 			expectedErr: ErrUnauthenticated,

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -39,9 +39,7 @@ export default function Header(props: HeaderProps) {
           {info && info.updateAvailable && <Notifications info={info} />}
 
           {/* user profile */}
-          {session && session.self && (
-            <UserProfile metadata={session.self.metadata} />
-          )}
+          {session && session.self && <UserProfile session={session.self} />}
         </div>
       </div>
     </div>

--- a/ui/src/types/auth/Github.ts
+++ b/ui/src/types/auth/Github.ts
@@ -16,5 +16,6 @@ export interface IAuthMethodGithubMetadata {
 }
 
 export interface IAuthGithubInternal extends IAuth {
+  method: 'METHOD_GITHUB';
   metadata: IAuthMethodGithubMetadata;
 }

--- a/ui/src/types/auth/JWT.ts
+++ b/ui/src/types/auth/JWT.ts
@@ -12,8 +12,10 @@ export interface IAuthMethodJWTMetadata {
   'io.flipt.auth.jwt.email'?: string;
   'io.flipt.auth.jwt.name'?: string;
   'io.flipt.auth.jwt.picture'?: string;
+  'io.flipt.auth.jwt.issuer'?: string;
 }
 
 export interface IAuthJWTInternal extends IAuth {
+  method: 'METHOD_JWT';
   metadata: IAuthMethodJWTMetadata;
 }

--- a/ui/src/types/auth/OIDC.ts
+++ b/ui/src/types/auth/OIDC.ts
@@ -22,5 +22,6 @@ export interface IAuthMethodOIDCMetadata {
 }
 
 export interface IAuthOIDCInternal extends IAuth {
+  method: 'METHOD_OIDC';
   metadata: IAuthMethodOIDCMetadata;
 }


### PR DESCRIPTION
Fixes: FLI-1019
Fixes: FLI-894

Uses the `iss` property in the JWT to redirect the user to cloud if they are logged in using cloud method on logout

![2024-05-14 10 54 01](https://github.com/flipt-io/flipt/assets/209477/79754ed0-149e-4bda-898b-06cdc00ff90a)
