### PR TITLE
Release/1.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v1.45.2](https://github.com/flipt-io/flipt/releases/tag/v1.45.2) - 2024-07-17
+## [v1.45.2](https://github.com/flipt-io/flipt/releases/tag/v1.45.2) - 2024-07-25
 
 ### Fixed
 
 - passing invalid logger to retriable http client
+- `config`: remove experiment tag from config struct (#3305)
 
 ## [v1.45.1](https://github.com/flipt-io/flipt/releases/tag/v1.45.1) - 2024-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `authz`: move out of experimental (#3203)
 - `proto`: prevent panic in protoc-gen-go-flipt-sdk (#3215)
 - `build`: move to new dagger v0.11.8 (#3144)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [v1.45.1](https://github.com/flipt-io/flipt/releases/tag/v1.45.1) - 2024-07-09
+
+### Fixed
+
+- forward x-flipt-accept-server-version to grpc (#3262)
+
 ## [v1.45.0](https://github.com/flipt-io/flipt/releases/tag/v1.45.0) - 2024-06-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.45.0](https://github.com/flipt-io/flipt/releases/tag/v1.45.0) - 2024-06-26
+
+### Added
+
+- Rbac cloud (#3203)
+- `authz`: add opa bundle support (#3194)
+- support environment variable substitution in config files (#3195)
+
+### Changed
+
+- `proto`: prevent panic in protoc-gen-go-flipt-sdk (#3215)
+- `build`: move to new dagger v0.11.8 (#3144)
+
+### Fixed
+
+- `build`: configure token authentication for migration test suite (#3177)
+
 ## [v1.44.0](https://github.com/flipt-io/flipt/releases/tag/v1.44.0) - 2024-06-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.45.2](https://github.com/flipt-io/flipt/releases/tag/v1.45.2) - 2024-07-17
+
+### Fixed
+
+- passing invalid logger to retriable http client
 
 ## [v1.45.1](https://github.com/flipt-io/flipt/releases/tag/v1.45.1) - 2024-07-09
 

--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -691,7 +691,6 @@ func authz(ctx context.Context, _ *dagger.Client, base, flipt *dagger.Container,
 
 	// create unique instance for test case
 	fliptToTest := flipt.
-		WithEnvVariable("FLIPT_EXPERIMENTAL_AUTHORIZATION_ENABLED", "true").
 		WithEnvVariable("FLIPT_AUTHORIZATION_REQUIRED", "true").
 		WithEnvVariable("FLIPT_AUTHORIZATION_BACKEND", "local").
 		WithEnvVariable("FLIPT_AUTHORIZATION_LOCAL_POLICY_PATH", policyPath).

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -378,7 +378,6 @@ func NewGRPCServer(
 
 	if cfg.Audit.Sinks.Webhook.Enabled {
 		httpClient := retryablehttp.NewClient()
-		httpClient.Logger = logger
 
 		if cfg.Audit.Sinks.Webhook.MaxBackoffDuration > 0 {
 			httpClient.RetryWaitMax = cfg.Audit.Sinks.Webhook.MaxBackoffDuration

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -21,6 +21,7 @@ import (
 	"go.flipt.io/flipt/internal/gateway"
 	"go.flipt.io/flipt/internal/info"
 	"go.flipt.io/flipt/internal/server/authn/method"
+	grpc_middleware "go.flipt.io/flipt/internal/server/middleware/grpc"
 	"go.flipt.io/flipt/rpc/flipt"
 	"go.flipt.io/flipt/rpc/flipt/analytics"
 	"go.flipt.io/flipt/rpc/flipt/evaluation"
@@ -61,7 +62,7 @@ func NewHTTPServer(
 		r               = chi.NewRouter()
 		api             = gateway.NewGatewayServeMux(logger)
 		evaluateAPI     = gateway.NewGatewayServeMux(logger)
-		evaluateDataAPI = gateway.NewGatewayServeMux(logger)
+		evaluateDataAPI = gateway.NewGatewayServeMux(logger, runtime.WithMetadata(grpc_middleware.ForwardFliptAcceptServerVersion))
 		analyticsAPI    = gateway.NewGatewayServeMux(logger)
 		httpPort        = cfg.Server.HTTPPort
 	)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	Version        string               `json:"version,omitempty" mapstructure:"version,omitempty" yaml:"version,omitempty"`
 	Audit          AuditConfig          `json:"audit,omitempty" mapstructure:"audit" yaml:"audit,omitempty"`
 	Authentication AuthenticationConfig `json:"authentication,omitempty" mapstructure:"authentication" yaml:"authentication,omitempty"`
-	Authorization  AuthorizationConfig  `json:"authorization,omitempty" mapstructure:"authorization" yaml:"authorization,omitempty" experiment:"authorization"`
+	Authorization  AuthorizationConfig  `json:"authorization,omitempty" mapstructure:"authorization" yaml:"authorization,omitempty"`
 	Cache          CacheConfig          `json:"cache,omitempty" mapstructure:"cache" yaml:"cache,omitempty"`
 	Cloud          CloudConfig          `json:"cloud,omitempty" mapstructure:"cloud" yaml:"cloud,omitempty" experiment:"cloud"`
 	Cors           CorsConfig           `json:"cors,omitempty" mapstructure:"cors" yaml:"cors,omitempty"`

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -361,4 +362,18 @@ func FliptAcceptServerVersionUnaryInterceptor(logger *zap.Logger) grpc.UnaryServ
 
 		return handler(ctx, req)
 	}
+}
+
+// ForwardFliptAcceptServerVersion extracts the "x-flipt-accept-server-version"" header from an HTTP request
+// and forwards them as grpc metadata entries.
+func ForwardFliptAcceptServerVersion(ctx context.Context, req *http.Request) metadata.MD {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		md = metadata.MD{}
+	}
+	values := req.Header.Values(fliptAcceptServerVersionHeaderKey)
+	if len(values) > 0 {
+		md[fliptAcceptServerVersionHeaderKey] = values
+	}
+	return md
 }

--- a/internal/server/middleware/grpc/middleware_test.go
+++ b/internal/server/middleware/grpc/middleware_test.go
@@ -3,6 +3,7 @@ package grpc_middleware
 import (
 	"context"
 	"fmt"
+	"net/http/httptest"
 	"testing"
 
 	"go.flipt.io/flipt/errors"
@@ -1649,4 +1650,16 @@ func TestFliptAcceptServerVersionUnaryInterceptor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestForwardFliptAcceptServerVersion(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	md := ForwardFliptAcceptServerVersion(context.Background(), req)
+	assert.Empty(t, md.Get(fliptAcceptServerVersionHeaderKey))
+	req.Header.Add(fliptAcceptServerVersionHeaderKey, "v1.32.0")
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("key", "value"))
+	md = ForwardFliptAcceptServerVersion(ctx, req)
+	assert.Equal(t, []string{"v1.32.0"}, md.Get(fliptAcceptServerVersionHeaderKey))
+	assert.Equal(t, []string{"value"}, md.Get("key"))
 }


### PR DESCRIPTION
Opening this PR to document the release of 1.45.2

It contains the fix for the authz config problem and the fix for passing the invalid logger to the retryable http client.
I would ignore the diff, as it has the previous patches changes in it which are already released.
Focus on the commits since 1.45.1.