### PR TITLE
chore: try to fix stackhawk action

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,9 +163,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download OpenAPI Spec
-        run: |
-          curl -s -o openapi.yml https://raw.githubusercontent.com/flipt-io/flipt-openapi/main/openapi.yml
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
       - name: Update HawkScan Configuration
         uses: mikefarah/yq@master


### PR DESCRIPTION
Try to fix StackHawk scanner action

https://github.com/flipt-io/flipt/actions/runs/10461968611/job/28971622605

![CleanShot 2024-08-19 at 19 44 05@2x](https://github.com/user-attachments/assets/b4b281ea-93aa-4907-93da-7b6b2b2f3b3e)

https://github.com/stackhawk/hawkscan-action?tab=readme-ov-file#java-requirements-for-hawkscan

Also use openapi.yml in root of repo, don't need to download it from anywhere now