### PR TITLE
chore: fix snapshot ITs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,6 +47,7 @@ jobs:
             "api/cockroach",
             "api/cache",
             "api/cachetls",
+            "api/snapshot",
             "fs/git",
             "fs/local",
             "fs/s3",
@@ -56,7 +57,6 @@ jobs:
             "import/export",
             "authn",
             "authz",
-            "rest",
           ]
     steps:
       - uses: actions/checkout@v4

--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -57,6 +57,7 @@ var (
 		"api/cockroach": withCockroach(api),
 		"api/cache":     cache,
 		"api/cachetls":  cacheWithTLS,
+		"api/snapshot":  snapshot,
 		"fs/git":        git,
 		"fs/local":      local,
 		"fs/s3":         s3,
@@ -66,7 +67,6 @@ var (
 		"import/export": importExport,
 		"authn":         authn,
 		"authz":         authz,
-		"rest":          rest,
 	}
 )
 
@@ -266,8 +266,8 @@ func api(ctx context.Context, _ *dagger.Client, base, flipt *dagger.Container, c
 		flipt.WithEnvVariable("UNIQUE", uuid.New().String()).WithExec(nil), conf)
 }
 
-func rest(ctx context.Context, _ *dagger.Client, base, flipt *dagger.Container, conf testConfig) func() error {
-	return suite(ctx, "rest", base,
+func snapshot(ctx context.Context, _ *dagger.Client, base, flipt *dagger.Container, conf testConfig) func() error {
+	return suite(ctx, "snapshot", base,
 		// create unique instance for test case
 		flipt.WithEnvVariable("UNIQUE", uuid.New().String()).WithExec(nil), conf)
 }

--- a/build/testing/integration/integration.go
+++ b/build/testing/integration/integration.go
@@ -48,6 +48,10 @@ type NamespaceExpectation struct {
 	Expected string
 }
 
+func (n NamespaceExpectation) String() string {
+	return n.Expected
+}
+
 type NamespaceExpectations []NamespaceExpectation
 
 // OtherNamespaceFrom returns any other namespace in the set of expected

--- a/build/testing/integration/snapshot/snapshot.go
+++ b/build/testing/integration/snapshot/snapshot.go
@@ -76,7 +76,7 @@ func Snapshot(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 				_, err = client.Flipt().CreateFlag(ctx, &flipt.CreateFlagRequest{
 					Type:         flipt.FlagType_BOOLEAN_FLAG_TYPE,
 					NamespaceKey: namespace.Key,
-					Key:          fmt.Sprintf("boolean_disabled%s", flag),
+					Key:          fmt.Sprintf("boolean_disabled_%s", flag),
 					Name:         "Boolean Disabled",
 					Description:  "This is a disabled boolean test flag",
 					Enabled:      false,
@@ -101,7 +101,6 @@ func Snapshot(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 				resp.Body.Close()
 
 				assert.NotEmpty(t, body)
-				fmt.Printf("body: %q\n", body)
 
 				req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/internal/v1/evaluation/snapshot/namespace/%s", opts.URL, namespace), nil)
 				req.Header.Set("If-None-Match", etag)

--- a/build/testing/integration/snapshot/snapshot.go
+++ b/build/testing/integration/snapshot/snapshot.go
@@ -1,4 +1,4 @@
-package rest
+package snapshot
 
 import (
 	"context"
@@ -11,10 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/build/testing/integration"
 	"go.flipt.io/flipt/rpc/flipt"
+	"golang.org/x/exp/rand"
 )
 
-// REST tests the REST API without using the SDK.
-func REST(t *testing.T, ctx context.Context, opts integration.TestOpts) {
+// Snapshot tests the evaluation data snapshot API without using the SDK (other than for creating)
+func Snapshot(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 	var (
 		client     = opts.TokenClient(t)
 		httpClient = opts.HTTPClient(t)
@@ -35,11 +36,12 @@ func REST(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 		require.NoError(t, err)
 
 		for _, namespace := range integration.Namespaces {
+			flag := fmt.Sprintf("%x", rand.Int63())
 			t.Run(fmt.Sprintf("namespace %q", namespace.Expected), func(t *testing.T) {
 				// create some flags
 				_, err = client.Flipt().CreateFlag(ctx, &flipt.CreateFlagRequest{
 					NamespaceKey: namespace.Key,
-					Key:          "test",
+					Key:          fmt.Sprintf("test_%s", flag),
 					Name:         "Test",
 					Description:  "This is a test flag",
 					Enabled:      true,
@@ -50,7 +52,7 @@ func REST(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 
 				_, err = client.Flipt().CreateFlag(ctx, &flipt.CreateFlagRequest{
 					NamespaceKey: namespace.Key,
-					Key:          "disabled",
+					Key:          fmt.Sprintf("disabled_%s", flag),
 					Name:         "Disabled",
 					Description:  "This is a disabled test flag",
 					Enabled:      false,
@@ -62,7 +64,7 @@ func REST(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 				_, err = client.Flipt().CreateFlag(ctx, &flipt.CreateFlagRequest{
 					Type:         flipt.FlagType_BOOLEAN_FLAG_TYPE,
 					NamespaceKey: namespace.Key,
-					Key:          "boolean_enabled",
+					Key:          fmt.Sprintf("boolean_enabled_%s", flag),
 					Name:         "Boolean Enabled",
 					Description:  "This is an enabled boolean test flag",
 					Enabled:      true,
@@ -74,7 +76,7 @@ func REST(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 				_, err = client.Flipt().CreateFlag(ctx, &flipt.CreateFlagRequest{
 					Type:         flipt.FlagType_BOOLEAN_FLAG_TYPE,
 					NamespaceKey: namespace.Key,
-					Key:          "boolean_disabled",
+					Key:          fmt.Sprintf("boolean_disabled%s", flag),
 					Name:         "Boolean Disabled",
 					Description:  "This is a disabled boolean test flag",
 					Enabled:      false,
@@ -86,8 +88,8 @@ func REST(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 				resp, err := httpClient.Get(fmt.Sprintf("%s/internal/v1/evaluation/snapshot/namespace/%s", opts.URL, namespace))
 
 				require.NoError(t, err)
+				require.NotNil(t, resp)
 				assert.Equal(t, http.StatusOK, resp.StatusCode)
-				defer safeClose(resp.Body)
 
 				// get etag from response
 				etag := resp.Header.Get("ETag")
@@ -96,8 +98,10 @@ func REST(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 				// read body
 				body, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
+				resp.Body.Close()
 
 				assert.NotEmpty(t, body)
+				fmt.Printf("body: %q\n", body)
 
 				req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/internal/v1/evaluation/snapshot/namespace/%s", opts.URL, namespace), nil)
 				req.Header.Set("If-None-Match", etag)
@@ -105,15 +109,12 @@ func REST(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 
 				resp, err = httpClient.Do(req)
 				require.NoError(t, err)
+				require.NotNil(t, resp)
 				assert.Equal(t, http.StatusNotModified, resp.StatusCode)
-				safeClose(resp.Body)
+				if resp.Body != nil {
+					resp.Body.Close()
+				}
 			})
 		}
 	})
-}
-
-func safeClose(r io.ReadCloser) {
-	if r != nil {
-		_ = r.Close()
-	}
 }

--- a/build/testing/integration/snapshot/snapshot_test.go
+++ b/build/testing/integration/snapshot/snapshot_test.go
@@ -1,0 +1,17 @@
+package snapshot_test
+
+import (
+	"context"
+	"testing"
+
+	"go.flipt.io/build/testing/integration"
+	"go.flipt.io/build/testing/integration/snapshot"
+)
+
+func TestSnapshot(t *testing.T) {
+	integration.Harness(t, func(t *testing.T, opts integration.TestOpts) {
+		ctx := context.Background()
+
+		snapshot.Snapshot(t, ctx, opts)
+	})
+}

--- a/go.work.sum
+++ b/go.work.sum
@@ -658,6 +658,7 @@ github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9
 github.com/google/flatbuffers v1.12.1/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/gnostic v0.5.7-v3refs/go.mod h1:73MKFl6jIHelAJNaBGFzt3SPtZULs9dYrGFt8OiIsHQ=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-containerregistry v0.17.0/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
@@ -888,10 +889,12 @@ github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2J
 github.com/moby/sys/mountinfo v0.5.0/go.mod h1:3bMD3Rg+zkqx8MRYPi7Pyb0Ie97QEBmdxbhnCLlSvSU=
 github.com/moby/sys/mountinfo v0.6.2 h1:BzJjoreD5BMFNmD9Rus6gdd1pLuecOFPt8wC+Vygl78=
 github.com/moby/sys/mountinfo v0.6.2/go.mod h1:IJb6JQeOklcdMU9F5xQ8ZALD+CUr5VlGpwtX+VE0rpI=
+github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/sys/signal v0.6.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/moby/sys/symlink v0.2.0/go.mod h1:7uZVF2dqJjG/NsClqul95CqKOBRQyYSNnJ6BMgR/gFs=
+github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4T7MmU=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/moby/term v0.0.0-20210610120745-9d4ed1856297/go.mod h1:vgPCkQMyxTZ7IDy8SXRufE172gr8+K/JE/7hHFxHW3A=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
@@ -1069,6 +1072,7 @@ github.com/secure-systems-lab/go-securesystemslib v0.4.0/go.mod h1:FGBZgq2tXWICs
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shibumi/go-pathspec v1.3.0/go.mod h1:Xutfslp817l2I1cZvgcfeMQJG5QnU2lh5tVaaMCl3jE=
+github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKlUeu/erjjvaPEYiI=
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -1410,6 +1414,7 @@ golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
while I was looking into #3325 , I realized the (previously) REST ITs which were to test the snapshot / data API were not actually being run

Once I got them running, they weren't actually passing.

This fixes both