### PR TITLE
feat: add support for custom context path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22
 
 FROM golang:${GO_VERSION}
 
@@ -31,6 +31,7 @@ WORKDIR /flipt
 
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY ./core ./core
 COPY ./errors ./errors
 COPY ./rpc/flipt ./rpc/flipt
 COPY ./sdk ./sdk

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Build and run Dev Container task
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/flipt-io/flipt/flipt-devcontainer
+          imageName: ghcr.io/${{ github.repository_owner }}/flipt/flipt-devcontainer
           runCmd: |
             mage bootstrap

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -440,10 +440,10 @@ func (a AuthenticationMethodOIDCConfig) info() AuthenticationMethodInfo {
 
 	// this ensures we expose the authorize and callback URL endpoint
 	// to the UI via the /auth/v1/method endpoint
-	for provider := range a.Providers {
-		providers[provider] = map[string]any{
-			"authorize_url": fmt.Sprintf("/auth/v1/method/oidc/%s/authorize", provider),
-			"callback_url":  fmt.Sprintf("/auth/v1/method/oidc/%s/callback", provider),
+	for name, provider := range a.Providers {
+		providers[name] = map[string]any{
+			"authorize_url": fmt.Sprintf("%s/auth/v1/method/oidc/%s/authorize", provider.RedirectAddress, name),
+			"callback_url":  fmt.Sprintf("%s/auth/v1/method/oidc/%s/callback", provider.RedirectAddress, name),
 		}
 	}
 
@@ -552,8 +552,8 @@ func (a AuthenticationMethodGithubConfig) info() AuthenticationMethodInfo {
 
 	metadata := make(map[string]any)
 
-	metadata["authorize_url"] = "/auth/v1/method/github/authorize"
-	metadata["callback_url"] = "/auth/v1/method/github/callback"
+	metadata["authorize_url"] = fmt.Sprintf("%s/auth/v1/method/github/authorize", a.RedirectAddress)
+	metadata["callback_url"] = fmt.Sprintf("%s/auth/v1/method/github/callback", a.RedirectAddress)
 
 	info.Metadata, _ = structpb.NewStruct(metadata)
 

--- a/internal/server/authn/method/github/server.go
+++ b/internal/server/authn/method/github/server.go
@@ -131,7 +131,9 @@ func (s *Server) Callback(ctx context.Context, r *auth.CallbackRequest) (*auth.C
 		return nil, err
 	}
 
-	metadata := map[string]string{}
+	metadata := map[string]string{
+		"io.flipt.auth.redirect_address": s.config.Methods.Github.Method.RedirectAddress,
+	}
 
 	if githubUserResponse.Name != "" {
 		metadata[storageMetadataGithubName] = githubUserResponse.Name

--- a/internal/server/authn/method/github/server_test.go
+++ b/internal/server/authn/method/github/server_test.go
@@ -101,10 +101,11 @@ func Test_Server(t *testing.T) {
 		require.NotEmpty(t, callback.ClientToken)
 		require.Equal(t, auth.Method_METHOD_GITHUB, callback.Authentication.Method)
 		require.Equal(t, map[string]string{
-			storageMetadataGithubEmail:   "user@flipt.io",
-			storageMetadataGithubName:    "fliptuser",
-			storageMetadataGithubPicture: "https://thispicture.com",
-			storageMetadataGithubSub:     "1234567890",
+			storageMetadataGithubEmail:       "user@flipt.io",
+			storageMetadataGithubName:        "fliptuser",
+			storageMetadataGithubPicture:     "https://thispicture.com",
+			storageMetadataGithubSub:         "1234567890",
+			"io.flipt.auth.redirect_address": "test.flipt.io",
 		}, callback.Authentication.Metadata)
 	})
 

--- a/internal/server/authn/method/oidc/server.go
+++ b/internal/server/authn/method/oidc/server.go
@@ -138,7 +138,8 @@ func (s *Server) Callback(ctx context.Context, req *auth.CallbackRequest) (_ *au
 	}
 
 	metadata := map[string]string{
-		storageMetadataOIDCProvider: req.Provider,
+		storageMetadataOIDCProvider:      req.Provider,
+		"io.flipt.auth.redirect_address": s.config.Methods.OIDC.Method.Providers[req.Provider].RedirectAddress,
 	}
 
 	// Extract custom claims

--- a/internal/server/authn/method/oidc/server_test.go
+++ b/internal/server/authn/method/oidc/server_test.go
@@ -341,10 +341,11 @@ func testOIDCFlow(t *testing.T, ctx context.Context, tpAddr, clientAddress strin
 		assert.Empty(t, response.ClientToken) // middleware moves it to cookie
 		assert.Equal(t, auth.Method_METHOD_OIDC, response.Authentication.Method)
 		assert.Equal(t, map[string]string{
-			"io.flipt.auth.oidc.provider": "google",
-			"io.flipt.auth.oidc.email":    "mark@flipt.io",
-			"io.flipt.auth.oidc.name":     "Mark Phelps",
-			"io.flipt.auth.oidc.sub":      "mark",
+			"io.flipt.auth.oidc.provider":    "google",
+			"io.flipt.auth.oidc.email":       "mark@flipt.io",
+			"io.flipt.auth.oidc.name":        "Mark Phelps",
+			"io.flipt.auth.oidc.sub":         "mark",
+			"io.flipt.auth.redirect_address": clientAddress,
 		}, response.Authentication.Metadata)
 
 		// ensure expiry is set

--- a/ui/src/components/header/UserProfile.tsx
+++ b/ui/src/components/header/UserProfile.tsx
@@ -21,7 +21,7 @@ export default function UserProfile(props: UserProfileProps) {
   let name: string | undefined;
   let login: string | undefined;
   let imgURL: string | undefined;
-  let logoutURL = '/';
+  let logoutURL: string | undefined;
 
   if (session) {
     const authMethods = ['github', 'oidc', 'jwt'];
@@ -52,14 +52,28 @@ export default function UserProfile(props: UserProfileProps) {
           metadata[authMethodIssuerKey as keyof typeof metadata];
         logoutURL = `//${logoutURI}`;
       }
+
+      const redirectAddressKey = 'io.flipt.auth.redirect_address';
+      if (metadata[redirectAddressKey as keyof typeof metadata]) {
+        let redirectAddress = metadata[
+          redirectAddressKey as keyof typeof metadata
+        ] as string;
+        redirectAddress = redirectAddress?.trim();
+        if (redirectAddress && !redirectAddress.endsWith('/')) {
+          redirectAddress += '/';
+        }
+        logoutURL = redirectAddress;
+      }
     }
   }
+
+  const logoutLocation = logoutURL || '/';
 
   const logout = async () => {
     try {
       await expireAuthSelf();
       clearSession();
-      window.location.href = logoutURL;
+      window.location.href = logoutLocation;
     } catch (err) {
       setError(err);
     }

--- a/ui/src/types/auth/Github.ts
+++ b/ui/src/types/auth/Github.ts
@@ -13,6 +13,7 @@ export interface IAuthMethodGithubMetadata {
   'io.flipt.auth.github.name'?: string;
   'io.flipt.auth.github.picture'?: string;
   'io.flipt.auth.github.preferred_username'?: string;
+  'io.flipt.auth.redirect_address'?: string;
 }
 
 export interface IAuthGithubInternal extends IAuth {

--- a/ui/src/types/auth/OIDC.ts
+++ b/ui/src/types/auth/OIDC.ts
@@ -19,6 +19,7 @@ export interface IAuthMethodOIDCMetadata {
   'io.flipt.auth.oidc.name'?: string;
   'io.flipt.auth.oidc.picture'?: string;
   'io.flipt.auth.oidc.preferred_username'?: string;
+  'io.flipt.auth.redirect_address'?: string;
 }
 
 export interface IAuthOIDCInternal extends IAuth {


### PR DESCRIPTION
This PR adds support for custom context path.

Redirection was broken when using a custom context path. It follows the standard using "X-Forwarded-Prefix" header to get the correct context path for redirection.

Thanks for the project.

If you need me to update something feel free to comment ;)