### PR TITLE
Release/1.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,23 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.46.0](https://github.com/flipt-io/flipt/releases/tag/v1.46.0) - 2024-07-15
+
+### Added
+
+- Etag support for client side evaluation (#3248)
+- Add provider configuration for ofrep (#3247)
+- `audit`: implement sink for kafka (#3204)
+
+### Changed
+
+- Fix issue with missing code coverage report (#3238)
+
 ## [v1.45.1](https://github.com/flipt-io/flipt/releases/tag/v1.45.1) - 2024-07-09
 
 ### Fixed
 
-- forward x-flipt-accept-server-version to grpc (#3262)
+- Forward x-flipt-accept-server-version to grpc (#3262)
 
 ## [v1.45.0](https://github.com/flipt-io/flipt/releases/tag/v1.45.0) - 2024-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.46.2](https://github.com/flipt-io/flipt/releases/tag/v1.46.2) - 2024-07-25
+
+### Fixed
+
+- `config`: remove experiment tag from config struct (#3305)
+
 ## [v1.46.1](https://github.com/flipt-io/flipt/releases/tag/v1.46.1) - 2024-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [v1.46.1](https://github.com/flipt-io/flipt/releases/tag/v1.46.1) - 2024-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [v1.46.1](https://github.com/flipt-io/flipt/releases/tag/v1.46.1) - 2024-07-17
+
+### Fixed
+
+- passing invalid logger to retriable http client (#3285)
+
 ## [v1.46.0](https://github.com/flipt-io/flipt/releases/tag/v1.46.0) - 2024-07-15
 
 ### Added

--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -671,7 +671,6 @@ func authz(ctx context.Context, _ *dagger.Client, base, flipt *dagger.Container,
 
 	// create unique instance for test case
 	fliptToTest := flipt.
-		WithEnvVariable("FLIPT_EXPERIMENTAL_AUTHORIZATION_ENABLED", "true").
 		WithEnvVariable("FLIPT_AUTHORIZATION_REQUIRED", "true").
 		WithEnvVariable("FLIPT_AUTHORIZATION_BACKEND", "local").
 		WithEnvVariable("FLIPT_AUTHORIZATION_LOCAL_POLICY_PATH", policyPath).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	Version        string               `json:"version,omitempty" mapstructure:"version,omitempty" yaml:"version,omitempty"`
 	Audit          AuditConfig          `json:"audit,omitempty" mapstructure:"audit" yaml:"audit,omitempty"`
 	Authentication AuthenticationConfig `json:"authentication,omitempty" mapstructure:"authentication" yaml:"authentication,omitempty"`
-	Authorization  AuthorizationConfig  `json:"authorization,omitempty" mapstructure:"authorization" yaml:"authorization,omitempty" experiment:"authorization"`
+	Authorization  AuthorizationConfig  `json:"authorization,omitempty" mapstructure:"authorization" yaml:"authorization,omitempty"`
 	Cache          CacheConfig          `json:"cache,omitempty" mapstructure:"cache" yaml:"cache,omitempty"`
 	Cloud          CloudConfig          `json:"cloud,omitempty" mapstructure:"cloud" yaml:"cloud,omitempty" experiment:"cloud"`
 	Cors           CorsConfig           `json:"cors,omitempty" mapstructure:"cors" yaml:"cors,omitempty"`


### PR DESCRIPTION
This brings the authz config fix into a `v1.46.2` release.
Also, updates the changelog to reflect this.
Seems like maybe we're missing `1.46.1` from the changelog in `main` too, so it updates that as well.

Update: or maybe it is, but it is unhappy about the merge base.