### PR TITLE
feat(analytics): allow to set Authorization header for prometheus

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -430,6 +430,7 @@ import "strings"
 			prometheus?: {
 				enabled?: bool | *false
 				url?:     string | *""
+				auth_token?:   string | *""
 			}
 		}
 		buffer?: {

--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -430,7 +430,7 @@ import "strings"
 			prometheus?: {
 				enabled?: bool | *false
 				url?:     string | *""
-				auth_token?:   string | *""
+				headers?: [string]: string
 			}
 		}
 		buffer?: {

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -1465,6 +1465,10 @@
                 "url": {
                   "type": "string",
                   "default": ""
+                },
+                "auth_token": {
+                  "type": "string",
+                  "default": ""
                 }
               },
               "title": "Prometheus"

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -1466,9 +1466,9 @@
                   "type": "string",
                   "default": ""
                 },
-                "auth_token": {
-                  "type": "string",
-                  "default": ""
+                "headers": {
+                  "type": ["object", "null"],
+                  "additionalProperties": { "type": "string" }
                 }
               },
               "title": "Prometheus"

--- a/examples/analytics/prometheus/docker-compose.yml
+++ b/examples/analytics/prometheus/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - --web.config.file=/etc/prometheus/web-config.yml
   flipt:
     image: flipt/flipt:latest
+    volumes:
+      - "./flipt-config.yml:/etc/flipt/config/default.yml"
     depends_on:
       prometheus:
         condition: service_healthy
@@ -25,7 +27,7 @@ services:
       - FLIPT_LOG_LEVEL=info
       - FLIPT_ANALYTICS_STORAGE_PROMETHEUS_ENABLED=true
       - FLIPT_ANALYTICS_STORAGE_PROMETHEUS_URL=http://prometheus:9090
-      - FLIPT_ANALYTICS_STORAGE_PROMETHEUS_AUTH_TOKEN='Basic YWRtaW46dGVzdA=='
+      - PROMETHEUS_AUTH_TOKEN='Basic YWRtaW46dGVzdA=='
       - FLIPT_META_TELEMETRY_ENABLED=false
     command: ["/flipt", "--force-migrate"]
 

--- a/examples/analytics/prometheus/docker-compose.yml
+++ b/examples/analytics/prometheus/docker-compose.yml
@@ -5,8 +5,12 @@ services:
     image: prom/prometheus:latest
     volumes:
       - "./prometheus.yml:/etc/prometheus/prometheus.yml"
+      - "./web-config.yml:/etc/prometheus/web-config.yml"
     ports:
       - "9090:9090"
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.config.file=/etc/prometheus/web-config.yml
   flipt:
     image: flipt/flipt:latest
     depends_on:
@@ -21,6 +25,7 @@ services:
       - FLIPT_LOG_LEVEL=info
       - FLIPT_ANALYTICS_STORAGE_PROMETHEUS_ENABLED=true
       - FLIPT_ANALYTICS_STORAGE_PROMETHEUS_URL=http://prometheus:9090
+      - FLIPT_ANALYTICS_STORAGE_PROMETHEUS_AUTH_TOKEN='Basic YWRtaW46dGVzdA=='
       - FLIPT_META_TELEMETRY_ENABLED=false
     command: ["/flipt", "--force-migrate"]
 

--- a/examples/analytics/prometheus/flipt-config.yml
+++ b/examples/analytics/prometheus/flipt-config.yml
@@ -1,0 +1,7 @@
+analytics:
+  storage:
+    prometheus:
+      enabled: true
+      url: http://localhost:9090
+      headers:
+        Authorization: ${PROMETHEUS_AUTH_TOKEN}

--- a/examples/analytics/prometheus/web-config.yml
+++ b/examples/analytics/prometheus/web-config.yml
@@ -1,0 +1,3 @@
+basic_auth_users:
+  admin: $2b$12$hNf2lSsxfm0.i4a.1kVpSOVyBCfIB51VRjgBUyv6kdnyTlgWj81Ay
+  # password is `test`

