### PR TITLE
fix(ui): await expiring auth self before redirecting

### DIFF
--- a/ui/src/components/header/UserProfile.tsx
+++ b/ui/src/components/header/UserProfile.tsx
@@ -55,9 +55,9 @@ export default function UserProfile(props: UserProfileProps) {
     }
   }
 
-  const logout = () => {
+  const logout = async () => {
     try {
-      expireAuthSelf();
+      await expireAuthSelf();
       clearSession();
       window.location.href = logoutURL;
     } catch (err) {


### PR DESCRIPTION
Fixes #3131 

This makes the logout function await expiring self before navigating away to the issuer or root.