### PR TITLE
feat(ui): save sort state in redux

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1401,6 +1401,7 @@ go.opentelemetry.io/otel v1.7.0/go.mod h1:5BdUoMIz5WEs0vt0CUEMtSSaTSHBBVwrhnz7+n
 go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znnUvNNEo=
 go.opentelemetry.io/otel v1.24.0/go.mod h1:W7b9Ozg4nkF5tWI5zsXkaKKDjdVjpD4oAt9Qi/MArHo=
 go.opentelemetry.io/otel v1.26.0/go.mod h1:UmLkJHUAidDval2EICqBMbnAd0/m2vmpf/dAM+fvFs4=
+go.opentelemetry.io/otel v1.28.0/go.mod h1:q68ijF8Fc8CnMHKyzqL6akLO46ePnjkgfIMIjUIX9z4=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=
 go.opentelemetry.io/otel/exporters/otlp v0.20.0/go.mod h1:YIieizyaN77rtLJra0buKiNBOm9XQfkPEKBeuhoMwAM=
 go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.3.0/go.mod h1:VpP4/RMn8bv8gNo9uK7/IMY4mtWLELsS+JIP0inH0h4=
@@ -1423,6 +1424,7 @@ go.opentelemetry.io/otel/metric v0.30.0/go.mod h1:/ShZ7+TS4dHzDFmfi1kSXMhMVubNoP
 go.opentelemetry.io/otel/metric v1.21.0/go.mod h1:o1p3CA8nNHW8j5yuQLdc1eeqEaPfzug24uvsyIEJRWM=
 go.opentelemetry.io/otel/metric v1.24.0/go.mod h1:VYhLe1rFfxuTXLgj4CBiyz+9WYBA8pNGJgDcSFRKBco=
 go.opentelemetry.io/otel/metric v1.26.0/go.mod h1:SY+rHOI4cEawI9a7N1A4nIg/nTQXe1ccCNWYOJUrpX4=
+go.opentelemetry.io/otel/metric v1.28.0/go.mod h1:Fb1eVBFZmLVTMb6PPohq3TO9IIhUisDsbJoL/+uQW4s=
 go.opentelemetry.io/otel/oteltest v0.20.0/go.mod h1:L7bgKf9ZB7qCwT9Up7i9/pn0PWIa9FqQ2IQ8LoxiGnw=
 go.opentelemetry.io/otel/sdk v0.20.0/go.mod h1:g/IcepuwNsoiX5Byy2nNV0ySUF1em498m7hBWC279Yc=
 go.opentelemetry.io/otel/sdk v1.3.0/go.mod h1:rIo4suHNhQwBIPg9axF8V9CA72Wz2mKF1teNrup8yzs=
@@ -1430,6 +1432,7 @@ go.opentelemetry.io/otel/sdk v1.7.0/go.mod h1:uTEOTwaqIVuTGiJN7ii13Ibp75wJmYUDe3
 go.opentelemetry.io/otel/sdk v1.21.0/go.mod h1:Nna6Yv7PWTdgJHVRD9hIYywQBRx7pbox6nwBnZIxl/E=
 go.opentelemetry.io/otel/sdk v1.22.0/go.mod h1:iu7luyVGYovrRpe2fmj3CVKouQNdTOkxtLzPvPz1DOc=
 go.opentelemetry.io/otel/sdk v1.24.0/go.mod h1:KVrIYw6tEubO9E96HQpcmpTKDVn9gdv35HoYiQWGDFg=
+go.opentelemetry.io/otel/sdk v1.28.0/go.mod h1:oYj7ClPUA7Iw3m+r7GeEjz0qckQRJK2B8zjcZEfu7Pg=
 go.opentelemetry.io/otel/sdk/export/metric v0.20.0/go.mod h1:h7RBNMsDJ5pmI1zExLi+bJK+Dr8NQCh0qGhm1KDnNlE=
 go.opentelemetry.io/otel/sdk/metric v0.20.0/go.mod h1:knxiS8Xd4E/N+ZqKmUPf3gTTZ4/0TjTXukfxjzSTpHE=
 go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
@@ -1438,6 +1441,7 @@ go.opentelemetry.io/otel/trace v1.7.0/go.mod h1:fzLSB9nqR2eXzxPXb2JW9IKE+ScyXA48
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
 go.opentelemetry.io/otel/trace v1.24.0/go.mod h1:HPc3Xr/cOApsBI154IU0OI0HJexz+aw5uPdbs3UCjNU=
 go.opentelemetry.io/otel/trace v1.26.0/go.mod h1:4iDxvGDQuUkHve82hJJ8UqrwswHYsZuWCBllGV2U2y0=
