### PR TITLE
fix(ui): show boolean flags as enabled in the console dropdown

### DIFF
--- a/ui/src/app/console/Console.tsx
+++ b/ui/src/app/console/Console.tsx
@@ -84,7 +84,8 @@ export default function Console() {
   const flags = useMemo(() => {
     const initialFlags = data?.flags || [];
     return initialFlags.map((flag) => {
-      const status = flag.enabled ? 'active' : 'inactive';
+      const status =
+        flag.enabled || flag.type === FlagType.BOOLEAN ? 'active' : 'inactive';
 
       return {
         ...flag,


### PR DESCRIPTION
With all changes to flags dashboard and showing the boolean flags as
always enabled this commit makes the same for console.

related #3300
