### PR TITLE
chore: fix deprecated goreleaser warnings

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -1,4 +1,5 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
+version: 2
 
 includes:
   - from_file:
@@ -8,17 +9,17 @@ changelog:
   disable: true
 
 docker_manifests:
-  - name_template: "flipt/flipt:nightly"
+  - version_template: "flipt/flipt:nightly"
     image_templates:
       - "flipt/flipt:v{{ incpatch .Version }}-nightly-amd64"
       - "flipt/flipt:v{{ incpatch .Version }}-nightly-arm64"
 
-  - name_template: "markphelps/flipt:nightly"
+  - version_template: "markphelps/flipt:nightly"
     image_templates:
       - "flipt/flipt:v{{ incpatch .Version }}-nightly-amd64"
       - "flipt/flipt:v{{ incpatch .Version }}-nightly-arm64"
 
-  - name_template: "ghcr.io/flipt-io/flipt:nightly"
+  - version_template: "ghcr.io/flipt-io/flipt:nightly"
     image_templates:
       - "ghcr.io/flipt-io/flipt:v{{ incpatch .Version }}-nightly-amd64"
       - "ghcr.io/flipt-io/flipt:v{{ incpatch .Version }}-nightly-arm64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,11 +73,11 @@ release:
     - [Newsletter](https://www.flipt.io/#newsletter)
 
 snapshot:
-  name_template: "{{ .ShortCommit }}-snapshot"
+  version_template: "{{ .ShortCommit }}-snapshot"
 
 nightly:
   # Default is `{{ incpatch .Version }}-{{ .ShortCommit }}-nightly`.
-  name_template: "{{ incpatch .Version }}-nightly"
+  version_template: "{{ incpatch .Version }}-nightly"
 
 changelog:
   disable: true


### PR DESCRIPTION
fix deprecated goreleaser warnings

https://goreleaser.com/deprecations/#nightlyname_template