### PR TITLE
fix: write response for cloud login before server shutdown

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1016,6 +1016,7 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/tchap/go-patricia v2.2.6+incompatible h1:JvoDL7JSoIP2HDE8AbDH3zC8QBPxmzYe32HHy5yQ+Ck=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tchap/go-patricia/v2 v2.3.1 h1:6rQp39lgIYZ+MHmdEq4xzuk1t7OdC35z/xm0BGhTkes=
 github.com/tchap/go-patricia/v2 v2.3.1/go.mod h1:VZRHKAb53DLaG+nA9EaYYiaEx6YztwDlLElMsnSHD4k=

--- a/internal/cmd/cloud/local_server.go
+++ b/internal/cmd/cloud/local_server.go
@@ -72,17 +72,17 @@ func (s *localServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		close(s.resultChan)
 	}()
 
-	params := r.URL.Query()
-	s.resultChan <- TokenResponse{
-		Token: params.Get("id_token"),
-		State: params.Get("state"),
-	}
-
 	w.Header().Add("content-type", "text/html")
 	if s.WriteSuccessHTML != nil {
 		s.WriteSuccessHTML(w)
 	} else {
 		defaultSuccessHTML(w)
+	}
+
+	params := r.URL.Query()
+	s.resultChan <- TokenResponse{
+		Token: params.Get("id_token"),
+		State: params.Get("state"),
 	}
 }
 


### PR DESCRIPTION
Should fix: FLI-1037

Write the html response before sending the token down the channel which causes the server to shutdown