### PR TITLE
fix(ofrep): relax flags constraint for bulk evaluation

### DIFF
--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -258,7 +258,7 @@ func NewGRPCServer(
 		evalsrv     = evaluation.New(logger, store)
 		evaldatasrv = evaluationdata.New(logger, store)
 		healthsrv   = health.NewServer()
-		ofrepsrv    = ofrep.New(logger, cfg.Cache, evalsrv)
+		ofrepsrv    = ofrep.New(logger, cfg.Cache, evalsrv, store)
 	)
 
 	var (

--- a/internal/common/store_mock.go
+++ b/internal/common/store_mock.go
@@ -10,6 +10,19 @@ import (
 
 var _ storage.Store = &StoreMock{}
 
+func NewMockStore(t interface {
+	mock.TestingT
+	Cleanup(func())
+},
+) *StoreMock {
+	mock := &StoreMock{}
+	mock.Test(t)
+
+	t.Cleanup(func() { mock.AssertExpectations(t) })
+
+	return mock
+}
+
 type StoreMock struct {
 	mock.Mock
 }

--- a/internal/server/ofrep/errors.go
+++ b/internal/server/ofrep/errors.go
@@ -39,7 +39,3 @@ func newFlagNotFoundError(key string) error {
 func newFlagMissingError() error {
 	return status.Error(codes.InvalidArgument, "flag key was not provided")
 }
-
-func newFlagsMissingError() error {
-	return status.Error(codes.InvalidArgument, "flags were not provided in context")
-}

--- a/internal/server/ofrep/extensions_test.go
+++ b/internal/server/ofrep/extensions_test.go
@@ -8,6 +8,7 @@ import (
 	"go.uber.org/zap/zaptest"
 
 	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/common"
 	"go.flipt.io/flipt/internal/config"
 	"go.flipt.io/flipt/rpc/flipt/ofrep"
 )
@@ -65,7 +66,8 @@ func TestGetProviderConfiguration(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			b := NewMockBridge(t)
-			s := New(zaptest.NewLogger(t), tc.cfg, b)
+			store := common.NewMockStore(t)
+			s := New(zaptest.NewLogger(t), tc.cfg, b, store)
 
 			resp, err := s.GetProviderConfiguration(context.TODO(), &ofrep.GetProviderConfigurationRequest{})
 

--- a/internal/server/ofrep/middleware_test.go
+++ b/internal/server/ofrep/middleware_test.go
@@ -23,11 +23,6 @@ func TestErrorHandler(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			input:          newFlagsMissingError(),
-			expectedCode:   http.StatusBadRequest,
-			expectedOutput: `{"errorCode":"INVALID_CONTEXT","errorDetails":"flags were not provided in context"}`,
-		},
-		{
 			input:          newFlagMissingError(),
 			expectedCode:   http.StatusBadRequest,
 			expectedOutput: `{"errorCode":"INVALID_CONTEXT","errorDetails":"flag key was not provided"}`,


### PR DESCRIPTION
Rework bulk evaluation logic to fetch namespace flags if ones are not provided in the evaluation context. As result
all boolean and enabled variant flags will be evaluated.

fixes #3412
