### PR TITLE
fix(ui): use dark scheme for browser built-in inputs/scrolls in dark mode

### DIFF
--- a/ui/src/assets/colors/dark.css
+++ b/ui/src/assets/colors/dark.css
@@ -30,6 +30,8 @@
   --red-100: 127 29 29;
   --red-50: 127 29 29;
 
+  color-scheme: dark;
+
   .shadow {
     --tw-shadow: 0 1px 3px 0 rgba(255, 255, 255, 0.1),
       0 1px 2px 0 rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
UI uses some elements for input date, time, etc... They have extra icon
which very hard to see in dark mode and their popups have white
background.

Before

![image](https://github.com/user-attachments/assets/bebc5cff-f642-42a0-9c38-7240c0afcf72)

After

![image](https://github.com/user-attachments/assets/5dcb3e06-cd8b-472f-860b-320c54e98719)
