### PR TITLE
fix(config): remove experiment tag from config struct

### DIFF
--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -671,7 +671,6 @@ func authz(ctx context.Context, _ *dagger.Client, base, flipt *dagger.Container,
 
 	// create unique instance for test case
 	fliptToTest := flipt.
-		WithEnvVariable("FLIPT_EXPERIMENTAL_AUTHORIZATION_ENABLED", "true").
 		WithEnvVariable("FLIPT_AUTHORIZATION_REQUIRED", "true").
 		WithEnvVariable("FLIPT_AUTHORIZATION_BACKEND", "local").
 		WithEnvVariable("FLIPT_AUTHORIZATION_LOCAL_POLICY_PATH", policyPath).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	Version        string               `json:"version,omitempty" mapstructure:"version,omitempty" yaml:"version,omitempty"`
 	Audit          AuditConfig          `json:"audit,omitempty" mapstructure:"audit" yaml:"audit,omitempty"`
 	Authentication AuthenticationConfig `json:"authentication,omitempty" mapstructure:"authentication" yaml:"authentication,omitempty"`
-	Authorization  AuthorizationConfig  `json:"authorization,omitempty" mapstructure:"authorization" yaml:"authorization,omitempty" experiment:"authorization"`
+	Authorization  AuthorizationConfig  `json:"authorization,omitempty" mapstructure:"authorization" yaml:"authorization,omitempty"`
 	Cache          CacheConfig          `json:"cache,omitempty" mapstructure:"cache" yaml:"cache,omitempty"`
 	Cloud          CloudConfig          `json:"cloud,omitempty" mapstructure:"cloud" yaml:"cloud,omitempty" experiment:"cloud"`
 	Cors           CorsConfig           `json:"cors,omitempty" mapstructure:"cors" yaml:"cors,omitempty"`


### PR DESCRIPTION
This fixes an issue observed in our community channels where authz config is being ignore:
https://community.flipt.io/t/authorization-configuration/34/7

This is causing this configuration to require the experimental env var check still.
We will need to backport patch fixes to at least 1.45.