### PR TITLE
build(proto): prevent panic in protoc-gen-go-flipt-sdk

### DIFF
--- a/internal/cmd/protoc-gen-go-flipt-sdk/grpc.go
+++ b/internal/cmd/protoc-gen-go-flipt-sdk/grpc.go
@@ -35,7 +35,7 @@ func generateGRPC(gen *protogen.Plugin) {
 			method = typ + "Client"
 		)
 
-		if len(file.Services) < 2 {
+		if len(file.Services) == 1 {
 			returnType := file.Services[0].GoName + "Client"
 			g.P("func (t Transport) ", method, "() ", relativeImport(g, file, returnType), "{")
 			g.P("return ", relativeImport(g, file, "New"+returnType), "(t.cc)")

--- a/internal/cmd/protoc-gen-go-flipt-sdk/http.go
+++ b/internal/cmd/protoc-gen-go-flipt-sdk/http.go
@@ -139,7 +139,7 @@ func generateHTTP(gen *protogen.Plugin, grpcAPIConfig string) {
 			netHTTP = importPackage(g, "net/http")
 		)
 
-		if len(file.Services) < 2 {
+		if len(file.Services) == 1 {
 			srv := file.Services[0]
 			returnType := srv.GoName + "Client"
 

--- a/internal/cmd/protoc-gen-go-flipt-sdk/main.go
+++ b/internal/cmd/protoc-gen-go-flipt-sdk/main.go
@@ -81,7 +81,7 @@ func generateSDK(gen *protogen.Plugin) {
 			returns = method
 		)
 
-		if len(file.Services) < 2 {
+		if len(file.Services) == 1 {
 			returns = relativeImport(g, file, file.Services[0].GoName+"Client")
 		}
 


### PR DESCRIPTION
if proto file doesn't have any services, `mage go:proto` fails with panic `panic: runtime error: index out of range [0] with length 0`