### PR TITLE
chore: update CHANGELOG for 1.45.2 and 1.46.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.46.2](https://github.com/flipt-io/flipt/releases/tag/v1.46.2) - 2024-07-25
+
+### Fixed
+
+- `config`: remove experiment tag from config struct (#3305)
+
 ## [v1.46.1](https://github.com/flipt-io/flipt/releases/tag/v1.46.1) - 2024-07-17
 
 ### Fixed
@@ -20,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix issue with missing code coverage report (#3238)
+
+## [v1.45.2](https://github.com/flipt-io/flipt/releases/tag/v1.45.2) - 2024-07-25
+
+### Fixed
+
+- passing invalid logger to retriable http client
+- `config`: remove experiment tag from config struct (#3305)
 
 ## [v1.45.1](https://github.com/flipt-io/flipt/releases/tag/v1.45.1) - 2024-07-09
 


### PR DESCRIPTION
As mentioned in both the release branch PRs.
This is just the changelog updates in isolation to keep main up to date.