### PR TITLE
feat(fs/git): add support for cloning target repository to the local filesystem

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -676,7 +676,7 @@ func TestLoad(t *testing.T) {
 					Type: GitStorageType,
 					Git: &Git{
 						Backend: GitBackend{
-							Type: GotBackendMemory,
+							Type: GitBackendMemory,
 						},
 						Repository:   "https://github.com/flipt-io/flipt.git",
 						Ref:          "production",
@@ -821,7 +821,7 @@ func TestLoad(t *testing.T) {
 					Type: GitStorageType,
 					Git: &Git{
 						Backend: GitBackend{
-							Type: GotBackendMemory,
+							Type: GitBackendMemory,
 						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,
@@ -841,7 +841,7 @@ func TestLoad(t *testing.T) {
 					Type: GitStorageType,
 					Git: &Git{
 						Backend: GitBackend{
-							Type: GotBackendMemory,
+							Type: GitBackendMemory,
 						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,
@@ -862,7 +862,7 @@ func TestLoad(t *testing.T) {
 					Type: GitStorageType,
 					Git: &Git{
 						Backend: GitBackend{
-							Type: GotBackendMemory,
+							Type: GitBackendMemory,
 						},
 						Ref:          "main",
 						RefType:      GitRefTypeSemver,
@@ -934,7 +934,7 @@ func TestLoad(t *testing.T) {
 					Type: GitStorageType,
 					Git: &Git{
 						Backend: GitBackend{
-							Type: GotBackendMemory,
+							Type: GitBackendMemory,
 						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -675,8 +675,8 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
-						Storage: GitStorageConfig{
-							Type: GitStorageMemory,
+						Backend: GitBackend{
+							Type: GotBackendMemory,
 						},
 						Repository:   "https://github.com/flipt-io/flipt.git",
 						Ref:          "production",
@@ -820,8 +820,8 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
-						Storage: GitStorageConfig{
-							Type: GitStorageMemory,
+						Backend: GitBackend{
+							Type: GotBackendMemory,
 						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,
@@ -840,8 +840,8 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
-						Storage: GitStorageConfig{
-							Type: GitStorageMemory,
+						Backend: GitBackend{
+							Type: GotBackendMemory,
 						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,
@@ -861,8 +861,8 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
-						Storage: GitStorageConfig{
-							Type: GitStorageMemory,
+						Backend: GitBackend{
+							Type: GotBackendMemory,
 						},
 						Ref:          "main",
 						RefType:      GitRefTypeSemver,
@@ -876,14 +876,14 @@ func TestLoad(t *testing.T) {
 		},
 		{
 			name: "git config provided with ref_type",
-			path: "./testdata/storage/git_provided_with_storage_type.yml",
+			path: "./testdata/storage/git_provided_with_backend_type.yml",
 			expected: func() *Config {
 				cfg := Default()
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
-						Storage: GitStorageConfig{
-							Type: GitStorageFilesystem,
+						Backend: GitBackend{
+							Type: GitBackendFilesystem,
 							Path: "/path/to/gitdir",
 						},
 						Ref:          "main",
@@ -933,8 +933,8 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
-						Storage: GitStorageConfig{
-							Type: GitStorageMemory,
+						Backend: GitBackend{
+							Type: GotBackendMemory,
 						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -675,6 +675,9 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
+						Storage: GitStorageConfig{
+							Type: GitStorageMemory,
+						},
 						Repository:   "https://github.com/flipt-io/flipt.git",
 						Ref:          "production",
 						RefType:      GitRefTypeStatic,
@@ -817,6 +820,9 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
+						Storage: GitStorageConfig{
+							Type: GitStorageMemory,
+						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,
 						Repository:   "git@github.com:foo/bar.git",
@@ -834,6 +840,9 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
+						Storage: GitStorageConfig{
+							Type: GitStorageMemory,
+						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,
 						Repository:   "git@github.com:foo/bar.git",
@@ -852,10 +861,34 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
+						Storage: GitStorageConfig{
+							Type: GitStorageMemory,
+						},
 						Ref:          "main",
 						RefType:      GitRefTypeSemver,
 						Repository:   "git@github.com:foo/bar.git",
 						Directory:    "baz",
+						PollInterval: 30 * time.Second,
+					},
+				}
+				return cfg
+			},
+		},
+		{
+			name: "git config provided with ref_type",
+			path: "./testdata/storage/git_provided_with_storage_type.yml",
+			expected: func() *Config {
+				cfg := Default()
+				cfg.Storage = StorageConfig{
+					Type: GitStorageType,
+					Git: &Git{
+						Storage: GitStorageConfig{
+							Type: GitStorageFilesystem,
+							Path: "/path/to/gitdir",
+						},
+						Ref:          "main",
+						RefType:      GitRefTypeStatic,
+						Repository:   "git@github.com:foo/bar.git",
 						PollInterval: 30 * time.Second,
 					},
 				}
@@ -900,6 +933,9 @@ func TestLoad(t *testing.T) {
 				cfg.Storage = StorageConfig{
 					Type: GitStorageType,
 					Git: &Git{
+						Storage: GitStorageConfig{
+							Type: GitStorageMemory,
+						},
 						Ref:          "main",
 						RefType:      GitRefTypeStatic,
 						Repository:   "git@github.com:foo/bar.git",

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -191,7 +191,7 @@ func (g *Git) validate() error {
 type GitBackendType string
 
 const (
-	GotBackendMemory     = GitBackendType("memory")
+	GitBackendMemory     = GitBackendType("memory")
 	GitBackendFilesystem = GitBackendType("filesystem")
 )
 

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -48,6 +48,7 @@ func (c *StorageConfig) setDefaults(v *viper.Viper) error {
 	case string(LocalStorageType):
 		v.SetDefault("storage.local.path", ".")
 	case string(GitStorageType):
+		v.SetDefault("storage.git.storage.type", "memory")
 		v.SetDefault("storage.git.ref", "main")
 		v.SetDefault("storage.git.ref_type", "static")
 		v.SetDefault("storage.git.poll_interval", "30s")
@@ -163,15 +164,16 @@ const (
 
 // Git contains configuration for referencing a git repository.
 type Git struct {
-	Repository      string         `json:"repository,omitempty" mapstructure:"repository" yaml:"repository,omitempty"`
-	Ref             string         `json:"ref,omitempty" mapstructure:"ref" yaml:"ref,omitempty"`
-	RefType         GitRefType     `json:"refType,omitempty" mapstructure:"ref_type" yaml:"ref_type,omitempty"`
-	Directory       string         `json:"directory,omitempty" mapstructure:"directory" yaml:"directory,omitempty"`
-	CaCertBytes     string         `json:"-" mapstructure:"ca_cert_bytes" yaml:"-" `
-	CaCertPath      string         `json:"-" mapstructure:"ca_cert_path" yaml:"-" `
-	InsecureSkipTLS bool           `json:"-" mapstructure:"insecure_skip_tls" yaml:"-"`
-	PollInterval    time.Duration  `json:"pollInterval,omitempty" mapstructure:"poll_interval" yaml:"poll_interval,omitempty"`
-	Authentication  Authentication `json:"-" mapstructure:"authentication,omitempty" yaml:"-"`
+	Repository      string           `json:"repository,omitempty" mapstructure:"repository" yaml:"repository,omitempty"`
+	Storage         GitStorageConfig `json:"storage,omitempty" mapstructure:"storage" yaml:"storage,omitempty"`
+	Ref             string           `json:"ref,omitempty" mapstructure:"ref" yaml:"ref,omitempty"`
+	RefType         GitRefType       `json:"refType,omitempty" mapstructure:"ref_type" yaml:"ref_type,omitempty"`
+	Directory       string           `json:"directory,omitempty" mapstructure:"directory" yaml:"directory,omitempty"`
+	CaCertBytes     string           `json:"-" mapstructure:"ca_cert_bytes" yaml:"-"`
+	CaCertPath      string           `json:"-" mapstructure:"ca_cert_path" yaml:"-"`
+	InsecureSkipTLS bool             `json:"-" mapstructure:"insecure_skip_tls" yaml:"-"`
+	PollInterval    time.Duration    `json:"pollInterval,omitempty" mapstructure:"poll_interval" yaml:"poll_interval,omitempty"`
+	Authentication  Authentication   `json:"-" mapstructure:"authentication,omitempty" yaml:"-"`
 }
 
 func (g *Git) validate() error {
@@ -184,6 +186,18 @@ func (g *Git) validate() error {
 	}
 
 	return nil
+}
+
+type GitStorage string
+
+const (
+	GitStorageMemory     = GitStorage("memory")
+	GitStorageFilesystem = GitStorage("filesystem")
+)
+
+type GitStorageConfig struct {
+	Type GitStorage `json:"type,omitempty" mapstructure:"type" yaml:"type,omitempty"`
+	Path string     `json:"path,omitempty" mapstructure:"path" yaml:"path,omitempty"`
 }
 
 // Object contains configuration of readonly object storage.

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -48,7 +48,7 @@ func (c *StorageConfig) setDefaults(v *viper.Viper) error {
 	case string(LocalStorageType):
 		v.SetDefault("storage.local.path", ".")
 	case string(GitStorageType):
-		v.SetDefault("storage.git.storage.type", "memory")
+		v.SetDefault("storage.git.backend.type", "memory")
 		v.SetDefault("storage.git.ref", "main")
 		v.SetDefault("storage.git.ref_type", "static")
 		v.SetDefault("storage.git.poll_interval", "30s")
@@ -164,16 +164,16 @@ const (
 
 // Git contains configuration for referencing a git repository.
 type Git struct {
-	Repository      string           `json:"repository,omitempty" mapstructure:"repository" yaml:"repository,omitempty"`
-	Storage         GitStorageConfig `json:"storage,omitempty" mapstructure:"storage" yaml:"storage,omitempty"`
-	Ref             string           `json:"ref,omitempty" mapstructure:"ref" yaml:"ref,omitempty"`
-	RefType         GitRefType       `json:"refType,omitempty" mapstructure:"ref_type" yaml:"ref_type,omitempty"`
-	Directory       string           `json:"directory,omitempty" mapstructure:"directory" yaml:"directory,omitempty"`
-	CaCertBytes     string           `json:"-" mapstructure:"ca_cert_bytes" yaml:"-"`
-	CaCertPath      string           `json:"-" mapstructure:"ca_cert_path" yaml:"-"`
-	InsecureSkipTLS bool             `json:"-" mapstructure:"insecure_skip_tls" yaml:"-"`
-	PollInterval    time.Duration    `json:"pollInterval,omitempty" mapstructure:"poll_interval" yaml:"poll_interval,omitempty"`
-	Authentication  Authentication   `json:"-" mapstructure:"authentication,omitempty" yaml:"-"`
+	Repository      string         `json:"repository,omitempty" mapstructure:"repository" yaml:"repository,omitempty"`
+	Backend         GitBackend     `json:"backend,omitempty" mapstructure:"backend" yaml:"backend,omitempty"`
+	Ref             string         `json:"ref,omitempty" mapstructure:"ref" yaml:"ref,omitempty"`
+	RefType         GitRefType     `json:"refType,omitempty" mapstructure:"ref_type" yaml:"ref_type,omitempty"`
+	Directory       string         `json:"directory,omitempty" mapstructure:"directory" yaml:"directory,omitempty"`
+	CaCertBytes     string         `json:"-" mapstructure:"ca_cert_bytes" yaml:"-"`
+	CaCertPath      string         `json:"-" mapstructure:"ca_cert_path" yaml:"-"`
+	InsecureSkipTLS bool           `json:"-" mapstructure:"insecure_skip_tls" yaml:"-"`
+	PollInterval    time.Duration  `json:"pollInterval,omitempty" mapstructure:"poll_interval" yaml:"poll_interval,omitempty"`
+	Authentication  Authentication `json:"-" mapstructure:"authentication,omitempty" yaml:"-"`
 }
 
 func (g *Git) validate() error {
@@ -188,16 +188,16 @@ func (g *Git) validate() error {
 	return nil
 }
 
-type GitStorage string
+type GitBackendType string
 
 const (
-	GitStorageMemory     = GitStorage("memory")
-	GitStorageFilesystem = GitStorage("filesystem")
+	GotBackendMemory     = GitBackendType("memory")
+	GitBackendFilesystem = GitBackendType("filesystem")
 )
 
-type GitStorageConfig struct {
-	Type GitStorage `json:"type,omitempty" mapstructure:"type" yaml:"type,omitempty"`
-	Path string     `json:"path,omitempty" mapstructure:"path" yaml:"path,omitempty"`
+type GitBackend struct {
+	Type GitBackendType `json:"type,omitempty" mapstructure:"type" yaml:"type,omitempty"`
+	Path string         `json:"path,omitempty" mapstructure:"path" yaml:"path,omitempty"`
 }
 
 // Object contains configuration of readonly object storage.

--- a/internal/config/testdata/storage/git_provided_with_backend_type.yml
+++ b/internal/config/testdata/storage/git_provided_with_backend_type.yml
@@ -2,6 +2,6 @@ storage:
   type: git
   git:
     repository: "git@github.com:foo/bar.git"
-    storage:
+    backend:
       type: "filesystem"
       path: "/path/to/gitdir"

--- a/internal/config/testdata/storage/git_provided_with_storage_type.yml
+++ b/internal/config/testdata/storage/git_provided_with_storage_type.yml
@@ -1,0 +1,7 @@
+storage:
+  type: git
+  git:
+    repository: "git@github.com:foo/bar.git"
+    storage:
+      type: "filesystem"
+      path: "/path/to/gitdir"

--- a/internal/storage/fs/store/store.go
+++ b/internal/storage/fs/store/store.go
@@ -32,6 +32,7 @@ import (
 func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (_ storage.Store, err error) {
 	switch cfg.Storage.Type {
 	case config.GitStorageType:
+		storage := cfg.Storage.Git
 		opts := []containers.Option[git.SnapshotStore]{
 			git.WithRef(cfg.Storage.Git.Ref),
 			git.WithPollOptions(
@@ -41,21 +42,37 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (_ st
 			git.WithDirectory(cfg.Storage.Git.Directory),
 		}
 
-		if cfg.Storage.Git.RefType == config.GitRefTypeSemver {
+		if storage.RefType == config.GitRefTypeSemver {
 			opts = append(opts, git.WithSemverResolver())
 		}
 
-		if cfg.Storage.Git.CaCertBytes != "" {
-			opts = append(opts, git.WithCABundle([]byte(cfg.Storage.Git.CaCertBytes)))
-		} else if cfg.Storage.Git.CaCertPath != "" {
-			if bytes, err := os.ReadFile(cfg.Storage.Git.CaCertPath); err == nil {
+		switch storage.Storage.Type {
+		case config.GitStorageFilesystem:
+			path := storage.Storage.Path
+			if path == "" {
+				path, err = os.MkdirTemp(os.TempDir(), "flipt-git-*")
+				if err != nil {
+					return nil, fmt.Errorf("making tempory directory for git storage: %w", err)
+				}
+			}
+
+			opts = append(opts, git.WithFilesystemStorage(path))
+			logger = logger.With(zap.String("git_storage_type", "filesystem"), zap.String("git_storage_path", path))
+		case config.GitStorageMemory:
+			logger = logger.With(zap.String("git_storage_type", "memory"))
+		}
+
+		if storage.CaCertBytes != "" {
+			opts = append(opts, git.WithCABundle([]byte(storage.CaCertBytes)))
+		} else if storage.CaCertPath != "" {
+			if bytes, err := os.ReadFile(storage.CaCertPath); err == nil {
 				opts = append(opts, git.WithCABundle(bytes))
 			} else {
 				return nil, err
 			}
 		}
 
-		auth := cfg.Storage.Git.Authentication
+		auth := storage.Authentication
 		switch {
 		case auth.BasicAuth != nil:
 			opts = append(opts, git.WithAuth(&http.BasicAuth{
@@ -95,7 +112,7 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (_ st
 			opts = append(opts, git.WithAuth(method))
 		}
 
-		snapStore, err := git.NewSnapshotStore(ctx, logger, cfg.Storage.Git.Repository, opts...)
+		snapStore, err := git.NewSnapshotStore(ctx, logger, storage.Repository, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/storage/fs/store/store.go
+++ b/internal/storage/fs/store/store.go
@@ -46,9 +46,9 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (_ st
 			opts = append(opts, git.WithSemverResolver())
 		}
 
-		switch storage.Storage.Type {
-		case config.GitStorageFilesystem:
-			path := storage.Storage.Path
+		switch storage.Backend.Type {
+		case config.GitBackendFilesystem:
+			path := storage.Backend.Path
 			if path == "" {
 				path, err = os.MkdirTemp(os.TempDir(), "flipt-git-*")
 				if err != nil {
@@ -58,7 +58,7 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (_ st
 
 			opts = append(opts, git.WithFilesystemStorage(path))
 			logger = logger.With(zap.String("git_storage_type", "filesystem"), zap.String("git_storage_path", path))
-		case config.GitStorageMemory:
+		case config.GotBackendMemory:
 			logger = logger.With(zap.String("git_storage_type", "memory"))
 		}
 

--- a/internal/storage/fs/store/store.go
+++ b/internal/storage/fs/store/store.go
@@ -58,7 +58,7 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (_ st
 
 			opts = append(opts, git.WithFilesystemStorage(path))
 			logger = logger.With(zap.String("git_storage_type", "filesystem"), zap.String("git_storage_path", path))
-		case config.GotBackendMemory:
+		case config.GitBackendMemory:
 			logger = logger.With(zap.String("git_storage_type", "memory"))
 		}
 


### PR DESCRIPTION
This adds support for having the Git backend clone to local disk.
The motivation is to offload some of the memory pressure for large repositories onto disk.
This way memory doesn't have to scale in proportion to repository size, with the tradeoff that initial clone and fetch times may be increased due to I/O on local disk.

```yaml
storage:
  type: git
  git:
    backend:
      type: filesytem
      path: /path/to/dir # optional: will create a tempdir in systems temp dir location otherwise
```