### PR TITLE
refactor(server/authz): make policy and data external dependencies

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -116,14 +116,18 @@ import "strings"
 
 	#authorization: {
 		#authorizationSource: {
-			backend: "filesystem"
-			filesystem: path: string
+			backend: "local"
+			local: path: string
+			poll_duration?: =~#duration
 		}
 
-		required?:      bool | *false
-		policy?:        #authorizationSource
-		data?:          #authorizationSource
-		poll_duration?: =~#duration | "30s"
+		required?: bool | *false
+		policy?: #authorizationSource & {
+			poll_duration: =~#duration | *"5m"
+		}
+		data?: #authorizationSource & {
+			poll_duration: =~#duration | *"30s"
+		}
 	}
 
 	#cache: {

--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -115,7 +115,15 @@ import "strings"
 	}
 
 	#authorization: {
-		required?: bool | *false
+		#authorizationSource: {
+			backend: "filesystem"
+			filesystem: path: string
+		}
+
+		required?:      bool | *false
+		policy?:        #authorizationSource
+		data?:          #authorizationSource
+		poll_duration?: =~#duration | "30s"
 	}
 
 	#cache: {
@@ -144,9 +152,9 @@ import "strings"
 	}
 
 	#cloud: {
-		host?: string | *"flipt.cloud"
-		organization?:  string
-		instance?:  string
+		host?:         string | *"flipt.cloud"
+		organization?: string
+		instance?:     string
 		authentication?: {
 			api_key?: string
 		}
@@ -349,7 +357,7 @@ import "strings"
 					body: string
 					headers?: [string]: string
 				}]
