### PR TITLE
Installation made fully POSIX compliant for sh based shells

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,17 +25,6 @@ get_latest_version() {
 }
 
 copy() {
-  # if [ ":$PATH:" = *":$HOME/.local/bin:"* ]; then
-  #     [ ! -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
-  #     mv /tmp/flipt "$HOME/.local/bin/flipt"
-  # else
-  #     # Try without sudo first, run with sudo only if mv failed without it.
-  #     mv /tmp/flipt /usr/local/bin/flipt || (
-  #       echo "Cannot write to installation target directory as current user, writing as root."
-  #       sudo mv /tmp/flipt /usr/local/bin/flipt
-  #     )
-  # fi
-
   case ":PATH:" in 
     *":HOME/.local/bin:"*) 
       [ ! -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
@@ -90,12 +79,16 @@ install() {
       [ "$ARCH" = "aarch64" ] && ARCH="arm64"
       ;;
     darwin*) 
-        ARCH=$(uname -m)
-        OS="darwin"
-        if [ "$ARCH" != "arm64" ]; then
-        echo "flipt is only available for mac arm64 architecture"
-        file_issue_prompt
-      fi
+      ARCH=$(uname -m)
+      OS="darwin"
+      case "$ARCH" in 
+        x86_64|arm64) : ;;
+        *) 
+          echo "flipt is only available for mac x86_64/arm64 architecture"
+          file_issue_prompt
+          ;;
+      esac 
+      [ "$ARCH" = "aarch64" ] && ARCH="arm64"   
       ;;
     *)
       echo "flipt isn't supported for your platform - $OSTYPE"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 #     _________       __ 
 #    / ____/ (_)___  / /_
@@ -20,15 +20,13 @@ file_issue_prompt() {
 }
 
 get_latest_version() {
-  local res=$(curl -fsSL https://api.github.com/repos/flipt-io/flipt/releases/latest | grep tag_name | cut -d '"' -f 4)
+  res=$(curl -fsSL https://api.github.com/repos/flipt-io/flipt/releases/latest | grep tag_name | cut -d '"' -f 4)
   echo "$res"
 }
 
 copy() {
-  if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
-      if [ ! -d "$HOME/.local/bin" ]; then
-        mkdir -p "$HOME/.local/bin"
-      fi
+  if [ ":$PATH:" = *":$HOME/.local/bin:"* ]; then
+      [ ! -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
       mv /tmp/flipt "$HOME/.local/bin/flipt"
   else
       # Try without sudo first, run with sudo only if mv failed without it.
@@ -42,45 +40,55 @@ copy() {
 # This function decides what version will be installed based on the following priority:
 # 1. Environment variable `VERSION` is set.
 # 2. Latest available on GitHub
-function get_version() {
-  if [[ -z "$VERSION" ]]; then
-      if [[ -n "$1" ]]; then
+get_version() {
+  if [ -z "$VERSION" ]; then
+      if [ -n "$1" ]; then
           VERSION="$1"
       else
           VERSION=$(get_latest_version)
       fi
   fi
+  
   # ensure version starts with v
-  if [[ "$VERSION" != v* ]]; then
-    VERSION="v$VERSION"
-  fi
+  case "$VERSION" in
+    v*) : ;;
+    *) VERSION="v$VERSION" ;;
+  esac
   echo "$VERSION"
 }
 
-function install() {
-  local version=$(get_version $1);
+install() {
+  version=$(get_version "$1");
   echo "Installing version $version"
-  if [[ "$OSTYPE" == "linux"* ]]; then
-      ARCH=$(uname -m);
-      OS="linux";
-      if [[ "$ARCH" != "x86_64" && "$ARCH" != "aarch64" ]]; then
+  
+  case "$OSTYPE" in 
+    linux*)
+      ARCH=$(uname -m)
+      OS="linux"
+      case "$ARCH" in 
+        x86_64|aarch64) : ;; 
+        *)
           echo "flipt is only available for linux x86_64/arm64 architecture"
           file_issue_prompt
+          ;; 
+        esac 
+        [ "$ARCH" = "aarch64" ] && ARCH="arm64"
+        ;;
+      darwin*) 
+        ARCH=$(uname -m)
+        OS="darwin"
+        if [ "$ARCH" != "arm64" ]; then
+        echo "flipt is only available for mac arm64 architecture"
+        file_issue_prompt
       fi
-      if [[ "$ARCH" == "aarch64" ]]; then
-          ARCH="arm64"
-      fi
-  elif [[ "$OSTYPE" == "darwin"* ]]; then
-      ARCH=$(uname -m);
-      OS="darwin";
-      if [[ "$ARCH" != "arm64" ]]; then
-          echo "flipt is only available for mac arm64 architecture"
-          file_issue_prompt
-      fi
-  else
+      ;;
+    *)
       echo "flipt isn't supported for your platform - $OSTYPE"
       file_issue_prompt
-  fi
+      ;;
+  esac
+
+
   curl -o /tmp/flipt.tar.gz -fsSL https://download.flipt.io/flipt/$version/$OS\_$ARCH.tar.gz
   tar -xzf /tmp/flipt.tar.gz -C /tmp
   chmod +x /tmp/flipt

--- a/install.sh
+++ b/install.sh
@@ -71,10 +71,10 @@ install() {
           echo "flipt is only available for linux x86_64/arm64 architecture"
           file_issue_prompt
           ;; 
-        esac 
-        [ "$ARCH" = "aarch64" ] && ARCH="arm64"
-        ;;
-      darwin*) 
+      esac 
+      [ "$ARCH" = "aarch64" ] && ARCH="arm64"
+      ;;
+    darwin*) 
         ARCH=$(uname -m)
         OS="darwin"
         if [ "$ARCH" != "arm64" ]; then
