### PR TITLE
add docstrings to functions

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -48,6 +48,7 @@ func (f *Flipt) Base(ctx context.Context, source *dagger.Directory) (*Container,
 	return f.BaseContainer, err
 }
 
+// Return container with Flipt binariesin a thinner alpine distribution
 func (f *Flipt) Build(ctx context.Context, source *dagger.Directory) (*Container, error) {
 	base, err := f.Base(ctx, source)
 	if err != nil {
@@ -64,6 +65,8 @@ type Test struct {
 	FliptContainer *dagger.Container
 }
 
+// Execute test specific by subcommand
+// see all available subcommands with dagger call test --help
 func (f *Flipt) Test(ctx context.Context, source *dagger.Directory) (*Test, error) {
 	flipt, err := f.Build(ctx, source)
 	if err != nil {
@@ -73,26 +76,32 @@ func (f *Flipt) Test(ctx context.Context, source *dagger.Directory) (*Test, erro
 	return &Test{source, f.BaseContainer, f.UIContainer, flipt}, nil
 }
 
+// Run all ui tests
 func (t *Test) UI(ctx context.Context) error {
 	return testing.UI(ctx, dag, t.UIContainer, t.FliptContainer)
 }
 
+// Run all unit tests
 func (t *Test) Unit(ctx context.Context) error {
 	return testing.Unit(ctx, dag, t.BaseContainer)
 }
 
+// Run all cli tests
 func (t *Test) CLI(ctx context.Context) error {
 	return testing.CLI(ctx, dag, t.Source, t.FliptContainer)
 }
 
+// Run all migration tests
 func (t *Test) Migration(ctx context.Context) error {
 	return testing.Migration(ctx, dag, t.BaseContainer, t.FliptContainer)
 }
 
+// Run all load tests
 func (t *Test) Load(ctx context.Context) error {
 	return testing.LoadTest(ctx, dag, t.BaseContainer, t.FliptContainer)
 }
 
+// Run all integration tests
 func (t *Test) Integration(
 	ctx context.Context,
 	// +optional
@@ -121,6 +130,8 @@ type Generate struct {
 	FliptContainer *dagger.Container
 }
 
+// Execute generate function with subcommand
+// see all available subcommands with dagger call generate --help
 func (f *Flipt) Generate(ctx context.Context, source *dagger.Directory) (*Generate, error) {
 	flipt, err := f.Build(ctx, source)
 	if err != nil {


### PR DESCRIPTION
this makes running `dagger functions` and `dagger call test --help` via the CLI a bit more useful.

```
levlaz@Levs-MacBook-Pro flipt % dagger functions
Name             Description
base             Returns a container with all the assets compiled and ready for testing and distribution
base-container   -
build            Return container with Flipt binariesin a thinner alpine distribution
generate         Execute generate function with subcommand
source           -
test             Execute test specific by subcommand
uicontainer      -

levlaz@Levs-MacBook-Pro flipt % dagger call test --help
Execute test specific by subcommand
see all available subcommands with dagger call test --help

USAGE
  dagger call test [arguments] <function>

FUNCTIONS
  base-container
  cli               Run all cli tests
  flipt-container
  integration       Run all integration tests
  load              Run all load tests
  migration         Run all migration tests
  source
  ui                Run all ui tests
  uicontainer
  unit              Run all unit tests

ARGUMENTS
      --source Directory   [required]

Use "dagger call test [command] --help" for more information about a command
```