-			},
+			}
 			cloud?: {
 				enabled?: bool | *false
 			}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -325,6 +325,38 @@
         "required": {
           "type": "boolean",
           "default": false
+        },
+        "policy": {
+          "type": ["object", "null"],
+          "$ref": "#/definitions/authorization/$defs/authorization_source"
+        },
+        "data": {
+          "type": ["object", "null"],
+          "$ref": "#/definitions/authorization/$defs/authorization_source"
+        },
+        "poll_duration": {
+          "type": "string",
+          "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
+          "default": "30s"
+        }
+      },
+      "$defs": {
+        "authorization_source": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "backend": {
+              "type": "string",
+              "enum": ["filesystem"]
+            },
+            "filesystem": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "path": {"type": "string"}
+              }
+            }
+          }
         }
       }
     },

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -333,11 +333,6 @@
         "data": {
           "type": ["object", "null"],
           "$ref": "#/definitions/authorization/$defs/authorization_source"
-        },
-        "poll_duration": {
-          "type": "string",
-          "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
-          "default": "30s"
         }
       },
       "$defs": {
@@ -347,14 +342,18 @@
           "properties": {
             "backend": {
               "type": "string",
-              "enum": ["filesystem"]
+              "enum": ["local"]
             },
-            "filesystem": {
+            "local": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
                 "path": {"type": "string"}
               }
+            },
+            "poll_duration": {
+              "type": "string",
+              "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$"
             }
           }
         }

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -359,7 +359,7 @@ func NewGRPCServer(
 		}
 
 		engineOpts := []containers.Option[authz.Engine]{
-			authz.WithPollDuration(cfg.Authorization.PollDuration),
+			authz.WithPollDuration(cfg.Authorization.Policy.PollDuration),
 		}
 
 		if cfg.Authorization.Data != nil {
@@ -367,6 +367,7 @@ func NewGRPCServer(
 			case config.AuthorizationBackendLocal:
 				engineOpts = append(engineOpts, authz.WithDataSource(
 					filesystem.DataSourceFromPath(cfg.Authorization.Data.Local.Path),
+					cfg.Authorization.Data.PollDuration,
 				))
 			default:
 				return nil, fmt.Errorf("unexpected authz data backend type: %q", cfg.Authorization.Data.Backend)

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -364,9 +364,9 @@ func NewGRPCServer(
 
 		if cfg.Authorization.Data != nil {
 			switch cfg.Authorization.Data.Backend {
-			case config.AuthorizationBackendFilesystem:
+			case config.AuthorizationBackendLocal:
 				engineOpts = append(engineOpts, authz.WithDataSource(
-					filesystem.DataSourceFromPath(cfg.Authorization.Data.Filesystem.Path),
+					filesystem.DataSourceFromPath(cfg.Authorization.Data.Local.Path),
 				))
 			default:
 				return nil, fmt.Errorf("unexpected authz data backend type: %q", cfg.Authorization.Data.Backend)
@@ -375,8 +375,8 @@ func NewGRPCServer(
 
 		var source authz.PolicySource
 		switch cfg.Authorization.Policy.Backend {
-		case config.AuthorizationBackendFilesystem:
-			source = filesystem.PolicySourceFromPath(cfg.Authorization.Policy.Filesystem.Path)
+		case config.AuthorizationBackendLocal:
+			source = filesystem.PolicySourceFromPath(cfg.Authorization.Policy.Local.Path)
 		default:
 			return nil, fmt.Errorf("unexpected authz policy backend type: %q", cfg.Authorization.Policy.Backend)
 		}

--- a/internal/config/authorization.go
+++ b/internal/config/authorization.go
@@ -1,6 +1,12 @@
 package config
 
-import "github.com/spf13/viper"
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/viper"
+)
 
 var (
 	_ defaulter = (*AuthorizationConfig)(nil)
@@ -10,13 +16,76 @@ var (
 type AuthorizationConfig struct {
 	// Required designates whether authorization credentials are validated.
 	// If required == true, then authorization is required for all API endpoints.
-	Required bool `json:"required" mapstructure:"required" yaml:"required"`
+	Required     bool                       `json:"required,omitempty" mapstructure:"required" yaml:"required,omitempty"`
+	Policy       *AuthorizationSourceConfig `json:"policy,omitempty" mapstructure:"policy" yaml:"policy,omitempty"`
+	Data         *AuthorizationSourceConfig `json:"data,omitempty" mapstructure:"data" yaml:"data,omitempty"`
+	PollDuration time.Duration              `json:"pollDuration,omitempty" mapstructure:"poll_duration" yaml:"poll_duration,omitempty"`
 }
 
 func (c *AuthorizationConfig) setDefaults(v *viper.Viper) error {
 	v.SetDefault("authorization", map[string]interface{}{
-		"required": false,
+		"required":      false,
+		"poll_duration": "30s",
 	})
 
 	return nil
+}
+
+func (c *AuthorizationConfig) validate() error {
+	if c.Required {
+		if c.Policy == nil {
+			return errors.New("authorization: policy source must be configured")
+		}
+
+		if err := c.Policy.validate(); err != nil {
+			return fmt.Errorf("authorization: policy: %w", err)
+		}
+
+		if err := c.Data.validate(); err != nil {
+			return fmt.Errorf("authorization: data: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type AuthorizationSourceConfig struct {
+	Backend    AuthorizationBackend          `json:"backend,omitempty" mapstructure:"backend" yaml:"backend,omitempty"`
+	Filesystem AuthorizationFilesystemConfig `json:"filesystem,omitempty" mapstructure:"filesystem" yaml:"filesystem,omitempty"`
+}
+
+func (a *AuthorizationSourceConfig) validate() (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("source: %w", err)
+		}
+	}()
+
+	if a == nil {
+		return nil
+	}
+
+	if a.Backend != AuthorizationBackendFilesystem {
+		return errors.New("backend must be one of [filesystem]")
+	}
+
+	if a.Filesystem.Path == "" {
+		return errors.New("filesystem: path must be non-empty string")
+	}
+
+	return nil
+}
+
+// AuthorizationBackend configures the data source backend for
+// additional data supplied to the policy evaluation engine
+type AuthorizationBackend string
+
+const (
+	AuthorizationBackendFilesystem = "filesystem"
+)
+
+// AuthorizationFilesystemConfig configures the filesystem backend source
+// for the authorization evaluation engines policies and data
+type AuthorizationFilesystemConfig struct {
+	Path string `json:"path,omitempty" mapstructure:"path" yaml:"path,omitempty"`
 }

--- a/internal/config/authorization.go
+++ b/internal/config/authorization.go
@@ -85,6 +85,10 @@ func (a *AuthorizationSourceConfig) validate() (err error) {
 		return errors.New("local: path must be non-empty string")
 	}
 
+	if a.PollDuration <= 0 {
+		return errors.New("local: poll_duration must be non-zero")
+	}
+
 	return nil
 }
 

--- a/internal/config/authorization.go
+++ b/internal/config/authorization.go
@@ -17,8 +17,8 @@ type AuthorizationConfig struct {
 	// Required designates whether authorization credentials are validated.
 	// If required == true, then authorization is required for all API endpoints.
 	Required     bool                       `json:"required,omitempty" mapstructure:"required" yaml:"required,omitempty"`
-	Policy       *AuthorizationSourceConfig `json:"policy,omitempty" mapstructure:"policy" yaml:"policy,omitempty"`
-	Data         *AuthorizationSourceConfig `json:"data,omitempty" mapstructure:"data" yaml:"data,omitempty"`
+	Policy       *AuthorizationSourceConfig `json:"policy,omitempty" mapstructure:"policy,omitempty" yaml:"policy,omitempty"`
+	Data         *AuthorizationSourceConfig `json:"data,omitempty" mapstructure:"data,omitempty" yaml:"data,omitempty"`
 	PollDuration time.Duration              `json:"pollDuration,omitempty" mapstructure:"poll_duration" yaml:"poll_duration,omitempty"`
 }
 

--- a/internal/config/authorization.go
+++ b/internal/config/authorization.go
@@ -16,17 +16,28 @@ var (
 type AuthorizationConfig struct {
 	// Required designates whether authorization credentials are validated.
 	// If required == true, then authorization is required for all API endpoints.
-	Required     bool                       `json:"required,omitempty" mapstructure:"required" yaml:"required,omitempty"`
-	Policy       *AuthorizationSourceConfig `json:"policy,omitempty" mapstructure:"policy,omitempty" yaml:"policy,omitempty"`
-	Data         *AuthorizationSourceConfig `json:"data,omitempty" mapstructure:"data,omitempty" yaml:"data,omitempty"`
-	PollDuration time.Duration              `json:"pollDuration,omitempty" mapstructure:"poll_duration" yaml:"poll_duration,omitempty"`
+	Required bool                       `json:"required,omitempty" mapstructure:"required" yaml:"required,omitempty"`
+	Policy   *AuthorizationSourceConfig `json:"policy,omitempty" mapstructure:"policy,omitempty" yaml:"policy,omitempty"`
+	Data     *AuthorizationSourceConfig `json:"data,omitempty" mapstructure:"data,omitempty" yaml:"data,omitempty"`
 }
 
 func (c *AuthorizationConfig) setDefaults(v *viper.Viper) error {
-	v.SetDefault("authorization", map[string]interface{}{
-		"required":      false,
-		"poll_duration": "30s",
-	})
+	auth := map[string]any{"required": false}
+	if v.GetBool("authorization.required") {
+		auth["policy"] = map[string]any{
+			"backend":       "local",
+			"poll_duration": "5m",
+		}
+
+		if v.GetString("authorization.data.local.path") != "" {
+			auth["data"] = map[string]any{
+				"backend":       "local",
+				"poll_duration": "30s",
+			}
+		}
+
+		v.SetDefault("authorization", auth)
+	}
 
 	return nil
 }
@@ -50,8 +61,9 @@ func (c *AuthorizationConfig) validate() error {
 }
 
 type AuthorizationSourceConfig struct {
-	Backend    AuthorizationBackend          `json:"backend,omitempty" mapstructure:"backend" yaml:"backend,omitempty"`
-	Filesystem AuthorizationFilesystemConfig `json:"filesystem,omitempty" mapstructure:"filesystem" yaml:"filesystem,omitempty"`
+	Backend      AuthorizationBackend      `json:"backend,omitempty" mapstructure:"backend" yaml:"backend,omitempty"`
+	Local        *AuthorizationLocalConfig `json:"local,omitempty" mapstructure:"local,omitempty" yaml:"local,omitempty"`
+	PollDuration time.Duration             `json:"pollDuration,omitempty" mapstructure:"poll_duration" yaml:"poll_duration,omitempty"`
 }
 
 func (a *AuthorizationSourceConfig) validate() (err error) {
@@ -65,12 +77,12 @@ func (a *AuthorizationSourceConfig) validate() (err error) {
 		return nil
 	}
 
-	if a.Backend != AuthorizationBackendFilesystem {
-		return errors.New("backend must be one of [filesystem]")
+	if a.Backend != AuthorizationBackendLocal {
+		return errors.New("backend must be one of [local]")
 	}
 
-	if a.Filesystem.Path == "" {
-		return errors.New("filesystem: path must be non-empty string")
+	if a.Local == nil || a.Local.Path == "" {
+		return errors.New("local: path must be non-empty string")
 	}
 
 	return nil
@@ -81,11 +93,11 @@ func (a *AuthorizationSourceConfig) validate() (err error) {
 type AuthorizationBackend string
 
 const (
-	AuthorizationBackendFilesystem = "filesystem"
+	AuthorizationBackendLocal = "local"
 )
 
-// AuthorizationFilesystemConfig configures the filesystem backend source
+// AuthorizationLocalConfig configures the local backend source
 // for the authorization evaluation engines policies and data
-type AuthorizationFilesystemConfig struct {
+type AuthorizationLocalConfig struct {
 	Path string `json:"path,omitempty" mapstructure:"path" yaml:"path,omitempty"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -637,8 +637,6 @@ func Default() *Config {
 			},
 		},
 
-		Authorization: AuthorizationConfig{
-			PollDuration: 30 * time.Second,
-		},
+		Authorization: AuthorizationConfig{},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -636,5 +636,9 @@ func Default() *Config {
 				FlushPeriod: 10 * time.Second,
 			},
 		},
+
+		Authorization: AuthorizationConfig{
+			PollDuration: 30 * time.Second,
+		},
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -617,12 +617,12 @@ func TestLoad(t *testing.T) {
 				cfg.Authorization = AuthorizationConfig{
 					Required: true,
 					Policy: &AuthorizationSourceConfig{
-						Backend: AuthorizationBackendFilesystem,
-						Filesystem: AuthorizationFilesystemConfig{
+						Backend: AuthorizationBackendLocal,
+						Local: &AuthorizationLocalConfig{
 							Path: "/path/to/policy.rego",
 						},
+						PollDuration: 30 * time.Second,
 					},
-					PollDuration: 30 * time.Second,
 				}
 
 				cfg.Authentication = AuthenticationConfig{
@@ -860,18 +860,19 @@ func TestLoad(t *testing.T) {
 				cfg.Authorization = AuthorizationConfig{
 					Required: true,
 					Policy: &AuthorizationSourceConfig{
-						Backend: AuthorizationBackendFilesystem,
-						Filesystem: AuthorizationFilesystemConfig{
+						Backend: AuthorizationBackendLocal,
+						Local: &AuthorizationLocalConfig{
 							Path: "/path/to/policy.rego",
 						},
+						PollDuration: time.Minute,
 					},
 					Data: &AuthorizationSourceConfig{
-						Backend: AuthorizationBackendFilesystem,
-						Filesystem: AuthorizationFilesystemConfig{
+						Backend: AuthorizationBackendLocal,
+						Local: &AuthorizationLocalConfig{
 							Path: "/path/to/policy/data.json",
 						},
+						PollDuration: 30 * time.Second,
 					},
-					PollDuration: 30 * time.Second,
 				}
 
 				return cfg

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -614,7 +614,16 @@ func TestLoad(t *testing.T) {
 			expected: func() *Config {
 				cfg := Default()
 
-				cfg.Authorization.Required = true
+				cfg.Authorization = AuthorizationConfig{
+					Required: true,
+					Policy: &AuthorizationSourceConfig{
+						Backend: AuthorizationBackendFilesystem,
+						Filesystem: AuthorizationFilesystemConfig{
+							Path: "/path/to/policy.rego",
+						},
+					},
+					PollDuration: 30 * time.Second,
+				}
 
 				cfg.Authentication = AuthenticationConfig{
 					Required: true,
@@ -847,6 +856,24 @@ func TestLoad(t *testing.T) {
 						},
 					},
 				}
+
+				cfg.Authorization = AuthorizationConfig{
+					Required: true,
+					Policy: &AuthorizationSourceConfig{
+						Backend: AuthorizationBackendFilesystem,
+						Filesystem: AuthorizationFilesystemConfig{
+							Path: "/path/to/policy.rego",
+						},
+					},
+					Data: &AuthorizationSourceConfig{
+						Backend: AuthorizationBackendFilesystem,
+						Filesystem: AuthorizationFilesystemConfig{
+							Path: "/path/to/policy/data.json",
+						},
+					},
+					PollDuration: 30 * time.Second,
+				}
+
 				return cfg
 			},
 		},

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -110,10 +110,11 @@ authentication:
 authorization:
   required: true
   policy:
-    backend: filesystem
-    filesystem:
+    backend: local
+    local:
       path: "/path/to/policy.rego"
+    poll_duration: 1m
   data:
-    backend: filesystem
-    filesystem:
+    backend: local
+    local:
       path: "/path/to/policy/data.json"

--- a/internal/config/testdata/advanced.yml
+++ b/internal/config/testdata/advanced.yml
@@ -106,3 +106,14 @@ authentication:
       cleanup:
         interval: 2h
         grace_period: 48h
+
+authorization:
+  required: true
+  policy:
+    backend: filesystem
+    filesystem:
+      path: "/path/to/policy.rego"
+  data:
+    backend: filesystem
+    filesystem:
+      path: "/path/to/policy/data.json"

--- a/internal/config/testdata/authorization/all_authentication_methods_enabled.yml
+++ b/internal/config/testdata/authorization/all_authentication_methods_enabled.yml
@@ -41,3 +41,7 @@ authentication:
 
 authorization:
   required: true
+  policy:
+    backend: filesystem
+    filesystem:
+      path: "/path/to/policy.rego"

--- a/internal/config/testdata/authorization/all_authentication_methods_enabled.yml
+++ b/internal/config/testdata/authorization/all_authentication_methods_enabled.yml
@@ -42,6 +42,7 @@ authentication:
 authorization:
   required: true
   policy:
-    backend: filesystem
-    filesystem:
+    backend: local
+    local:
       path: "/path/to/policy.rego"
+    poll_duration: 30s

--- a/internal/config/testdata/marshal/yaml/default.yml
+++ b/internal/config/testdata/marshal/yaml/default.yml
@@ -48,6 +48,3 @@ db:
 meta:
   check_for_updates: true
   telemetry_enabled: true
-
-authorization:
-  poll_duration: 30s

--- a/internal/config/testdata/marshal/yaml/default.yml
+++ b/internal/config/testdata/marshal/yaml/default.yml
@@ -48,3 +48,6 @@ db:
 meta:
   check_for_updates: true
   telemetry_enabled: true
+
+authorization:
+  poll_duration: 30s

--- a/internal/server/authz/engine_test.go
+++ b/internal/server/authz/engine_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 )
 
 func TestEngine_NewEngine(t *testing.T) {
 	ctx := context.Background()
-	engine, err := NewEngine(ctx)
+	engine, err := NewEngine(ctx, zaptest.NewLogger(t), testRBACPolicy, WithDataSource(testRoleDefinitions))
 	require.NoError(t, err)
 	require.NotNil(t, engine)
 }
@@ -24,64 +25,163 @@ func TestEngine_IsAllowed(t *testing.T) {
 		{
 			name: "admin is allowed to create",
 			input: `{
-				"role": "admin",
-				"action": "create",
-				"scope": "flag"
-			}`,
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "admin"
+                    }
+                },
+                "request": {
+                    "action": "create",
+                    "resource": "flag"
+                }
+            }`,
 			expected: true,
 		},
 		{
 			name: "admin is allowed to read",
 			input: `{
-				"role": "admin",
-				"action": "read",
-				"scope": "flag"
-			}`,
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "admin"
+                    }
+                },
+                "request": {
+                    "action": "read",
+                    "resource": "flag"
+                }
+            }`,
 			expected: true,
 		},
 		{
 			name: "editor is allowed to create flags",
 			input: `{
-				"role": "editor",
-				"action": "create",
-				"scope": "flag"
-			}`,
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "editor"
+                    }
+                },
+                "request": {
+                    "action": "create",
+                    "resource": "flag"
+                }
+            }`,
 			expected: true,
 		},
 		{
 			name: "editor is allowed to read",
 			input: `{
-				"role": "editor",
-				"action": "read",
-				"scope": "flag"
-			}`,
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "editor"
+                    }
+                },
+                "request": {
+                    "action": "read",
+                    "resource": "flag"
+                }
+            }`,
 			expected: true,
 		},
 		{
 			name: "editor is not allowed to create namespaces",
 			input: `{
-				"role": "editor",
-				"action": "create",
-				"scope": "namespace"
-			}`,
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "editor"
+                    }
+                },
+                "request": {
+                    "action": "create",
+                    "resource": "namespace"
+                }
+            }`,
 			expected: false,
 		},
 		{
 			name: "viewer is allowed to read",
 			input: `{
-				"role": "viewer",
-				"action": "read",
-				"scope": "flag"
-			}`,
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "viewer"
+                    }
+                },
+                "request": {
+                    "action": "read",
+                    "resource": "segment"
+                }
+            }`,
 			expected: true,
 		},
 		{
 			name: "viewer is not allowed to create",
 			input: `{
-				"role": "viewer",
-				"action": "create",
-				"scope": "flag"
-			}`,
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "viewer"
+                    }
+                },
+                "request": {
+                    "action": "create",
+                    "resource": "flag"
+                }
+            }`,
+			expected: false,
+		},
+		{
+			name: "namespaced_viewer is allowed to read in namespace",
+			input: `{
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "namespaced_viewer"
+                    }
+                },
+                "request": {
+                    "action": "read",
+                    "resource": "flag",
+                    "namespace": "foo"
+                }
+            }`,
+			expected: true,
+		},
+		{
+			name: "namespaced_viewer is not allowed to read in unexpected namespace",
+			input: `{
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "namespaced_viewer"
+                    }
+                },
+                "request": {
+                    "action": "read",
+                    "resource": "flag",
+                    "namespace": "bar"
+                }
+            }`,
+			expected: false,
+		},
+		{
+			name: "namespaced_viewer is not allowed to read in without namespace scope",
+			input: `{
+                "authentication": {
+                    "method": "METHOD_JWT",
+                    "metadata": {
+                        "io.flipt.auth.role": "namespaced_viewer"
+                    }
+                },
+                "request": {
+                    "action": "read",
+                    "resource": "flag"
+                }
+            }`,
 			expected: false,
 		},
 	}
@@ -89,7 +189,7 @@ func TestEngine_IsAllowed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			engine, err := NewEngine(ctx)
+			engine, err := NewEngine(ctx, zaptest.NewLogger(t), testRBACPolicy, WithDataSource(testRoleDefinitions))
 			require.NoError(t, err)
 
 			var input map[string]interface{}
@@ -103,3 +203,136 @@ func TestEngine_IsAllowed(t *testing.T) {
 		})
 	}
 }
