### PR TITLE
feat: support postgresql url prefix

### DIFF
--- a/internal/storage/sql/db.go
+++ b/internal/storage/sql/db.go
@@ -52,6 +52,7 @@ func init() {
 	// drop references to lib/pq and relay on pgx
 	dburl.Unregister("postgres")
 	dburl.RegisterAlias("pgx", "postgres")
+	dburl.RegisterAlias("pgx", "postgresql")
 }
 
 // Open opens a connection to the db

--- a/internal/storage/sql/db_internal_test.go
+++ b/internal/storage/sql/db_internal_test.go
@@ -35,6 +35,31 @@ func TestParse(t *testing.T) {
 			dsn:    "flipt.db?_fk=true&cache=shared&mode=rwc",
 		},
 		{
+			name: "postgresql url",
+			cfg: config.DatabaseConfig{
+				URL: "postgresql://postgres@localhost:5432/flipt?sslmode=disable",
+			},
+			driver: Postgres,
+			dsn:    "postgres://postgres@localhost:5432/flipt?binary_parameters=yes&sslmode=disable",
+		},
+		{
+			name: "postgresql url prepared statements enabled",
+			cfg: config.DatabaseConfig{
+				URL:                       "postgresql://postgres@localhost:5432/flipt?sslmode=disable",
+				PreparedStatementsEnabled: true,
+			},
+			driver: Postgres,
+			dsn:    "postgres://postgres@localhost:5432/flipt?sslmode=disable",
+		},
+		{
+			name: "postgresql no disable sslmode",
+			cfg: config.DatabaseConfig{
+				URL: "postgresql://postgres@localhost:5432/flipt",
+			},
+			driver: Postgres,
+			dsn:    "postgres://postgres@localhost:5432/flipt?binary_parameters=yes",
+		},
+		{
 			name: "postgres url prepared statements enabled",
 			cfg: config.DatabaseConfig{
 				URL:                       "postgres://postgres@localhost:5432/flipt?sslmode=disable",


### PR DESCRIPTION
this change resolves https://github.com/flipt-io/flipt/issues/3351 by registering `postgresql` URL alias.