### PR TITLE
Mp/UI new table

### DIFF
--- a/ui/src/app/flags/Flags.tsx
+++ b/ui/src/app/flags/Flags.tsx
@@ -37,7 +37,7 @@ export default function Flags() {
           New Flag
         </Button>
       </PageHeader>
-      <div className="flex flex-col gap-1 py-2">
+      <div className="flex flex-col gap-1 space-y-2 py-2">
         {flags && flags.length > 0 ? (
           <FlagTable flags={flags} />
         ) : (

--- a/ui/src/app/segments/Segments.tsx
+++ b/ui/src/app/segments/Segments.tsx
@@ -38,7 +38,7 @@ export default function Segments() {
           New Segment
         </Button>
       </PageHeader>
-      <div className="flex flex-col gap-1 py-2">
+      <div className="flex flex-col gap-1 space-y-2 py-2">
         {segments && segments.length > 0 ? (
           <SegmentTable segments={segments} />
         ) : (

--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -177,7 +177,7 @@ export default function FlagTable(props: FlagTableProps) {
             <div className="flex w-full flex-col gap-1">
               <div className="flex items-center">
                 <div className="flex items-center gap-2">
-                  <div className="font-semibold">{item.name}</div>
+                  <div className="truncate font-semibold">{item.name}</div>
                   <Badge variant="outlinemuted" className="hidden sm:block">
                     {item.key}
                   </Badge>

--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -22,12 +22,13 @@ import { formatDistanceToNowStrict, parseISO } from 'date-fns';
 import { Search } from '~/components/ui/search';
 import { DataTableViewOptions } from '~/components/ui/table-view-options';
 import Guide from '~/components/ui/guide';
+import { VariableIcon, ToggleLeftIcon } from 'lucide-react';
 
 type FlagTableProps = {
   flags: IFlag[];
 };
 
-function Details({ item }: { item: IFlag }) {
+function FlagDetails({ item }: { item: IFlag }) {
   const enabled = item.type === FlagType.BOOLEAN || item.enabled;
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -35,7 +36,14 @@ function Details({ item }: { item: IFlag }) {
         {enabled ? 'Enabled' : 'Disabled'}
       </Badge>
       <span>•</span>
-      <span>{flagTypeToLabel(item.type)}</span>
+      <span className="flex items-center gap-1">
+        {item.type === FlagType.BOOLEAN ? (
+          <ToggleLeftIcon className="h-4 w-4" />
+        ) : (
+          <VariableIcon className="h-4 w-4" />
+        )}
+        {flagTypeToLabel(item.type)}
+      </span>
       <span className="hidden sm:block">•</span>
       <span className="hidden sm:block">
         Created{' '}
@@ -187,7 +195,7 @@ export default function FlagTable(props: FlagTableProps) {
             <div className="line-clamp-2 text-xs text-secondary-foreground">
               {item.description}
             </div>
-            <Details item={item} />
+            <FlagDetails item={item} />
           </button>
         );
       })}

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -13,7 +13,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
 import { selectSorting, setSorting } from '~/app/segments/segmentsApi';
 import { useTimezone } from '~/data/hooks/timezone';
-import { ISegment, segmentMatchTypeToLabel } from '~/types/Segment';
+import {
+  ISegment,
+  SegmentMatchType,
+  segmentMatchTypeToLabel
+} from '~/types/Segment';
 import { cn } from '~/lib/utils';
 import { Badge } from '~/components/ui/badge';
 import { formatDistanceToNowStrict, parseISO } from 'date-fns';
@@ -22,6 +26,7 @@ import { DataTableViewOptions } from '~/components/ui/table-view-options';
 import Guide from '~/components/ui/guide';
 import { useNavigate } from 'react-router-dom';
 import { DataTablePagination } from '~/components/ui/table-pagination';
+import { AsteriskIcon, SigmaIcon } from 'lucide-react';
 
 type SegmentTableProps = {
   segments: ISegment[];
@@ -30,7 +35,14 @@ type SegmentTableProps = {
 function SegmentDetails({ item }: { item: ISegment }) {
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <span>Matches {segmentMatchTypeToLabel(item.matchType)}</span>
+      <span className="flex items-center gap-1">
+        {item.matchType === SegmentMatchType.ALL ? (
+          <SigmaIcon className="h-4 w-4" />
+        ) : (
+          <AsteriskIcon className="h-4 w-4" />
+        )}
+        Matches {segmentMatchTypeToLabel(item.matchType)}
+      </span>
       <span className="hidden sm:block">•</span>
       <span className="hidden sm:block">
         Created{' '}

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -166,7 +166,7 @@ export default function SegmentTable(props: SegmentTableProps) {
             <div className="flex w-full flex-col gap-1">
               <div className="flex items-center">
                 <div className="flex items-center gap-2">
-                  <div className="font-semibold">{item.name}</div>
+                  <div className="truncate font-semibold">{item.name}</div>
                   <Badge variant="outlinemuted" className="hidden sm:block">
                     {item.key}
                   </Badge>

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -30,7 +30,7 @@ type SegmentTableProps = {
 function Details({ item }: { item: ISegment }) {
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">
-      <span>{segmentMatchTypeToLabel(item.matchType)}</span>
+      <span>Matches {segmentMatchTypeToLabel(item.matchType)}</span>
       <span className="hidden sm:block">•</span>
       <span className="hidden sm:block">
         Created{' '}

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -27,7 +27,7 @@ type SegmentTableProps = {
   segments: ISegment[];
 };
 
-function Details({ item }: { item: ISegment }) {
+function SegmentDetails({ item }: { item: ISegment }) {
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">
       <span>Matches {segmentMatchTypeToLabel(item.matchType)}</span>
@@ -176,7 +176,7 @@ export default function SegmentTable(props: SegmentTableProps) {
             <div className="line-clamp-2 text-xs text-secondary-foreground">
               {item.description}
             </div>
-            <Details item={item} />
+            <SegmentDetails item={item} />
           </button>
         );
       })}

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ const badgeVariants = cva(
           'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
         outline: 'text-foreground',
         outlinemuted: 'text-muted-foreground',
-        enabled: 'text-destructive-foreground bg-chart-2/60'
+        enabled: 'text-destructive-foreground bg-green-500'
       }
     },
     defaultVariants: {


### PR DESCRIPTION
![CleanShot 2024-11-30 at 17 01 00@2x](https://github.com/user-attachments/assets/9a3294c9-00fc-4f22-a055-53d6c06541a4)
![CleanShot 2024-11-30 at 17 00 41@2x](https://github.com/user-attachments/assets/6c7090d5-4214-4495-be00-5cd26d20080f)

couple minor suggested changes:

- give a bit more vertical spacing in between rows
- add icon next to flag type
- add 'Matches' next to segment type
- changed enabled badge to be brighter green to match enabled toggle
- add truncate class to flag and segment names