### PR TITLE
fix: passing invalid logger to retriable http client

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -384,7 +384,6 @@ func NewGRPCServer(
 
 	if cfg.Audit.Sinks.Webhook.Enabled {
 		httpClient := retryablehttp.NewClient()
-		httpClient.Logger = logger
 
 		if cfg.Audit.Sinks.Webhook.MaxBackoffDuration > 0 {
 			httpClient.RetryWaitMax = cfg.Audit.Sinks.Webhook.MaxBackoffDuration


### PR DESCRIPTION
Fixes: #3283 

It seems the retryiableHTTP lib accepts any old `interface{}` for its `Logger`.. this is why it passed buildtime but fails at runtime since it actually enforces the logger type at runtime

https://github.com/hashicorp/go-retryablehttp/blob/40b0cad1633fd521cee5884724fcf03d039aaf3f/client.go#L408

simple fix here is to just not pass our own logger to the httpClient