### PR TITLE
fix(import): import flags with complex metadata

### DIFF
--- a/internal/ext/encoding.go
+++ b/internal/ext/encoding.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"gopkg.in/yaml.v2"
+	yamlv3 "gopkg.in/yaml.v3"
 )
 
 type Encoding string
@@ -44,7 +45,7 @@ func (n NopCloseEncoder) Close() error { return nil }
 func (e Encoding) NewDecoder(r io.Reader) Decoder {
 	switch e {
 	case EncodingYML, EncodingYAML:
-		return yaml.NewDecoder(r)
+		return yamlv3.NewDecoder(r)
 	case EncodingJSON:
 		return json.NewDecoder(r)
 	}

--- a/internal/ext/importer_test.go
+++ b/internal/ext/importer_test.go
@@ -1101,6 +1101,21 @@ func TestImport(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "import with flag complex metadata",
+			path: "testdata/import_flag_complex_metadata",
+			expected: &mockCreator{
+				createflagReqs: []*flipt.CreateFlagRequest{
+					{
+						NamespaceKey: "default",
+						Key:          "test",
+						Name:         "test",
+						Type:         flipt.FlagType_BOOLEAN_FLAG_TYPE,
+						Metadata:     newStruct(t, map[string]any{"args": map[string]any{"name": "value"}}),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/ext/testdata/import_flag_complex_metadata.json
+++ b/internal/ext/testdata/import_flag_complex_metadata.json
@@ -1,0 +1,3 @@
+# exported by Flipt (v1.51.1) on 2024-11-21T16:59:50Z
+
+{"version":"1.4","namespace":{"key":"default","name":"Default","description":"Default namespace"},"flags":[{"key":"test","name":"test","type":"BOOLEAN_FLAG_TYPE","enabled":false,"metadata":{"args":{"name":"value"}}}]}

--- a/internal/ext/testdata/import_flag_complex_metadata.yml
+++ b/internal/ext/testdata/import_flag_complex_metadata.yml
@@ -1,0 +1,15 @@
+# exported by Flipt (v1.51.1) on 2024-11-21T11:39:38Z
+
+version: "1.4"
+namespace:
+  key: default
+  name: Default
+  description: Default namespace
+flags:
+  - key: test
+    name: test
+    type: BOOLEAN_FLAG_TYPE
+    enabled: false
+    metadata:
+      args:
+        name: value


### PR DESCRIPTION
This pull request includes several changes to the `internal/ext` package to enhance the encoding and importing functionalities. 

-  `yaml.v3` is used as import encoder. It returns `map[string]any` instead of `map[any]any` in `jaml.v2`. 
-  fix the issue with importing json backups generated by `flipt export -o file.json`

closes #3635  
closes #3636 