+
+type policySource string
+
+func (p policySource) Get(context.Context, []byte) ([]byte, []byte, error) {
+	return []byte(p), nil, nil
+}
+
+type dataSource string
+
+func (d dataSource) Get(context.Context, []byte) (data map[string]any, _ []byte, _ error) {
+	return data, nil, json.Unmarshal([]byte(d), &data)
+}
+
+var (
+	testRBACPolicy = policySource(`package authz.v1
+
+import data
+import rego.v1
+
+default allow = false
+
+allow if {
+	some rule in has_rules
+
+	permit_string(rule.resource, input.request.resource)
+	permit_slice(rule.actions, input.request.action)
+	permit_string(rule.namespace, input.request.namespace)
+}
+
+allow if {
+	some rule in has_rules
+
+	permit_string(rule.resource, input.request.resource)
+	permit_slice(rule.actions, input.request.action)
+	not rule.namespace
+}
+
+has_rules contains rules if {
+	some role in data.roles
+	role.name == input.authentication.metadata["io.flipt.auth.role"]
+	rules := role.rules[_]
+}
+
+permit_string(allowed, _) if {
+	allowed == "*"
+}
+
+permit_string(allowed, requested) if {
+	allowed == requested
+}
+
+permit_slice(allowed, _) if {
+	allowed[_] = "*"
+}
+
+permit_slice(allowed, requested) if {
+	allowed[_] = requested
+}`)
+	testRoleDefinitions = dataSource(`{
+    "version": "0.1.0",
+    "roles": [
+        {
+            "name": "admin",
+            "rules": [
+                {
+                    "resource": "*",
+                    "actions": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "editor",
+            "rules": [
+                {
+                    "resource": "namespace",
+                    "actions": [
+                        "read"
+                    ]
+                },
+                {
+                    "resource": "authentication",
+                    "actions": [
+                        "read"
+                    ]
+                },
+                {
+                    "resource": "flag",
+                    "actions": [
+                        "create",
+                        "read",
+                        "update",
+                        "delete"
+                    ]
+                },
+                {
+                    "resource": "segment",
+                    "actions": [
+                        "create",
+                        "read",
+                        "update",
+                        "delete"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "viewer",
+            "rules": [
+                {
+                    "resource": "*",
+                    "actions": [
+                        "read"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "namespaced_viewer",
+            "rules": [
+                {
+                    "resource": "*",
+                    "actions": [
+                        "read"
+                    ],
+                    "namespace": "foo"
+                }
+            ]
+        }
+    ]
+}`)
+)

