### PR TITLE
fix: nightly and snapshot builds (mage)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Install Mage
         uses: magefile/mage-action@v3
         with:
+          # mac build currently doesn't exist for v1.15.0 https://github.com/magefile/mage/issues/481
+          version: v1.14.0
           install-only: true
 
       - name: Prep Build

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Install Mage
         uses: magefile/mage-action@v3
         with:
+          # mac build currently doesn't exist for v1.15.0 https://github.com/magefile/mage/issues/481
+          version: v1.14.0
           install-only: true
 
       - name: Prep Build


### PR DESCRIPTION
Fix nightly and snapshot workflows as mage doesn't exist for v1.15 on darwin

https://github.com/flipt-io/flipt/actions/runs/8886339670/job/24399582939#step:8:10

https://github.com/magefile/mage/issues/481