### PR TITLE
chore: remove flipt cloud serve

### DIFF
--- a/cmd/flipt/cloud.go
+++ b/cmd/flipt/cloud.go
@@ -5,20 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"time"
 
-	"github.com/MicahParks/keyfunc/v3"
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/spf13/cobra"
 	"go.flipt.io/flipt/internal/cmd/cloud"
 	"go.flipt.io/flipt/internal/cmd/util"
-	"go.flipt.io/flipt/internal/config"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -40,10 +34,6 @@ type cloudTunnel struct {
 	Organization string `json:"organization"`
 	Status       string `json:"status"`
 	ExpiresAt    int64  `json:"expiresAt,omitempty"`
-}
-
-type cloudError struct {
-	Error string `json:"error"`
 }
 
 func newCloudCommand() *cobra.Command {
@@ -81,15 +71,6 @@ func newCloudCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(logoutCmd)
-
-	serveCmd := &cobra.Command{
-		Use:   "serve [flags]",
-		Short: "Serve your local instance via Flipt Cloud",
-		RunE:  cloud.serve,
-		Args:  cobra.NoArgs,
-	}
-
-	cmd.AddCommand(serveCmd)
 
 	return cmd
 }
@@ -130,240 +111,6 @@ func (c *cloudCommand) login(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("\n✓ Authenticated with Flipt Cloud!\nYou can now run commands that require cloud authentication.")
 	return nil
-}
-
-func (c *cloudCommand) serve(cmd *cobra.Command, args []string) error {
-	ctx := cmd.Context()
-
-	logger, cfg, err := buildConfig(ctx)
-	if err != nil {
-		return err
-	}
-
-	if !cfg.Experimental.Cloud.Enabled {
-		return errors.New("cloud feature is not enabled")
-	}
-
-	u, err := url.Parse(c.url)
-	if err != nil {
-		return fmt.Errorf("parsing cloud URL: %w", err)
-	}
-
-	srvConfig := func(cfg *config.Config, t cloudTunnel) *config.Config {
-		cfg.Cloud.Host = u.Hostname()
-		cfg.Cloud.Gateway = t.Gateway
-		cfg.Cloud.Organization = t.Organization
-		cfg.Cloud.Authentication.ApiKey = "" // clear API key if present to use JWT
-		cfg.Server.Cloud.Enabled = true
-		cfg.Authentication.Session.Domain = u.Host
-		cfg.Authentication.Methods.Cloud.Enabled = true
-		return cfg
-	}
-
-	// first check for existing of auth token/cloud.json
-	// if not found, prompt user to login
-AUTH:
-	cloudAuthFile := filepath.Join(userConfigDir, "cloud.json")
-	f, err := os.ReadFile(cloudAuthFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			fmt.Println("\n✗ No cloud authentication token found.")
-
-			ok, err := util.PromptConfirm("Open browser to authenticate with Flipt Cloud?", false)
-			if err != nil {
-				return err
-			}
-
-			// if they didn't attempt login, exit
-			if !ok {
-				return nil
-			}
-
-			if err := c.loginFlow(ctx); err != nil {
-				return err
-			}
-
-			// otherwise, try reading the file again
-			goto AUTH
-		}
-
-		return fmt.Errorf("reading cloud auth payload %w", err)
-	}
-
-	var auth cloudAuth
-
-	if err := json.Unmarshal(f, &auth); err != nil {
-		return fmt.Errorf("unmarshalling cloud auth payload: %w", err)
-	}
-
-	fmt.Println("\n✓ Found Flipt Cloud authentication.")
-
-	// validate JWT using our JWKS endpoint
-	jwksURL := fmt.Sprintf("%s%s", c.url, "/api/auth/jwks")
-
-	k, err := keyfunc.NewDefaultCtx(ctx, []string{jwksURL})
-	if err != nil {
-		return fmt.Errorf("creating keyfunc: %w", err)
-	}
-
-	parsed, err := jwt.Parse(auth.Token, k.Keyfunc, jwt.WithExpirationRequired())
-	if err != nil {
-		if errors.Is(err, jwt.ErrTokenExpired) {
-			fmt.Println("✗ Existing cloud authentication token expired.")
-
-			ok, err := util.PromptConfirm("Open browser to authenticate with Flipt Cloud?", false)
-			if err != nil {
-				return err
-			}
-
-			// if they didn't attempt login, exit
-			if !ok {
-				return nil
-			}
-
-			if err := c.loginFlow(ctx); err != nil {
-				return err
-			}
-
-			// otherwise, try reading the file again
-			goto AUTH
-		}
-
-		return fmt.Errorf("parsing JWT: %w", err)
-	}
-
-	if !parsed.Valid {
-		return errors.New("invalid JWT")
-	}
-
-	fmt.Println("✓ Validated Flipt Cloud authentication.")
-
-	if auth.Tunnel != nil {
-		// check if gateway actually exists
-		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/api/gateways/%s/status", c.url, auth.Tunnel.ID), nil)
-
-		if err != nil {
-			return fmt.Errorf("creating request: %w", err)
-		}
-
-		req.Header.Set("Authorization", fmt.Sprintf("JWT %s", auth.Token))
-		req.Header.Set("Accept", "application/json")
-
-		client := &http.Client{
-			Timeout: 30 * time.Second,
-		}
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return fmt.Errorf("making request: %w", err)
-		}
-
-		_ = resp.Body.Close()
-
-		switch resp.StatusCode {
-		case http.StatusNotFound:
-			fmt.Println("Existing linked Flipt Cloud gateway not found.")
-			ok, err := util.PromptConfirm("Continue with new gateway?", false)
-			if err != nil {
-				return err
-			}
-
-			if !ok {
-				return nil
-			}
-
-		case http.StatusOK:
-			// check if gateway has not expired
-			if time.Now().Unix() <= auth.Tunnel.ExpiresAt {
-				fmt.Println("✓ Found existing linked Flipt Cloud gateway.")
-				// prompt user to see if they want to use existing gateway
-				ok, err := util.PromptConfirm("Use existing gateway?", false)
-				if err != nil {
-					return err
-				}
-
-				if ok {
-					logger, cfg, err := buildConfig(ctx)
-					if err != nil {
-						return err
-					}
-
-					fmt.Println("✓ Starting local instance linked with Flipt Cloud.")
-					return run(ctx, logger, srvConfig(cfg, *auth.Tunnel))
-				}
-			} else {
-				fmt.Println("Existing linked Flipt Cloud gateway has expired.")
-				ok, err := util.PromptConfirm("Continue with new gateway?", false)
-				if err != nil {
-					return err
-				}
-
-				if !ok {
-					return nil
-				}
-			}
-		default:
-			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		}
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/api/gateways", c.url), nil)
-	if err != nil {
-		return fmt.Errorf("creating request: %w", err)
-	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("JWT %s", auth.Token))
-	req.Header.Set("Accept", "application/json")
-
-	client := &http.Client{
-		Timeout: 30 * time.Second,
-	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return fmt.Errorf("making request: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusForbidden {
-		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
-
-	body, err := io.ReadAll(resp.Body)
-	defer resp.Body.Close()
-
-	if err != nil {
-		return fmt.Errorf("reading response body: %w", err)
-	}
-
-	_ = resp.Body.Close()
-
-	if resp.StatusCode == http.StatusForbidden {
-		var cloudErr cloudError
-		if err := json.Unmarshal(body, &cloudErr); err != nil {
-			return fmt.Errorf("unmarshalling response body: %w", err)
-		}
-
-		return errors.New(cloudErr.Error)
-	}
-
-	fmt.Println("✓ Created temporary gateway in Flipt Cloud.")
-	var t cloudTunnel
-	if err := json.Unmarshal(body, &t); err != nil {
-		return fmt.Errorf("unmarshalling response body: %w", err)
-	}
-
-	auth.Tunnel = &t
-	cloudAuthBytes, err := json.Marshal(auth)
-	if err != nil {
-		return fmt.Errorf("marshalling cloud auth token: %w", err)
-	}
-
-	if err := os.WriteFile(cloudAuthFile, cloudAuthBytes, 0600); err != nil {
-		return fmt.Errorf("writing cloud auth token: %w", err)
-	}
-
-	fmt.Println("✓ Starting local instance linked with Flipt Cloud.")
-	return run(ctx, logger, srvConfig(cfg, t))
 }
 
 func (c *cloudCommand) loginFlow(ctx context.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/Masterminds/squirrel v1.5.4
-	github.com/MicahParks/keyfunc/v3 v3.3.3
 	github.com/XSAM/otelsql v0.31.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.23
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.29.1
@@ -32,7 +31,6 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/gobwas/glob v0.2.3
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang-migrate/migrate/v4 v4.17.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.19.2
@@ -128,7 +126,6 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/ClickHouse/ch-go v0.61.5 // indirect
-	github.com/MicahParks/jwkset v0.5.18 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.4 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
@@ -190,6 +187,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/glog v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,6 @@ github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
-github.com/MicahParks/jwkset v0.5.18 h1:WLdyMngF7rCrnstQxA7mpRoxeaWqGzPM/0z40PJUK4w=
-github.com/MicahParks/jwkset v0.5.18/go.mod h1:q8ptTGn/Z9c4MwbcfeCDssADeVQb3Pk7PnVxrvi+2QY=
-github.com/MicahParks/keyfunc/v3 v3.3.3 h1:c6j9oSu1YUo0k//KwF1miIQlEMtqNlj7XBFLB8jtEmY=
-github.com/MicahParks/keyfunc/v3 v3.3.3/go.mod h1:f/UMyXdKfkZzmBeBFUeYk+zu066J1Fcl48f7Wnl5Z48=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=

--- a/internal/server/audit/kafka/kafka_test.go
+++ b/internal/server/audit/kafka/kafka_test.go
@@ -24,7 +24,7 @@ import (
 
 func adminCreateUser(t testing.TB, base string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	t.Cleanup(cancel)
 	endpoint, err := url.JoinPath(base, "/v1/security/users")
 	require.NoError(t, err)
@@ -58,13 +58,13 @@ func adminCreateTopic(t testing.TB, bootstrapServers []string, topic string) {
 
 	adminClient := kadm.NewClient(client)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	_, err = adminClient.CreateTopic(ctx, 1, 1, nil, topic)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		_, err := adminClient.DeleteTopic(ctx, topic)
 		assert.NoError(t, err)
@@ -112,7 +112,7 @@ func TestNewSinkAndSend(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			topic := fmt.Sprintf("default-%s", tt.name)
 			adminCreateTopic(t, bootstrapServers, topic)
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			t.Cleanup(cancel)
 			cfg := config.KafkaSinkConfig{
 				BootstrapServers: bootstrapServers,

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -47,7 +47,7 @@
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.24.7",
-        "@playwright/test": "^1.44.0",
+        "@playwright/test": "^1.44.1",
         "@tailwindcss/forms": "^0.5.7",
         "@types/jest": "^29.5.12",
         "@types/loadable__component": "^5.13.9",
@@ -3736,48 +3736,18 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
-      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
+      "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.44.0"
+        "playwright": "1.45.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
-      "dev": true,
-      "dependencies": {
-        "playwright-core": "1.44.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
-      "dev": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -17064,30 +17034,12 @@
       "dev": true
     },
     "@playwright/test": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
-      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
+      "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
       "dev": true,
       "requires": {
-        "playwright": "1.44.0"
-      },
-      "dependencies": {
-        "playwright": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-          "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
-          "dev": true,
-          "requires": {
-            "fsevents": "2.3.2",
-            "playwright-core": "1.44.0"
-          }
-        },
-        "playwright-core": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-          "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
-          "dev": true
-        }
+        "playwright": "1.45.1"
       }
     },
     "@radix-ui/primitive": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.24.7",
-    "@playwright/test": "^1.44.0",
+    "@playwright/test": "^1.44.1",
     "@tailwindcss/forms": "^0.5.7",
     "@types/jest": "^29.5.12",
     "@types/loadable__component": "^5.13.9",


### PR DESCRIPTION
Fixes: FLI-1091

We have decided to remove the `flipt cloud serve` command and require all cloud environments to be created from flipt.cloud