### PR TITLE
chore: try to fix codecov uploading

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,11 @@ jobs:
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4.5.0
+        with:
+          file: coverage.txt
+          flags: unittests
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-darwin:
     name: "Tests (Go - Darwin)"


### PR DESCRIPTION
I think previously we  didnt have to pass `CODECOV_TOKEN` to the  upload action, but now it seems like its required:

https://github.com/codecov/codecov-action/tree/v4.5.0/?tab=readme-ov-file#usage