### PR TITLE
refactor(authz): pass entire request and authentication to IsAllowed

### DIFF
--- a/internal/server/audit/audit_test.go
+++ b/internal/server/audit/audit_test.go
@@ -32,19 +32,28 @@ func (s *sampleSink) Close() error { return nil }
 func TestSinkSpanExporter(t *testing.T) {
 	cases := []struct {
 		name      string
-		fType     flipt.Subject
+		resource  flipt.Resource
+		subject   flipt.Subject
 		action    flipt.Action
 		expectErr bool
 	}{
 		{
 			name:      "Valid",
-			fType:     flipt.SubjectFlag,
+			resource:  flipt.ResourceFlag,
+			subject:   flipt.SubjectFlag,
+			action:    flipt.ActionCreate,
+			expectErr: false,
+		},
+		{
+			name:      "Valid Rule",
+			resource:  flipt.ResourceFlag,
+			subject:   flipt.SubjectRule,
 			action:    flipt.ActionCreate,
 			expectErr: false,
 		},
 		{
 			name:      "Invalid",
-			fType:     flipt.Subject(""),
+			subject:   flipt.Subject(""),
 			action:    flipt.Action(""),
 			expectErr: true,
 		},
@@ -68,7 +77,7 @@ func TestSinkSpanExporter(t *testing.T) {
 
 			_, span := tr.Start(ctx, "OnStart")
 
-			r := flipt.NewRequest(c.fType, c.action)
+			r := flipt.NewRequest(c.resource, c.action, flipt.WithSubject(c.subject))
 			e := NewEvent(
 				r,
 				&Actor{

--- a/internal/server/audit/events.go
+++ b/internal/server/audit/events.go
@@ -51,10 +51,15 @@ func NewEvent(r flipt.Request, actor *Actor, payload interface{}) *Event {
 		action = "read"
 	}
 
+	typ := string(r.Resource)
+	if r.Subject != "" {
+		typ = string(r.Subject)
+	}
+
 	return &Event{
 		Version: eventVersion,
 		Action:  action,
-		Type:    string(r.Subject),
+		Type:    typ,
 		Metadata: Metadata{
 			Actor: actor,
 		},

--- a/internal/server/audit/logfile/logfile_test.go
+++ b/internal/server/audit/logfile/logfile_test.go
@@ -208,7 +208,7 @@ func TestSink_SendAudits(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sink)
 
-	e := audit.NewEvent(flipt.NewRequest(flipt.SubjectFlag, flipt.ActionCreate), nil, nil)
+	e := audit.NewEvent(flipt.NewRequest(flipt.ResourceFlag, flipt.ActionCreate), nil, nil)
 	assert.NoError(t, sink.SendAudits(context.Background(), []audit.Event{*e}))
 
 	assert.NotNil(t, f.Buffer)

--- a/internal/server/authn/server.go
+++ b/internal/server/authn/server.go
@@ -180,7 +180,7 @@ func (s *Server) DeleteAuthentication(ctx context.Context, req *auth.DeleteAuthe
 			return nil, err
 		}
 		if a.Method == auth.Method_METHOD_TOKEN {
-			request := flipt.NewRequest(flipt.SubjectToken, flipt.ActionDelete)
+			request := flipt.NewRequest(flipt.ResourceAuthentication, flipt.ActionDelete, flipt.WithSubject(flipt.SubjectToken))
 			event := audit.NewEvent(request, actor, a.Metadata)
 			event.AddToSpan(ctx)
 		}

--- a/internal/server/authz/middleware/grpc/middleware.go
+++ b/internal/server/authz/middleware/grpc/middleware.go
@@ -73,34 +73,9 @@ func AuthorizationRequiredInterceptor(logger *zap.Logger, policyVerifier authz.V
 			return ctx, errUnauthorized
 		}
 
-		role, ok := auth.Metadata["io.flipt.auth.role"]
-		if !ok {
-			logger.Error("unauthorized", zap.String("reason", "user role required"))
-			return ctx, errUnauthorized
-		}
-
-		request := requester.Request()
-		action := string(request.Action)
-		if action == "" {
-			logger.Error("unauthorized", zap.String("reason", "request action required"))
-			return ctx, errUnauthorized
-		}
-
-		resource := string(request.Resource)
-		if resource == "" {
-			// fallback to subject if resource is not provided
-			resource = string(request.Subject)
-		}
-
-		if resource == "" {
-			logger.Error("unauthorized", zap.String("reason", "request resource or subject required"))
-			return ctx, errUnauthorized
-		}
-
 		allowed, err := policyVerifier.IsAllowed(ctx, map[string]interface{}{
-			"role":     role,
-			"action":   action,
-			"resource": resource,
+			"request":        requester.Request(),
+			"authentication": auth,
 		})
 
 		if err != nil {

--- a/rpc/flipt/auth/request.go
+++ b/rpc/flipt/auth/request.go
@@ -5,5 +5,5 @@ import (
 )
 
 func (req *CreateTokenRequest) Request() flipt.Request {
-	return flipt.NewRequest(flipt.SubjectToken, flipt.ActionCreate)
+	return flipt.NewRequest(flipt.ResourceAuthentication, flipt.ActionCreate, flipt.WithSubject(flipt.SubjectToken))
 }

--- a/rpc/flipt/request.go
+++ b/rpc/flipt/request.go
@@ -14,9 +14,10 @@ type Subject string
 type Action string
 
 const (
-	ResourceNamespace Resource = "namespace"
-	ResourceFlag      Resource = "flag"
-	ResourceSegment   Resource = "segment"
+	ResourceNamespace      Resource = "namespace"
+	ResourceFlag           Resource = "flag"
+	ResourceSegment        Resource = "segment"
+	ResourceAuthentication Resource = "authentication"
 
 	SubjectConstraint   Subject = "constraint"
 	SubjectDistribution Subject = "distribution"
@@ -35,183 +36,193 @@ const (
 )
 
 type Request struct {
-	Namespaced
-	Resource Resource `json:"resource"`
-	Subject  Subject  `json:"subject"`
-	Action   Action   `json:"action"`
+	Namespace string   `json:"namespace"`
+	Resource  Resource `json:"resource"`
+	Subject   Subject  `json:"subject"`
+	Action    Action   `json:"action"`
 }
 
-func NewResourceScopedRequest(r Resource, s Subject, a Action) Request {
-	return Request{
+func WithNamespace(ns string) func(*Request) {
+	return func(r *Request) {
+		r.Namespace = ns
+	}
+}
+
+func WithSubject(s Subject) func(*Request) {
+	return func(r *Request) {
+		r.Subject = s
+	}
+}
+
+func NewRequest(r Resource, a Action, opts ...func(*Request)) Request {
+	req := Request{
 		Resource: r,
-		Subject:  s,
 		Action:   a,
 	}
-}
 
-func NewRequest(s Subject, a Action) Request {
-	return Request{
-		Subject: s,
-		Action:  a,
+	for _, opt := range opts {
+		opt(&req)
 	}
+
+	return req
 }
 
-func newFlagScopedRequest(s Subject, a Action) Request {
-	return NewResourceScopedRequest(ResourceFlag, s, a)
+func newFlagScopedRequest(ns string, s Subject, a Action) Request {
+	return NewRequest(ResourceFlag, a, WithNamespace(ns), WithSubject(s))
 }
 
-func newSegmentScopedRequest(s Subject, a Action) Request {
-	return NewResourceScopedRequest(ResourceSegment, s, a)
+func newSegmentScopedRequest(ns string, s Subject, a Action) Request {
+	return NewRequest(ResourceSegment, a, WithNamespace(ns), WithSubject(s))
 }
 
 // Namespaces
 func (req *GetNamespaceRequest) Request() Request {
-	return NewRequest(SubjectNamespace, ActionRead)
+	return NewRequest(ResourceNamespace, ActionRead, WithNamespace(req.Key))
 }
 
 func (req *ListNamespaceRequest) Request() Request {
-	return NewRequest(SubjectNamespace, ActionRead)
+	return NewRequest(ResourceNamespace, ActionRead)
 }
 
 func (req *CreateNamespaceRequest) Request() Request {
-	return NewRequest(SubjectNamespace, ActionCreate)
+	return NewRequest(ResourceNamespace, ActionCreate, WithNamespace(req.Key))
 }
 
 func (req *UpdateNamespaceRequest) Request() Request {
-	return NewRequest(SubjectNamespace, ActionUpdate)
+	return NewRequest(ResourceNamespace, ActionUpdate, WithNamespace(req.Key))
 }
 
 func (req *DeleteNamespaceRequest) Request() Request {
-	return NewRequest(SubjectNamespace, ActionDelete)
+	return NewRequest(ResourceFlag, ActionDelete, WithNamespace(req.Key))
 }
 
 // Flags
 func (req *GetFlagRequest) Request() Request {
-	return NewRequest(SubjectFlag, ActionRead)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectFlag, ActionRead)
 }
 
 func (req *ListFlagRequest) Request() Request {
-	return NewRequest(SubjectFlag, ActionRead)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectFlag, ActionRead)
 }
 
 func (req *CreateFlagRequest) Request() Request {
-	return NewRequest(SubjectFlag, ActionCreate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectFlag, ActionCreate)
 }
 
 func (req *UpdateFlagRequest) Request() Request {
-	return NewRequest(SubjectFlag, ActionUpdate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectFlag, ActionUpdate)
 }
 
 func (req *DeleteFlagRequest) Request() Request {
-	return NewRequest(SubjectFlag, ActionDelete)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectFlag, ActionDelete)
 }
 
 // Variants
 func (req *CreateVariantRequest) Request() Request {
-	return newFlagScopedRequest(SubjectVariant, ActionCreate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectVariant, ActionCreate)
 }
 
 func (req *UpdateVariantRequest) Request() Request {
-	return newFlagScopedRequest(SubjectVariant, ActionUpdate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectVariant, ActionUpdate)
 }
 
 func (req *DeleteVariantRequest) Request() Request {
-	return newFlagScopedRequest(SubjectVariant, ActionDelete)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectVariant, ActionDelete)
 }
 
 // Rules
 func (req *ListRuleRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRule, ActionRead)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRule, ActionRead)
 }
 
 func (req *GetRuleRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRule, ActionRead)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRule, ActionRead)
 }
 
 func (req *CreateRuleRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRule, ActionCreate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRule, ActionCreate)
 }
 
 func (req *UpdateRuleRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRule, ActionUpdate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRule, ActionUpdate)
 }
 
 func (req *OrderRulesRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRule, ActionUpdate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRule, ActionUpdate)
 }
 
 func (req *DeleteRuleRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRule, ActionDelete)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRule, ActionDelete)
 }
 
 // Rollouts
 func (req *ListRolloutRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRollout, ActionRead)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRollout, ActionRead)
 }
 
 func (req *GetRolloutRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRollout, ActionRead)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRollout, ActionRead)
 }
 
 func (req *CreateRolloutRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRollout, ActionCreate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRollout, ActionCreate)
 }
 
 func (req *UpdateRolloutRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRollout, ActionUpdate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRollout, ActionUpdate)
 }
 
 func (req *OrderRolloutsRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRollout, ActionUpdate)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRollout, ActionUpdate)
 }
 
 func (req *DeleteRolloutRequest) Request() Request {
-	return newFlagScopedRequest(SubjectRollout, ActionDelete)
+	return newFlagScopedRequest(req.NamespaceKey, SubjectRollout, ActionDelete)
 }
 
 // Segments
 func (req *GetSegmentRequest) Request() Request {
-	return NewRequest(SubjectSegment, ActionRead)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectSegment, ActionRead)
 }
 
 func (req *ListSegmentRequest) Request() Request {
-	return NewRequest(SubjectSegment, ActionRead)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectSegment, ActionRead)
 }
 
 func (req *CreateSegmentRequest) Request() Request {
-	return NewRequest(SubjectSegment, ActionCreate)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectSegment, ActionCreate)
 }
 
 func (req *UpdateSegmentRequest) Request() Request {
-	return NewRequest(SubjectSegment, ActionUpdate)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectSegment, ActionUpdate)
 }
 
 func (req *DeleteSegmentRequest) Request() Request {
-	return NewRequest(SubjectSegment, ActionDelete)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectSegment, ActionDelete)
 }
 
 // Constraints
 func (req *CreateConstraintRequest) Request() Request {
-	return newSegmentScopedRequest(SubjectConstraint, ActionCreate)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectConstraint, ActionCreate)
 }
 
 func (req *UpdateConstraintRequest) Request() Request {
-	return newSegmentScopedRequest(SubjectConstraint, ActionUpdate)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectConstraint, ActionUpdate)
 }
 
 func (req *DeleteConstraintRequest) Request() Request {
-	return newSegmentScopedRequest(SubjectConstraint, ActionDelete)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectConstraint, ActionDelete)
 }
 
 // Distributions
 func (req *CreateDistributionRequest) Request() Request {
-	return newSegmentScopedRequest(SubjectDistribution, ActionCreate)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectDistribution, ActionCreate)
 }
 
 func (req *UpdateDistributionRequest) Request() Request {
-	return newSegmentScopedRequest(SubjectDistribution, ActionUpdate)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectDistribution, ActionUpdate)
 }
 
 func (req *DeleteDistributionRequest) Request() Request {
-	return newSegmentScopedRequest(SubjectDistribution, ActionDelete)
+	return newSegmentScopedRequest(req.NamespaceKey, SubjectDistribution, ActionDelete)
 }


### PR DESCRIPTION
Updates the call to `IsAllowed` to take a map containing both the entire request structure and the entire authentication instance.