### PR TITLE
chore: fix test coverage not being reported correctly

### DIFF
--- a/build/testing/test.go
+++ b/build/testing/test.go
@@ -95,7 +95,7 @@ func Unit(ctx context.Context, client *dagger.Client, flipt *dagger.Container) (
 		WithEnvVariable("TEST_GIT_REPO_URL", "http://gitea:3000/root/features.git").
 		WithEnvVariable("TEST_GIT_REPO_HEAD", push["HEAD"]).
 		WithEnvVariable("TEST_GIT_REPO_TAG", push["TAG"]).
-		WithExec([]string{"go", "test", "-race", "-coverprofile=coverage.txt", "-covermode=atomic", "./..."}).
+		WithExec([]string{"go", "test", "-race", "-coverprofile=coverage.txt", "-covermode=atomic", "-coverpkg=./...", "./..."}).
 		Sync(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/storage/sql/db_test.go
+++ b/internal/storage/sql/db_test.go
@@ -153,10 +153,7 @@ type DBTestSuite struct {
 	namespace string
 }
 
-var dd string
-
 func TestMain(m *testing.M) {
-	dd = os.Getenv("FLIPT_TEST_DATABASE_PROTOCOL")
 	os.Exit(m.Run())
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -250,7 +250,7 @@ func (g Go) Test() error {
 		testArgs = append(testArgs, "test")
 	}
 
-	testArgs = append(testArgs, []string{"-v", "-covermode=atomic", "-count=1", "-coverprofile=coverage.txt", "-timeout=60s"}...)
+	testArgs = append(testArgs, []string{"-v", "-covermode=atomic", "-count=1", "-coverprofile=coverage.txt", "-timeout=60s", "-coverpkg=./..."}...)
 
 	if os.Getenv("FLIPT_TEST_SHORT") != "" {
 		testArgs = append(testArgs, "-short")


### PR DESCRIPTION
test coverage was not being aggregated correctly because it wasn't considering tests not in the same package as the code under test, `-coverpkg=./...` fixes this