--- a/internal/server/authz/engine_test.go
+++ b/internal/server/authz/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -11,7 +12,7 @@ import (
 
 func TestEngine_NewEngine(t *testing.T) {
 	ctx := context.Background()
-	engine, err := NewEngine(ctx, zaptest.NewLogger(t), testRBACPolicy, WithDataSource(testRoleDefinitions))
+	engine, err := NewEngine(ctx, zaptest.NewLogger(t), testRBACPolicy, WithDataSource(testRoleDefinitions, 5*time.Second))
 	require.NoError(t, err)
 	require.NotNil(t, engine)
 }
@@ -189,7 +190,7 @@ func TestEngine_IsAllowed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			engine, err := NewEngine(ctx, zaptest.NewLogger(t), testRBACPolicy, WithDataSource(testRoleDefinitions))
+			engine, err := NewEngine(ctx, zaptest.NewLogger(t), testRBACPolicy, WithDataSource(testRoleDefinitions, 5*time.Second))
 			require.NoError(t, err)
 
 			var input map[string]interface{}

--- a/internal/server/authz/middleware/grpc/middleware.go
+++ b/internal/server/authz/middleware/grpc/middleware.go
@@ -86,21 +86,21 @@ func AuthorizationRequiredInterceptor(logger *zap.Logger, policyVerifier authz.V
 			return ctx, errUnauthorized
 		}
 
-		scope := string(request.Scope)
-		if scope == "" {
-			// fallback to subject if scope is not provided
-			scope = string(request.Subject)
+		resource := string(request.Resource)
+		if resource == "" {
+			// fallback to subject if resource is not provided
+			resource = string(request.Subject)
 		}
 
-		if scope == "" {
-			logger.Error("unauthorized", zap.String("reason", "request scope or subject required"))
+		if resource == "" {
+			logger.Error("unauthorized", zap.String("reason", "request resource or subject required"))
 			return ctx, errUnauthorized
 		}
 
 		allowed, err := policyVerifier.IsAllowed(ctx, map[string]interface{}{
-			"role":   role,
-			"action": action,
-			"scope":  scope,
+			"role":     role,
+			"action":   action,
+			"resource": resource,
 		})
 
 		if err != nil {

--- a/internal/server/authz/middleware/grpc/middleware_test.go
+++ b/internal/server/authz/middleware/grpc/middleware_test.go
@@ -32,14 +32,14 @@ func (s *mockServer) SkipsAuthorization(ctx context.Context) bool {
 }
 
 type mockRequester struct {
-	action flipt.Action
-	scope  flipt.Scope
+	action   flipt.Action
+	resource flipt.Resource
 }
 
 func (r *mockRequester) Request() flipt.Request {
 	return flipt.Request{
-		Action: r.action,
-		Scope:  r.scope,
+		Action:   r.action,
+		Resource: r.resource,
 	}
 }
 
@@ -114,12 +114,12 @@ func TestAuthorizationRequiredInterceptor(t *testing.T) {
 				},
 			},
 			req: &mockRequester{
-				scope: "foo",
+				resource: "foo",
 			},
 			wantAllowed: false,
 		},
 		{
-			name: "missing scope",
+			name: "missing resource",
 			authn: &authrpc.Authentication{
 				Metadata: map[string]string{
 					"io.flipt.auth.role": "admin",

--- a/internal/server/authz/source/filesystem/filesystem.go
+++ b/internal/server/authz/source/filesystem/filesystem.go
@@ -1,0 +1,75 @@
+package filesystem
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"go.flipt.io/flipt/internal/server/authz"
+)
+
+var _ authz.DataSource = (*DataSource)(nil)
+var _ authz.PolicySource = (*PolicySource)(nil)
+
+// PolicySource is an implementation of authz.PolicySource
+// It sources policy definitions from the location filesystem
+type PolicySource struct {
+	path string
+}
+
+// PolicySourceFromPath builds an instance pof *PolicySourceFromPath which reads the provided
+// path and returns the located policy
+func PolicySourceFromPath(path string) *PolicySource {
+	return &PolicySource{path}
+}
+
+// Get reads the *PolicySource path as and returns it as a byte slice
+// If the mod time of the filepath has not changed based on the provided previously seen
+// mod time then it returns authz.ErrNotModified
+func (p *PolicySource) Get(_ context.Context, seen []byte) ([]byte, []byte, error) {
+	return read(p.path, seen)
+}
+
+// DataSource is an implementation of authz.DataSource
+// It sources additional data for the policy engine from the local filesystem
+type DataSource struct {
+	path string
+}
+
+// DataSourceFromPath builds an instance of *DataSource which reads the provided
+// path and parses it as JSON on calls to Get
+func DataSourceFromPath(path string) *DataSource {
+	return &DataSource{path: path}
+}
+
+// Get fetches and parses the *DataSource path as JSON and returns it
+// modelled as a go map of string to any type
+// If the mod time of the filepath has not changed based on the provided previously seen
+// mod time then it returns authz.ErrNotModified
+func (d *DataSource) Get(_ context.Context, seen []byte) (map[string]any, []byte, error) {
+	b, mod, err := read(d.path, seen)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	data := map[string]any{}
+
+	return data, mod, json.Unmarshal(b, &data)
+}
+
+func read(path string, seen []byte) (data, mod []byte, _ error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mod = []byte(info.ModTime().Format(time.RFC3339))
+	if seen != nil && bytes.Compare(seen, mod) == 0 {
+		return nil, nil, authz.ErrNotModified
+	}
+
+	data, err = os.ReadFile(path)
+	return
+}

--- a/internal/server/authz/source/filesystem/filesystem.go
+++ b/internal/server/authz/source/filesystem/filesystem.go
@@ -59,14 +59,14 @@ func (d *DataSource) Get(_ context.Context, seen []byte) (map[string]any, []byte
 	return data, mod, json.Unmarshal(b, &data)
 }
 
-func read(path string, seen []byte) (data, mod []byte, _ error) {
+func read(path string, seen []byte) (data, mod []byte, err error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	mod = []byte(info.ModTime().Format(time.RFC3339))
-	if seen != nil && bytes.Compare(seen, mod) == 0 {
+	if seen != nil && bytes.Equal(seen, mod) {
 		return nil, nil, authz.ErrNotModified
 	}
 

--- a/rpc/flipt/request.go
+++ b/rpc/flipt/request.go
@@ -4,8 +4,8 @@ type Requester interface {
 	Request() Request
 }
 
-// Scope represents what resource or parent resource is being acted on.
-type Scope string
+// Resource represents what resource or parent resource is being acted on.
+type Resource string
 
 // Subject returns the subject of the request.
 type Subject string
@@ -14,9 +14,9 @@ type Subject string
 type Action string
 
 const (
-	ScopeNamespace Scope = "namespace"
-	ScopeFlag      Scope = "flag"
-	ScopeSegment   Scope = "segment"
+	ResourceNamespace Resource = "namespace"
+	ResourceFlag      Resource = "flag"
+	ResourceSegment   Resource = "segment"
 
 	SubjectConstraint   Subject = "constraint"
 	SubjectDistribution Subject = "distribution"
@@ -36,16 +36,16 @@ const (
 
 type Request struct {
 	Namespaced
-	Scope   Scope   `json:"scope"`
-	Subject Subject `json:"subject"`
-	Action  Action  `json:"action"`
+	Resource Resource `json:"resource"`
+	Subject  Subject  `json:"subject"`
+	Action   Action   `json:"action"`
 }
 
-func NewScopedRequest(scope Scope, s Subject, a Action) Request {
+func NewResourceScopedRequest(r Resource, s Subject, a Action) Request {
 	return Request{
-		Scope:   scope,
-		Subject: s,
-		Action:  a,
+		Resource: r,
+		Subject:  s,
+		Action:   a,
 	}
 }
 
@@ -57,11 +57,11 @@ func NewRequest(s Subject, a Action) Request {
 }
 
 func newFlagScopedRequest(s Subject, a Action) Request {
-	return NewScopedRequest(ScopeFlag, s, a)
+	return NewResourceScopedRequest(ResourceFlag, s, a)
 }
 
 func newSegmentScopedRequest(s Subject, a Action) Request {
-	return NewScopedRequest(ScopeSegment, s, a)
+	return NewResourceScopedRequest(ResourceSegment, s, a)
 }
 
 // Namespaces


### PR DESCRIPTION
Fixes FLI-1028

This refactors the engine to source policy and optionally data from a configurable source.
Currently, this is simply a path on the filesystem which is periodically read.

The filesystem source uses mod time to avoid causing the policy engine to need to be recompiled or for the data to have to be updated when it does not change.

p.s. I renamed scope to resource because I think scope is often the tuple of subject/resource and action/verb (e.g. `flag:read`).