### PR TITLE
fix: support scoped namespace tokens for evaluation data api

### DIFF
--- a/build/testing/integration/snapshot/snapshot_test.go
+++ b/build/testing/integration/snapshot/snapshot_test.go
@@ -15,8 +15,7 @@ import (
 func TestSnapshot(t *testing.T) {
 	integration.Harness(t, func(t *testing.T, opts integration.TestOpts) {
 		var (
-			httpClient = opts.HTTPClient(t, integration.WithRole("viewer")) // TODO: test other roles/namespace combinations
-			protocol   = opts.Protocol()
+			protocol = opts.Protocol()
 		)
 
 		if protocol == integration.ProtocolGRPC {
@@ -24,42 +23,60 @@ func TestSnapshot(t *testing.T) {
 		}
 
 		t.Run("Evaluation Data", func(t *testing.T) {
-			for _, namespace := range integration.Namespaces {
-				t.Run(fmt.Sprintf("namespace %q", namespace.Expected), func(t *testing.T) {
-					t.Logf("Get snapshot for namespace.")
-
-					resp, err := httpClient.Get(fmt.Sprintf("%s/internal/v1/evaluation/snapshot/namespace/%s", opts.URL, namespace))
-
-					require.NoError(t, err)
-					require.NotNil(t, resp)
-					assert.Equal(t, http.StatusOK, resp.StatusCode)
-
-					// get etag from response
-					etag := resp.Header.Get("ETag")
-					assert.NotEmpty(t, etag)
-
-					// read body
-					body, err := io.ReadAll(resp.Body)
-					require.NoError(t, err)
-					resp.Body.Close()
-
-					assert.NotEmpty(t, body)
-
-					t.Logf("Get snapshot for namespace with etag/if-none-match.")
-
-					req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/internal/v1/evaluation/snapshot/namespace/%s", opts.URL, namespace), nil)
-					req.Header.Set("If-None-Match", etag)
-					require.NoError(t, err)
-
-					resp, err = httpClient.Do(req)
-					require.NoError(t, err)
-					require.NotNil(t, resp)
-					assert.Equal(t, http.StatusNotModified, resp.StatusCode)
-					if resp.Body != nil {
-						resp.Body.Close()
+			for _, role := range []string{"admin", "editor", "viewer"} {
+				t.Run(fmt.Sprintf("role %q", role), func(t *testing.T) {
+					httpClient := opts.HTTPClient(t, integration.WithRole(role))
+					for _, namespace := range integration.Namespaces {
+						t.Run(fmt.Sprintf("namespace %q", namespace.Expected), func(t *testing.T) {
+							testSnapshotForNamespace(t, httpClient, opts.URL.String(), namespace.Expected)
+						})
 					}
 				})
 			}
+
+			t.Run("With Namespace Scoped Token", func(t *testing.T) {
+				for _, namespace := range integration.Namespaces {
+					t.Run(fmt.Sprintf("namespace %q", namespace.Expected), func(t *testing.T) {
+						httpClient := opts.HTTPClient(t, integration.WithNamespace(namespace.Expected))
+						testSnapshotForNamespace(t, httpClient, opts.URL.String(), namespace.Expected)
+					})
+				}
+			})
 		})
 	})
+}
+
+func testSnapshotForNamespace(t *testing.T, client *http.Client, url, namespace string) {
+	t.Logf("Get snapshot for namespace.")
+
+	resp, err := client.Get(fmt.Sprintf("%s/internal/v1/evaluation/snapshot/namespace/%s", url, namespace))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// get etag from response
+	etag := resp.Header.Get("ETag")
+	assert.NotEmpty(t, etag)
+
+	// read body
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.NotEmpty(t, body)
+
+	t.Logf("Get snapshot for namespace with etag/if-none-match.")
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/internal/v1/evaluation/snapshot/namespace/%s", url, namespace), nil)
+	req.Header.Set("If-None-Match", etag)
+	require.NoError(t, err)
+
+	resp, err = client.Do(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusNotModified, resp.StatusCode)
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
 }

--- a/build/testing/integration/snapshot/snapshot_test.go
+++ b/build/testing/integration/snapshot/snapshot_test.go
@@ -37,7 +37,8 @@ func TestSnapshot(t *testing.T) {
 			t.Run("With Namespace Scoped Token", func(t *testing.T) {
 				for _, namespace := range integration.Namespaces {
 					t.Run(fmt.Sprintf("namespace %q", namespace.Expected), func(t *testing.T) {
-						httpClient := opts.HTTPClient(t, integration.WithNamespace(namespace.Expected))
+						clientOpts := []integration.ClientOpt{integration.WithNamespace(namespace.Expected), integration.WithRole("admin")}
+						httpClient := opts.HTTPClient(t, clientOpts...)
 						testSnapshotForNamespace(t, httpClient, opts.URL.String(), namespace.Expected)
 					})
 				}

--- a/internal/server/evaluation/data/server.go
+++ b/internal/server/evaluation/data/server.go
@@ -41,6 +41,10 @@ func (srv *Server) RegisterGRPC(server *grpc.Server) {
 	evaluation.RegisterDataServiceServer(server, srv)
 }
 
+func (srv *Server) AllowsNamespaceScopedAuthentication(ctx context.Context) bool {
+	return true
+}
+
 func toEvaluationFlagType(f flipt.FlagType) evaluation.EvaluationFlagType {
 	switch f {
 	case flipt.FlagType_BOOLEAN_FLAG_TYPE:

--- a/rpc/flipt/evaluation/request.go
+++ b/rpc/flipt/evaluation/request.go
@@ -8,3 +8,7 @@ func (r *EvaluationNamespaceSnapshotRequest) Request() []flipt.Request {
 		flipt.NewRequest(flipt.ResourceSegment, flipt.ActionRead, flipt.WithNamespace(r.Key)),
 	}
 }
+
+func (r *EvaluationNamespaceSnapshotRequest) GetNamespaceKey() string {
+	return r.Key
+}


### PR DESCRIPTION
Re: #3438 

Adds support for namespace scoped tokens for evaluation data api