### PR TITLE
fix(build): configure token authentication for migration test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,5 +100,5 @@ jobs:
         with:
           install-only: true
 
-      - name: Run UI Tests
+      - name: Run Migration Tests
         run: mage dagger:run test:migration

--- a/build/testing/migration.go
+++ b/build/testing/migration.go
@@ -42,23 +42,24 @@ func Migration(ctx context.Context, client *dagger.Client, base, flipt *dagger.C
 		Tag(*release.TagName).
 		Tree()
 
-	// handle the case that we're migrating to a new path location (path now includes "/main/")
-	fi, err := base.File("build/testing/integration/readonly/testdata/main/default.yaml").Sync(ctx)
-	if err != nil {
-		fi = base.File("build/testing/integration/readonly/testdata/default.yaml")
-	}
-
 	base = base.
 		WithMountedDirectory(".", fliptDir)
 
-	// import testdata into latest Flipt instance (using latest image for import)
-	_, err = latest.
-		WithFile("import.yaml", fi).
-		WithServiceBinding("flipt", latest.WithExec(nil).AsService()).
-		WithExec([]string{"sh", "-c", "sleep 5 && /flipt import --address grpc://flipt:9000 import.yaml"}).
-		Sync(ctx)
-	if err != nil {
-		return err
+	for _, namespace := range []string{"default", "production"} {
+		fi, err := base.File(fmt.Sprintf("build/testing/integration/readonly/testdata/main/%s.yaml", namespace)).Sync(ctx)
+		if err != nil {
+			return err
+		}
+
+		// import testdata into latest Flipt instance (using latest image for import)
+		_, err = latest.
+			WithFile("import.yaml", fi).
+			WithServiceBinding("flipt", latest.WithExec(nil).AsService()).
+			WithExec([]string{"sh", "-c", "sleep 5 && /flipt import --address grpc://flipt:9000 import.yaml"}).
+			Sync(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	// run migration with edge Flipt build
@@ -78,6 +79,7 @@ func Migration(ctx context.Context, client *dagger.Client, base, flipt *dagger.C
 	// ensure new edge Flipt build continues to work as expected
 	_, err = base.
 		WithServiceBinding("flipt", flipt.
+			WithEnvVariable("FLIPT_AUTHENTICATION_REQUIRED", "true").
 			WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_ENABLED", "true").
 			WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_BOOTSTRAP_TOKEN", "secret").
 			WithExec(nil).

--- a/build/testing/migration.go
+++ b/build/testing/migration.go
@@ -77,10 +77,17 @@ func Migration(ctx context.Context, client *dagger.Client, base, flipt *dagger.C
 
 	// ensure new edge Flipt build continues to work as expected
 	_, err = base.
-		WithServiceBinding("flipt", flipt.WithExec(nil).AsService()).
+		WithServiceBinding("flipt", flipt.
+			WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_ENABLED", "true").
+			WithEnvVariable("FLIPT_AUTHENTICATION_METHODS_TOKEN_BOOTSTRAP_TOKEN", "secret").
+			WithExec(nil).
+			AsService()).
 		WithWorkdir("build/testing/integration/readonly").
 		WithEnvVariable("UNIQUE", uuid.New().String()).
-		WithExec([]string{"go", "test", "-v", "-race", "--flipt-addr", "grpc://flipt:9000", "."}).
+		WithExec([]string{"go", "test", "-v", "-race",
+			"--flipt-addr", "grpc://flipt:9000",
+			"--flipt-token", "secret",
+			"."}).
 		Sync(ctx)
 
 	return err


### PR DESCRIPTION
This is a fix for the migration test suite which has been failing since I refactored all the things.
There were a couple things I overlooked for this particular IT suite in the move.

There were two things I changed in the read only harness. Those were that now both namespaces are tested explicitly in the harness itself (remove from the matrix) and I made it so that the harness uses the bootstrap token to create a new token for the lifetime of the test.

What we're seeing in the other suites is the authentication method service is not mounted, because this suite has historically not need auth to work (now it does). So I have enable token method, made auth required and created a bootstrap token. Additionally, I have imported both the production and default namespace data (we only needed default before).