+go.opentelemetry.io/otel/trace v1.28.0/go.mod h1:jPyXzNPg6da9+38HEwElrQiHlVMTnVfM3/yv2OlIHaI=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.11.0/go.mod h1:QpEjXPrNQzrFDZgoTo49dgHR9RYRSrg3NAKnUGl9YpQ=
 go.opentelemetry.io/proto/otlp v0.16.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=

--- a/ui/src/app/flags/flagsApi.ts
+++ b/ui/src/app/flags/flagsApi.ts
@@ -1,7 +1,31 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createApi } from '@reduxjs/toolkit/query/react';
+import { SortingState } from '@tanstack/react-table';
+import { RootState } from '~/store';
 import { IFlag, IFlagBase, IFlagList } from '~/types/Flag';
 import { IVariantBase } from '~/types/Variant';
 import { baseQuery } from '~/utils/redux-rtk';
+
+
+const initialState: {
+  sorting: SortingState;
+} = {
+  sorting: []
+};
+
+export const flagsTableSlice = createSlice({
+  name: 'flagsTable',
+  initialState,
+  reducers: {
+    setSorting: (state, action: PayloadAction<SortingState>) => {
+      const newSorting = action.payload;
+      state.sorting = newSorting;
+    },
+  }
+});
+
+export const selectSorting = (state: RootState) => state.flagsTable.sorting;
+export const { setSorting } = flagsTableSlice.actions;
 
 export const flagsApi = createApi({
   reducerPath: 'flags',

--- a/ui/src/app/flags/flagsApi.ts
+++ b/ui/src/app/flags/flagsApi.ts
@@ -6,7 +6,6 @@ import { IFlag, IFlagBase, IFlagList } from '~/types/Flag';
 import { IVariantBase } from '~/types/Variant';
 import { baseQuery } from '~/utils/redux-rtk';
 
-
 const initialTableState: {
   sorting: SortingState;
 } = {
@@ -20,7 +19,7 @@ export const flagsTableSlice = createSlice({
     setSorting: (state, action: PayloadAction<SortingState>) => {
       const newSorting = action.payload;
       state.sorting = newSorting;
-    },
+    }
   }
 });
 

--- a/ui/src/app/flags/flagsApi.ts
+++ b/ui/src/app/flags/flagsApi.ts
@@ -7,7 +7,7 @@ import { IVariantBase } from '~/types/Variant';
 import { baseQuery } from '~/utils/redux-rtk';
 
 
-const initialState: {
+const initialTableState: {
   sorting: SortingState;
 } = {
   sorting: []
@@ -15,7 +15,7 @@ const initialState: {
 
 export const flagsTableSlice = createSlice({
   name: 'flagsTable',
-  initialState,
+  initialState: initialTableState,
   reducers: {
     setSorting: (state, action: PayloadAction<SortingState>) => {
       const newSorting = action.payload;

--- a/ui/src/app/segments/segmentsApi.ts
+++ b/ui/src/app/segments/segmentsApi.ts
@@ -1,8 +1,31 @@
 import { TagDescription } from '@reduxjs/toolkit/query';
 import { createApi } from '@reduxjs/toolkit/query/react';
+import { SortingState } from '@tanstack/react-table';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { RootState } from '~/store';
 import { IConstraintBase } from '~/types/Constraint';
 import { ISegment, ISegmentBase, ISegmentList } from '~/types/Segment';
 import { baseQuery } from '~/utils/redux-rtk';
+
+const initialTableState: {
+  sorting: SortingState;
+} = {
+  sorting: []
+};
+
+export const segmentsTableSlice = createSlice({
+  name: 'segmentsTable',
+  initialState: initialTableState,
+  reducers: {
+    setSorting: (state, action: PayloadAction<SortingState>) => {
+      const newSorting = action.payload;
+      state.sorting = newSorting;
+    }
+  }
+});
+
+export const selectSorting = (state: RootState) => state.segmentsTable.sorting;
+export const { setSorting } = segmentsTableSlice.actions;
 
 export const segmentTag = (namespaceKey: string): TagDescription<'Segment'> => {
   return { type: 'Segment', id: namespaceKey };

--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -8,7 +8,6 @@ import {
   getSortedRowModel,
   PaginationState,
   Row,
-  SortingState,
   useReactTable
 } from '@tanstack/react-table';
 import { useState } from 'react';

--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -164,7 +164,8 @@ export default function FlagTable(props: FlagTableProps) {
     },
     globalFilterFn: 'includesString',
     onSortingChange: (updater) => {
-      const newSorting = typeof updater === 'function' ? updater(sorting) : updater;
+      const newSorting =
+        typeof updater === 'function' ? updater(sorting) : updater;
       dispatch(setSorting(newSorting));
     },
     onPaginationChange: setPagination,

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -8,7 +8,6 @@ import {
   getSortedRowModel,
   PaginationState,
   Row,
-  SortingState,
   useReactTable
 } from '@tanstack/react-table';
 import { useState } from 'react';

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -12,9 +12,10 @@ import {
   useReactTable
 } from '@tanstack/react-table';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
+import { selectSorting, setSorting } from '~/app/segments/segmentsApi';
 import Pagination from '~/components/Pagination';
 import Searchbox from '~/components/Searchbox';
 import { useTimezone } from '~/data/hooks/timezone';
@@ -28,6 +29,8 @@ type SegmentTableProps = {
 export default function SegmentTable(props: SegmentTableProps) {
   const { segments } = props;
 
+  const dispatch = useDispatch();
+
   const namespace = useSelector(selectCurrentNamespace);
   const { inTimezone } = useTimezone();
 
@@ -35,7 +38,6 @@ export default function SegmentTable(props: SegmentTableProps) {
 
   const searchThreshold = 10;
 
-  const [sorting, setSorting] = useState<SortingState>([]);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: 20
@@ -113,6 +115,7 @@ export default function SegmentTable(props: SegmentTableProps) {
     })
   ];
 
+  const sorting = useSelector(selectSorting);
   const table = useReactTable({
     data: segments,
     columns,
@@ -122,7 +125,11 @@ export default function SegmentTable(props: SegmentTableProps) {
       pagination
     },
     globalFilterFn: 'includesString',
-    onSortingChange: setSorting,
+    onSortingChange: (updater) => {
+      const newSorting =
+        typeof updater === 'function' ? updater(sorting) : updater;
+      dispatch(setSorting(newSorting));
+    },
     onPaginationChange: setPagination,
     onGlobalFilterChange: setFilter,
     getCoreRowModel: getCoreRowModel(),

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -11,7 +11,7 @@ import {
   namespacesSlice
 } from '~/app/namespaces/namespacesSlice';
 import { analyticsApi } from './app/flags/analyticsApi';
-import { flagsApi } from './app/flags/flagsApi';
+import { flagsApi, flagsTableSlice } from './app/flags/flagsApi';
 import { rolloutTag, rolloutsApi } from './app/flags/rolloutsApi';
 import { ruleTag, rulesApi } from './app/flags/rulesApi';
 import { metaSlice } from './app/meta/metaSlice';
@@ -142,9 +142,13 @@ export const store = configureStore({
       status: LoadingStatus.IDLE,
       currentNamespace,
       error: undefined
+    },
+    flagsTable: {
+      sorting: []
     }
   },
   reducer: {
+    flagsTable: flagsTableSlice.reducer,
     refs: refsSlice.reducer,
     user: eventSlice.reducer,
     preferences: preferencesSlice.reducer,

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -19,7 +19,11 @@ import {
   preferencesKey,
   preferencesSlice
 } from './app/preferences/preferencesSlice';
-import { segmentTag, segmentsApi } from './app/segments/segmentsApi';
+import {
+  segmentTag,
+  segmentsApi,
+  segmentsTableSlice
+} from './app/segments/segmentsApi';
 import { tokensApi } from './app/tokens/tokensApi';
 import { LoadingStatus } from './types/Meta';
 import { refsKey, refsSlice } from './app/refs/refsSlice';
@@ -145,10 +149,14 @@ export const store = configureStore({
     },
     flagsTable: {
       sorting: []
+    },
+    segmentsTable: {
+      sorting: []
     }
   },
   reducer: {
     flagsTable: flagsTableSlice.reducer,
+    segmentsTable: segmentsTableSlice.reducer,
     refs: refsSlice.reducer,
     user: eventSlice.reducer,
     preferences: preferencesSlice.reducer,


### PR DESCRIPTION
Re: #3413 

![2024-08-31 12 01 35](https://github.com/user-attachments/assets/02df71ae-0ed7-4266-ac83-b12d6719f589)

Moves sorting state of tables to redux so that it persists between pages

## TODO

- [x] Segments Table
- [ ] ~~Anywhere else we allow sorting in tables~~ will do this if requested by users later