### PR TITLE
fix(audit): include default_variant into flag audit payload

### DIFF
--- a/internal/server/audit/types.go
+++ b/internal/server/audit/types.go
@@ -8,21 +8,26 @@ import (
 // the different sinks.
 
 type Flag struct {
-	Key          string `json:"key"`
-	Name         string `json:"name"`
-	Description  string `json:"description"`
-	Enabled      bool   `json:"enabled"`
-	NamespaceKey string `json:"namespace_key"`
+	Key            string `json:"key"`
+	Name           string `json:"name"`
+	Description    string `json:"description"`
+	Enabled        bool   `json:"enabled"`
+	NamespaceKey   string `json:"namespace_key"`
+	DefaultVariant string `json:"default_variant,omitempty"`
 }
 
 func NewFlag(f *flipt.Flag) *Flag {
-	return &Flag{
+	af := &Flag{
 		Key:          f.Key,
 		Name:         f.Name,
 		Description:  f.Description,
 		Enabled:      f.Enabled,
 		NamespaceKey: f.NamespaceKey,
 	}
+	if f.DefaultVariant != nil {
+		af.DefaultVariant = f.DefaultVariant.Key
+	}
+	return af
 }
 
 type Variant struct {

--- a/internal/server/audit/types_test.go
+++ b/internal/server/audit/types_test.go
@@ -9,10 +9,11 @@ import (
 
 func TestFlag(t *testing.T) {
 	f := &flipt.Flag{
-		Key:          "flipt",
-		Name:         "flipt",
-		NamespaceKey: "flipt",
-		Enabled:      false,
+		Key:            "flipt",
+		Name:           "flipt",
+		NamespaceKey:   "flipt",
+		Enabled:        false,
+		DefaultVariant: nil,
 	}
 	nf := NewFlag(f)
 
@@ -20,6 +21,26 @@ func TestFlag(t *testing.T) {
 	assert.Equal(t, nf.Key, f.Key)
 	assert.Equal(t, nf.Name, f.Name)
 	assert.Equal(t, nf.NamespaceKey, f.NamespaceKey)
+}
+
+func TestFlagWithDefaultVariant(t *testing.T) {
+	f := &flipt.Flag{
+		Key:          "flipt",
+		Name:         "flipt",
+		NamespaceKey: "flipt",
+		Enabled:      false,
+		DefaultVariant: &flipt.Variant{
+			Key: "default-variant",
+		},
+	}
+	nf := NewFlag(f)
+
+	assert.Equal(t, nf.Enabled, f.Enabled)
+	assert.Equal(t, nf.Key, f.Key)
+	assert.Equal(t, nf.Name, f.Name)
+	assert.Equal(t, nf.NamespaceKey, f.NamespaceKey)
+	assert.Equal(t, "default-variant", nf.DefaultVariant)
+
 }
 
 func TestVariant(t *testing.T) {


### PR DESCRIPTION
fixes #3471 