### PR TITLE
fix(ofrep): forward x-flipt-namespace http header from grpc-gateway to the ofrep service

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -68,7 +68,7 @@ func NewHTTPServer(
 		evaluateAPI     = gateway.NewGatewayServeMux(logger)
 		evaluateDataAPI = gateway.NewGatewayServeMux(logger, runtime.WithMetadata(grpc_middleware.ForwardFliptAcceptServerVersion), runtime.WithForwardResponseOption(http_middleware.HttpResponseModifier))
 		analyticsAPI    = gateway.NewGatewayServeMux(logger)
-		ofrepAPI        = gateway.NewGatewayServeMux(logger, runtime.WithErrorHandler(ofrep_middleware.ErrorHandler(logger)))
+		ofrepAPI        = gateway.NewGatewayServeMux(logger, runtime.WithMetadata(grpc_middleware.ForwardFliptNamespace), runtime.WithErrorHandler(ofrep_middleware.ErrorHandler(logger)))
 		httpPort        = cfg.Server.HTTPPort
 	)
 

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -318,6 +318,8 @@ func AuditEventUnaryInterceptor(logger *zap.Logger, eventPairChecker audit.Event
 // x-flipt-accept-server-version represents the maximum version of the flipt server that the client can handle.
 const fliptAcceptServerVersionHeaderKey = "x-flipt-accept-server-version"
 
+const fliptNamespaceHeaderKey = "x-flipt-namespace"
+
 type fliptAcceptServerVersionContextKey struct{}
 
 // WithFliptAcceptServerVersion sets the flipt version in the context.
@@ -366,13 +368,23 @@ func FliptAcceptServerVersionUnaryInterceptor(logger *zap.Logger) grpc.UnaryServ
 // ForwardFliptAcceptServerVersion extracts the "x-flipt-accept-server-version"" header from an HTTP request
 // and forwards them as grpc metadata entries.
 func ForwardFliptAcceptServerVersion(ctx context.Context, req *http.Request) metadata.MD {
+	return forwardHeader(ctx, req, fliptAcceptServerVersionHeaderKey)
+}
+
+// ForwardFliptNamespace extracts the "x-flipt-namespace" header from an HTTP request
+// and forwards them as grpc metadata entries.
+func ForwardFliptNamespace(ctx context.Context, req *http.Request) metadata.MD {
+	return forwardHeader(ctx, req, fliptNamespaceHeaderKey)
+}
+
+func forwardHeader(ctx context.Context, req *http.Request, headerKey string) metadata.MD {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		md = metadata.MD{}
 	}
-	values := req.Header.Values(fliptAcceptServerVersionHeaderKey)
+	values := req.Header.Values(headerKey)
 	if len(values) > 0 {
-		md[fliptAcceptServerVersionHeaderKey] = values
+		md[headerKey] = values
 	}
 	return md
 }

--- a/internal/server/middleware/grpc/middleware_test.go
+++ b/internal/server/middleware/grpc/middleware_test.go
@@ -68,12 +68,10 @@ func TestValidationUnaryInterceptor(t *testing.T) {
 		)
 
 		t.Run(tt.name, func(t *testing.T) {
-			var (
-				spyHandler = grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
-					called++
-					return nil, nil
-				})
-			)
+			spyHandler := grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
+				called++
+				return nil, nil
+			})
 
 			_, _ = ValidationUnaryInterceptor(context.Background(), req, nil, spyHandler)
 			assert.Equal(t, wantCalled, called)
@@ -144,11 +142,9 @@ func TestErrorUnaryInterceptor(t *testing.T) {
 		)
 
 		t.Run(tt.name, func(t *testing.T) {
-			var (
-				spyHandler = grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
-					return nil, wantErr
-				})
-			)
+			spyHandler := grpc.UnaryHandler(func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, wantErr
+			})
 
 			_, err := ErrorUnaryInterceptor(context.Background(), nil, nil, spyHandler)
 			if wantErr != nil {
@@ -292,7 +288,6 @@ func TestEvaluationUnaryInterceptor_Evaluation(t *testing.T) {
 				assert.NotEmpty(t, resp.GetRequestId())
 			} else {
 				assert.Equal(t, test.requestID, resp.GetRequestId())
-
 			}
 
 			assert.NotZero(t, resp.GetTimestamp())
@@ -1662,4 +1657,14 @@ func TestForwardFliptAcceptServerVersion(t *testing.T) {
 	md = ForwardFliptAcceptServerVersion(ctx, req)
 	assert.Equal(t, []string{"v1.32.0"}, md.Get(fliptAcceptServerVersionHeaderKey))
 	assert.Equal(t, []string{"value"}, md.Get("key"))
+}
+
+func TestForwardFliptNamespace(t *testing.T) {
+	req := httptest.NewRequest("GET", "/", nil)
+	md := ForwardFliptNamespace(context.Background(), req)
+	assert.Empty(t, md.Get(fliptAcceptServerVersionHeaderKey))
+	req.Header.Add(fliptNamespaceHeaderKey, "extra-namespace")
+
+	md = ForwardFliptNamespace(context.Background(), req)
+	assert.Equal(t, []string{"extra-namespace"}, md.Get(fliptNamespaceHeaderKey))
 }


### PR DESCRIPTION
From Discord [message](https://discord.com/channels/960634591000014878/1303354231901917329/1303366864466088091)

>  I have two namespaces : Default and test with different flags. By passing in the header X-Flipt-Namespace: test, i always have the flags from Default namespace

