### PR TITLE
fix: prevent redis shutdown

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -519,8 +519,8 @@ func getCache(ctx context.Context, cfg *config.Config) (cache.Cacher, errFunc, e
 				cacheErr = err
 				return
 			}
-			cacheFunc = func(ctx context.Context) error {
-				return rdb.Shutdown(ctx).Err()
+			cacheFunc = func(_ context.Context) error {
+				return rdb.Close()
 			}
 
 			status := rdb.Ping(ctx)


### PR DESCRIPTION
We found that redis shutdown is unexpected on grpc server exit while redeploying Flipt.
![shutdown](https://github.com/flipt-io/flipt/assets/77097900/618ecf02-ae6f-416a-a9b6-9c2855b2e163)