--- a/internal/config/analytics.go
+++ b/internal/config/analytics.go
@@ -60,9 +60,9 @@ func (c *ClickhouseConfig) Options() (*clickhouse.Options, error) {
 
 // PrometheusConfig defines the connection details for connecting Flipt to Prometheus.
 type PrometheusConfig struct {
-	Enabled   bool   `json:"enabled,omitempty" mapstructure:"enabled" yaml:"enabled,omitempty"`
-	URL       string `json:"-" mapstructure:"url" yaml:"-"`
-	AuthToken string `json:"-" mapstructure:"auth_token" yaml:"-"`
+	Enabled bool              `json:"enabled,omitempty" mapstructure:"enabled" yaml:"enabled,omitempty"`
+	URL     string            `json:"-" mapstructure:"url" yaml:"-"`
+	Headers map[string]string `json:"-" mapstructure:"headers" yaml:"-"`
 }
 
 //nolint:unparam

--- a/internal/config/analytics.go
+++ b/internal/config/analytics.go
@@ -60,8 +60,9 @@ func (c *ClickhouseConfig) Options() (*clickhouse.Options, error) {
 
 // PrometheusConfig defines the connection details for connecting Flipt to Prometheus.
 type PrometheusConfig struct {
-	Enabled bool   `json:"enabled,omitempty" mapstructure:"enabled" yaml:"enabled,omitempty"`
-	URL     string `json:"url,omitempty" mapstructure:"url" yaml:"url,omitempty"`
+	Enabled   bool   `json:"enabled,omitempty" mapstructure:"enabled" yaml:"enabled,omitempty"`
+	URL       string `json:"-" mapstructure:"url" yaml:"-"`
+	AuthToken string `json:"-" mapstructure:"auth_token" yaml:"-"`
 }
 
 //nolint:unparam

--- a/internal/server/analytics/prometheus/client.go
+++ b/internal/server/analytics/prometheus/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/api"
@@ -26,6 +27,12 @@ type client struct {
 func New(logger *zap.Logger, cfg *config.Config) (*client, error) {
 	apiClient, err := api.NewClient(api.Config{
 		Address: cfg.Analytics.Storage.Prometheus.URL,
+		RoundTripper: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if cfg.Analytics.Storage.Prometheus.AuthToken != "" {
+				r.Header.Set("Authorization", cfg.Analytics.Storage.Prometheus.AuthToken)
+			}
+			return api.DefaultRoundTripper.RoundTrip(r)
+		}),
 	})
 	if err != nil {
 		return nil, err
@@ -75,4 +82,10 @@ func (c *client) GetFlagEvaluationsCount(ctx context.Context, req *panalytics.Fl
 
 func (c *client) String() string {
 	return "prometheus"
+}
+
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
 }

--- a/internal/server/analytics/prometheus/client.go
+++ b/internal/server/analytics/prometheus/client.go
@@ -28,8 +28,8 @@ func New(logger *zap.Logger, cfg *config.Config) (*client, error) {
 	apiClient, err := api.NewClient(api.Config{
 		Address: cfg.Analytics.Storage.Prometheus.URL,
 		RoundTripper: roundTripFunc(func(r *http.Request) (*http.Response, error) {
-			if cfg.Analytics.Storage.Prometheus.AuthToken != "" {
-				r.Header.Set("Authorization", cfg.Analytics.Storage.Prometheus.AuthToken)
+			for k, v := range cfg.Analytics.Storage.Prometheus.Headers {
+				r.Header.Set(k, v)
 			}
 			return api.DefaultRoundTripper.RoundTrip(r)
 		}),


### PR DESCRIPTION
Prometheus supports basic auth. Fly.io has bearer token or own Fly
token. To simplify maintenance and Flipt configuration, this PR will allow to set
HTTP Authorization header with value from prometheus auth_token configuration.

