### PR TITLE
change(config): rename git backend filesystem to local

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -129,9 +129,9 @@ import "strings"
 			min_idle_conn?:      int | *0
 			conn_max_idle_time?: =~#duration | int | *0
 			net_timeout?:        =~#duration | int | *0
-			ca_cert_path?:      string
-			ca_cert_bytes?:     string
-			insecure_skip_tls?: bool | *false
+			ca_cert_path?:       string
+			ca_cert_bytes?:      string
+			insecure_skip_tls?:  bool | *false
 		}
 
 		memory?: {
@@ -142,9 +142,9 @@ import "strings"
 	}
 
 	#cloud: {
-		host?: string | *"flipt.cloud"
-		organization?:  string
-		instance?:  string
+		host?:         string | *"flipt.cloud"
+		organization?: string
+		instance?:     string
 		authentication?: {
 			api_key?: string
 		}
@@ -176,6 +176,7 @@ import "strings"
 		local?: path: string | *"."
 		git?: {
 			repository:         string
+			backend?:           *"memory" | "local"
 			ref?:               string | *"main"
 			ref_type?:          *"static" | "semver"
 			directory?:         string
@@ -347,7 +348,7 @@ import "strings"
 					body: string
 					headers?: [string]: string
 				}]
-			},
+			}
 			cloud?: {
 				enabled?: bool | *false
 			}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -607,6 +607,11 @@
             "repository": {
               "type": "string"
             },
+            "backend": {
+              "type": "string",
+              "enum": ["memory", "local"],
+              "default": "local"
+            },
             "ref": {
               "type": "string",
               "default": "main"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -921,7 +921,7 @@ func TestLoad(t *testing.T) {
 					Type: GitStorageType,
 					Git: &Git{
 						Backend: GitBackend{
-							Type: GitBackendFilesystem,
+							Type: GitBackendLocal,
 							Path: "/path/to/gitdir",
 						},
 						Ref:          "main",

--- a/internal/config/storage.go
+++ b/internal/config/storage.go
@@ -191,8 +191,8 @@ func (g *Git) validate() error {
 type GitBackendType string
 
 const (
-	GitBackendMemory     = GitBackendType("memory")
-	GitBackendFilesystem = GitBackendType("filesystem")
+	GitBackendMemory = GitBackendType("memory")
+	GitBackendLocal  = GitBackendType("local")
 )
 
 type GitBackend struct {

--- a/internal/config/testdata/storage/git_provided_with_backend_type.yml
+++ b/internal/config/testdata/storage/git_provided_with_backend_type.yml
@@ -3,5 +3,5 @@ storage:
   git:
     repository: "git@github.com:foo/bar.git"
     backend:
-      type: "filesystem"
+      type: "local"
       path: "/path/to/gitdir"

--- a/internal/storage/fs/store/store.go
+++ b/internal/storage/fs/store/store.go
@@ -47,7 +47,7 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (_ st
 		}
 
 		switch storage.Backend.Type {
-		case config.GitBackendFilesystem:
+		case config.GitBackendLocal:
 			path := storage.Backend.Path
 			if path == "" {
 				path, err = os.MkdirTemp(os.TempDir(), "flipt-git-*")


### PR DESCRIPTION
As per a discussion in https://github.com/flipt-io/flipt/pull/3108#discussion_r1612321837

We're changing `storage.git.backend == filesystem` to `storage.git.backend == local`.
This is to keep it consistent with local naming conventions which exist.
This is not technically a breaking change, because this code is currently unreleased.