### PR TITLE
fix(ui): remove unnecessary scrolls for quick edit forms

### DIFF
--- a/ui/src/app/flags/rules/Rules.tsx
+++ b/ui/src/app/flags/rules/Rules.tsx
@@ -145,7 +145,7 @@ export function DefaultVariant(props: RulesProps) {
               </div>
               <div className="flex w-full flex-1 items-center p-2 text-xs lg:p-0">
                 <div className="flex grow flex-col items-center justify-center sm:ml-2 md:flex-row md:justify-between">
-                  <Form className="bg-white flex w-full flex-col overflow-y-scroll">
+                  <Form className="bg-white flex w-full flex-col">
                     <div className="w-full flex-1">
                       <div className="space-y-6 py-6 sm:space-y-0 sm:py-0">
                         {flag.variants && flag.variants.length > 0 && (

--- a/ui/src/components/rollouts/Rollouts.tsx
+++ b/ui/src/components/rollouts/Rollouts.tsx
@@ -118,7 +118,7 @@ export function DefaultRollout(props: RolloutsProps) {
 
               <div className="flex w-full flex-1 items-center p-2 text-xs lg:p-0">
                 <div className="flex grow flex-col items-center justify-center sm:ml-2 md:flex-row md:justify-between">
-                  <Form className="bg-white flex w-full flex-col overflow-y-scroll">
+                  <Form className="bg-white flex w-full flex-col">
                     <div className="w-full flex-1">
                       <div className="space-y-6 py-6 sm:space-y-0 sm:py-0">
                         <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:p-2">

--- a/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
+++ b/ui/src/components/rollouts/forms/QuickEditRolloutForm.tsx
@@ -155,7 +155,7 @@ export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
       }}
     >
       {(formik) => (
-        <Form className="bg-white flex h-full w-full flex-col overflow-y-scroll">
+        <Form className="bg-white flex h-full w-full flex-col">
           <div className="w-full flex-1">
             <div className="space-y-6 py-6 sm:space-y-0 sm:py-0">
               {rollout.type === RolloutType.THRESHOLD ? (

--- a/ui/src/components/rules/forms/QuickEditRuleForm.tsx
+++ b/ui/src/components/rules/forms/QuickEditRuleForm.tsx
@@ -195,7 +195,7 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
     >
       {(formik) => {
         return (
-          <Form className="bg-white flex h-full w-full flex-col overflow-y-scroll">
+          <Form className="bg-white flex h-full w-full flex-col">
             <div className="w-full flex-1">
               <div className="space-y-6 py-6 sm:space-y-0 sm:py-0">
                 <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-2">


### PR DESCRIPTION
This pr addressed these scrolls in Chrome on Linux.

![Screenshot From 2024-11-05 18-18-01](https://github.com/user-attachments/assets/66c8e68d-9fb9-4178-84ec-6dc6bcf0efac)
