### PR TITLE
chore: update NextJS example to use updated versions of Flipt clientside SDKs

### DIFF
--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -4,7 +4,7 @@ This is an example of how to use Flipt with a NextJS application.
 
 **Note:** This example is not meant to be used in production, it is only meant to demonstrate how to use Flipt with NextJS.
 
-It uses both the [Flipt TypeScript SDK](https://github.com/flipt-io/flipt-node)  and [Flipt Browser SDK](https://github.com/flipt-io/flipt-client-sdks/tree/main/flipt-client-browser) to evalute feature flags from the Flipt API in two different ways:
+It uses both the [Flipt Node SDK](https://github.com/flipt-io/flipt-client-sdks/tree/main/flipt-client-node) and [Flipt Browser SDK](https://github.com/flipt-io/flipt-client-sdks/tree/main/flipt-client-browser) to evalute feature flags from the Flipt API in two different ways:
 
 1. Using the [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props) function to evaluate the flags on the server side before rendering the page 
 1. Using the Flipt Browser SDK to evaluate the flags in the browser/client side
@@ -13,9 +13,11 @@ We also included [some code](./pages/api/hello.ts) showing how you could use Fli
 
 ## Example
 
-In this example, we are leveraging Flipt to prototype some personalization for our NextJS application. We want to show a different greeting message to the user at random, but we aren't sure if we should use client-side data fetching or server-side data fetching, so we are going to try both ways. We will use both the Flipt TypeScript SDK (server-side) and Flipt Browser SDK (client-side) to integrate with Flipt.
+In this example, we are leveraging Flipt to prototype some personalization for our NextJS application. We want to show a different greeting message to the user at random, but we aren't sure if we should use client-side data fetching or server-side data fetching, so we are going to try both ways. We will use both the Flipt Node SDK and Flipt Browser SDK to integrate with Flipt.
 
 ## Architecture
+
+Both examples are using the same Flipt flag and are evaluating the flag within the application. Both of these SDKs pull flag state from the Flipt server and perform evaluation client-side in the browser or server-side (Node.js) in the application.
 
 ### Client Side
 
@@ -23,7 +25,7 @@ For the client-side example, we are using the [Flipt Browser SDK](https://github
 
 ### Server Side
 
-For the server-side example, we are using the [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props) function to evaluate the flags on the server side before rendering the page. This uses the `FliptApiClient` directly to evalute the `language` flag to then render the greeting message.
+For the server-side example, we are using the [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props) function to evaluate the flags on the server side before rendering the page. This uses the `FliptEvaluationClient` to evalute the `language` flag to then render the greeting message. While this example is using the same flag as the client-side example, it is important to note that the Flipt Node SDK is running on the server-side and is not sending any data to the browser.
 
 ## Requirements
 

--- a/examples/nextjs/components/Greeting.tsx
+++ b/examples/nextjs/components/Greeting.tsx
@@ -12,10 +12,10 @@ export default function Greeting() {
           url: process.env.NEXT_PUBLIC_FLIPT_ADDR ?? "http://localhost:8080",
         });
 
-        const evaluation = client.evaluateVariant("language", uuidv4(), {});
-        console.log(evaluation);
+        const result = client.evaluateVariant("language", uuidv4(), {});
+        console.log(result);
 
-        let language = evaluation.result?.variant_key;
+        let language = result.variantKey;
 
         const greeting =
           language == "es"

--- a/examples/nextjs/package-lock.json
+++ b/examples/nextjs/package-lock.json
@@ -8,8 +8,8 @@
       "name": "flipt-nextjs-example",
       "version": "0.1.0",
       "dependencies": {
-        "@flipt-io/flipt": "^0.2.17",
-        "@flipt-io/flipt-client-browser": "^0.0.15",
+        "@flipt-io/flipt-client": "^0.10.0",
+        "@flipt-io/flipt-client-browser": "^0.2.0",
         "@next/font": "13.0.7",
         "@types/node": "18.11.17",
         "@types/react": "18.0.26",
@@ -73,33 +73,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@datadog/browser-core": {
-      "version": "4.50.1",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@datadog/browser-rum": {
-      "version": "4.50.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@datadog/browser-core": "4.50.1",
-        "@datadog/browser-rum-core": "4.50.1"
-      },
-      "peerDependencies": {
-        "@datadog/browser-logs": "4.50.1"
-      },
-      "peerDependenciesMeta": {
-        "@datadog/browser-logs": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@datadog/browser-rum-core": {
-      "version": "4.50.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@datadog/browser-core": "4.50.1"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.4.1",
       "license": "MIT",
@@ -121,21 +94,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/@flipt-io/flipt": {
-      "version": "0.2.17",
-      "dependencies": {
-        "@datadog/browser-rum": "^4.48.1",
-        "form-data": "4.0.0",
-        "js-base64": "3.7.2",
-        "node-fetch": "2.7.0",
-        "qs": "6.11.2",
-        "url-join": "4.0.1"
-      }
+    "node_modules/@flipt-io/flipt-client": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@flipt-io/flipt-client/-/flipt-client-0.10.0.tgz",
+      "integrity": "sha512-Cphmevva1ZfWvzIKxfXnHdB2KCy87N+VObMgz9++n9cKB6/1COCzp9lAg8pny57/V2sUzr5jxwTw1qIp+cP/iA=="
     },
     "node_modules/@flipt-io/flipt-client-browser": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@flipt-io/flipt-client-browser/-/flipt-client-browser-0.0.15.tgz",
-      "integrity": "sha512-NBDLpt7Gy7SWLhmz6P0Bl4iaf1HT7a67cJ61EE7JMPSAl7ZyJdPQKuqgRUuMyw+FXiEMCI0mUYwnGunQW51Nng=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@flipt-io/flipt-client-browser/-/flipt-client-browser-0.2.0.tgz",
+      "integrity": "sha512-Txzh2NmoIPeK76FpnznX+sJPQmjMRDq2fydGM8N+LLxtYz3Vz0u9dwzo7ZnjVkcniKyHKVm5UJyHtQNekzw6aQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
@@ -819,10 +786,6 @@
       "version": "0.0.8",
       "license": "MIT"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
       "dev": true,
@@ -1076,16 +1039,6 @@
       "version": "1.1.4",
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "dev": true,
@@ -1221,13 +1174,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/dequal": {
@@ -1956,18 +1902,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "dev": true,
@@ -2635,10 +2569,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/js-base64": {
-      "version": "3.7.2",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/js-sdsl": {
       "version": "4.4.2",
       "license": "MIT",
@@ -2797,23 +2727,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "license": "ISC",
@@ -2946,24 +2859,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/node-releases": {
@@ -3414,19 +3309,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.11.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -4102,10 +3984,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "license": "MIT"
-    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "dev": true,
@@ -4288,10 +4166,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "license": "MIT"
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
@@ -4306,18 +4180,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@flipt-io/flipt": "^0.2.17",
-    "@flipt-io/flipt-client-browser": "^0.0.15",
+    "@flipt-io/flipt-client": "^0.10.0",
+    "@flipt-io/flipt-client-browser": "^0.2.0",
     "@next/font": "13.0.7",
     "@types/node": "18.11.17",
     "@types/react": "18.0.26",

--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -1,4 +1,4 @@
-import { FliptApiClient } from "@flipt-io/flipt";
+import { FliptEvaluationClient } from "@flipt-io/flipt-client";
 import Head from "next/head";
 import Greeting from "../components/Greeting";
 import { v4 as uuidv4 } from "uuid";
@@ -28,21 +28,13 @@ export default function Home(data: HomeProps) {
   );
 }
 
-const client = new FliptApiClient({
-  environment: process.env.FLIPT_ADDR ?? "http://flipt:8080",
-});
 
 export async function getServerSideProps() {
+  const client = await FliptEvaluationClient.init("default", {url: process.env.FLIPT_ADDR ?? "http://flipt:8080"}  );
   let language = "en";
   try {
-    const evaluation = await client.evaluation.variant({
-      namespaceKey: "default",
-      flagKey: "language",
-      entityId: uuidv4(),
-      context: {},
-    });
-
-    language = evaluation.variantKey;
+    const result = client.evaluateVariant("language", uuidv4(), {});
+    language = result.variantKey;
   } catch (err) {
     console.log(err);
   }


### PR DESCRIPTION
Updates to swap out `flipt-node` with `flipt-client-node` and updates to latest browser SDK

This is to show that both JS client side SDKs work in different contexts in NextJS