@@ -87,7 +87,6 @@ install() {
       file_issue_prompt
       ;;
   esac
-
 
   curl -o /tmp/flipt.tar.gz -fsSL https://download.flipt.io/flipt/$version/$OS\_$ARCH.tar.gz
   tar -xzf /tmp/flipt.tar.gz -C /tmp

--- a/install.sh
+++ b/install.sh
@@ -60,8 +60,10 @@ get_version() {
 install() {
   version=$(get_version "$1");
   echo "Installing version $version"
+
+  OSCHECK=$(uname | tr '[:upper:]' '[:lower:]')
   
-  case "$OSTYPE" in 
+  case "$OSCHECK" in 
     linux*)
       ARCH=$(uname -m)
       OS="linux"

--- a/install.sh
+++ b/install.sh
@@ -25,16 +25,29 @@ get_latest_version() {
 }
 
 copy() {
-  if [ ":$PATH:" = *":$HOME/.local/bin:"* ]; then
+  # if [ ":$PATH:" = *":$HOME/.local/bin:"* ]; then
+  #     [ ! -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
+  #     mv /tmp/flipt "$HOME/.local/bin/flipt"
+  # else
+  #     # Try without sudo first, run with sudo only if mv failed without it.
+  #     mv /tmp/flipt /usr/local/bin/flipt || (
+  #       echo "Cannot write to installation target directory as current user, writing as root."
+  #       sudo mv /tmp/flipt /usr/local/bin/flipt
+  #     )
+  # fi
+
+  case ":PATH:" in 
+    *":HOME/.local/bin:"*) 
       [ ! -d "$HOME/.local/bin" ] && mkdir -p "$HOME/.local/bin"
       mv /tmp/flipt "$HOME/.local/bin/flipt"
-  else
-      # Try without sudo first, run with sudo only if mv failed without it.
+      ;;
+    *)
       mv /tmp/flipt /usr/local/bin/flipt || (
-        echo "Cannot write to installation target directory as current user, writing as root."
-        sudo mv /tmp/flipt /usr/local/bin/flipt
-      )
-  fi
+      echo "Cannot write to installation target directory as current user, writing as root."
+      sudo mv /tmp/flipt /usr/local/bin/flipt
+    )
+    ;;
+  esac 
 }
 
 # This function decides what version will be installed based on the following priority:


### PR DESCRIPTION
During the installation of flipt CLI on Debian servers with `curl -fsSL https://get.flipt.io/install | sh` as mentioned in the flipt docs https://docs.flipt.io/self-hosted/overview due to lack of POSIX complaint, the script used to crash since these scripts had a lot of Bashism into it, but marked as `#!/bin/sh` as well as in doc, it's piped to sh. 

Now the prior script was working on bash and it's the default shell for most of the Linux distros, it contains keywords that are only supported on bash and will fail with sh. Scripts running on sh can run on bash due to its POSIX compliance, and hence, it was a good idea to elevate it to sh improving its portability. 

By making this script POSIX compliant, it would be working on most of the shells beyond bash. 

The final script is tested on macOS 14.5 and on a fresh Ubuntu Server, with sh. 

<img width="940" alt="Screenshot 2024-06-18 at 12 57 52" src="https://github.com/flipt-io/flipt/assets/72488360/dc1a2c36-3c2b-44ee-9d78-92800fcb371a">

In the following image, the first one is on my fork (POSIX compliant) while the second is the current installation script which fails on this freshly spawned Ubuntu Server. 