### PR TITLE
chore: add back magefile for release task

### DIFF
--- a/build/magefile.go
+++ b/build/magefile.go
@@ -1,0 +1,33 @@
+//go:build mage
+// +build mage
+
+package main
+
+import (
+	"context"
+
+	"github.com/magefile/mage/mg"
+	"go.flipt.io/build/release"
+)
+
+type Release mg.Namespace
+
+func (r Release) Next(ctx context.Context, module, versionParts string) error {
+	return release.Next(module, versionParts)
+}
+
+func (r Release) Latest(ctx context.Context, module string) error {
+	return release.Latest(module, false)
+}
+
+func (r Release) LatestRC(ctx context.Context, module string) error {
+	return release.Latest(module, true)
+}
+
+func (r Release) Changelog(ctx context.Context, module, version string) error {
+	return release.UpdateChangelog(module, version)
+}
+
+func (r Release) Tag(ctx context.Context, module, version string) error {
+	return release.Tag(ctx, module, version)
+}

--- a/build/release/release.go
+++ b/build/release/release.go
@@ -164,7 +164,7 @@ func UpdateChangelog(module, version string) error {
 	messages := strings.Split(strings.TrimSpace(string(out)), "\n")
 
 	return insertChangeLogEntryIntoFile(
-		path.Join(prefix, "CHANGELOG.md"),
+		path.Join(prefix, "..", "CHANGELOG.md"),
 		parseChangeLogVersion(prefix, version, time.Now(), messages...),
 	)
 }
@@ -274,7 +274,7 @@ func latestRelease(module string, includePre bool) (prefix string, version strin
 		return
 	}
 
-	repo, err := git.PlainOpen(".")
+	repo, err := git.PlainOpen("../.")
 	if err != nil {
 		return "", "", err
 	}

--- a/build/release/release.go
+++ b/build/release/release.go
@@ -205,12 +205,7 @@ func ensureVersionAfter(requested, latest string) error {
 	return nil
 }
 
-func tagModule(ctx context.Context, module, version string) error {
-	const (
-		owner = "flipt-io"
-		repo  = "flipt"
-	)
-
+func tagModule(_ context.Context, module, version string) error {
 	prefix, err := moduleTagPrefix(module)
 	if err != nil {
 		return err


### PR DESCRIPTION
add back magefile for release task

makes it so `mage -d build release:changelog go.flipt.io/flipt $(mage -d build release:next go.flipt.io/flipt minor)` still works

Maybe in the future we replace this with an interactive script?