### PR TITLE
fix: dont return db url in meta/config response

### DIFF
--- a/build/testing/integration/api/api.go
+++ b/build/testing/integration/api/api.go
@@ -1422,6 +1422,9 @@ func API(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 		var configMap map[string]any
 		require.NoError(t, json.Unmarshal(config.Data, &configMap))
 
+		// Add check for password fields
+		assert.False(t, checkForPasswordFields(configMap), "Configuration contains a field named 'password'")
+
 		for _, name := range []string{
 			"log",
 			"ui",
@@ -1468,4 +1471,18 @@ func API(t *testing.T, ctx context.Context, opts integration.TestOpts) {
 
 func namespaceIsDefault(ns string) bool {
 	return ns == "" || ns == "default"
+}
+
+func checkForPasswordFields(data map[string]any) bool {
+	for key, value := range data {
+		if key == "password" {
+			return true
+		}
+		if nestedMap, ok := value.(map[string]any); ok {
+			if checkForPasswordFields(nestedMap) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -406,6 +406,7 @@ contrib.go.opencensus.io/integrations/ocsql v0.1.7/go.mod h1:8DsSdjz3F+APR+0z0Wk
 cuelang.org/go v0.8.2/go.mod h1:CoDbYolfMms4BhWUlhD+t5ORnihR7wvjcfgyO9lL5FI=
 cuelang.org/go v0.9.2/go.mod h1:qpAYsLOf7gTM1YdEg6cxh553uZ4q9ZDWlPbtZr9q1Wk=
 cuelang.org/go v0.10.0/go.mod h1:HzlaqqqInHNiqE6slTP6+UtxT9hN6DAzgJgdbNxXvX8=
+cuelang.org/go v0.10.1/go.mod h1:HzlaqqqInHNiqE6slTP6+UtxT9hN6DAzgJgdbNxXvX8=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
 github.com/99designs/keyring v1.2.1/go.mod h1:fc+wB5KTk9wQ9sDx0kFXB3A0MaeGHM9AwRStKOQ5vOA=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
@@ -1448,6 +1449,7 @@ github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrb
 github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
 github.com/prometheus/client_golang v1.20.0/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
+github.com/prometheus/client_golang v1.20.4/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.0.0-20171117100541-99fa1f4be8e5/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
 github.com/prometheus/client_model v0.5.0/go.mod h1:dTiFglRmd66nLR9Pv9f0mZi7B7fk5Pm3gvsjB5tr+kI=

--- a/internal/config/database.go
+++ b/internal/config/database.go
@@ -33,12 +33,12 @@ const (
 //
 // Flipt currently supports SQLite, Postgres and MySQL backends.
 type DatabaseConfig struct {
-	URL                       string           `json:"url,omitempty" mapstructure:"url,omitempty" yaml:"url,omitempty"`
+	URL                       string           `json:"-" mapstructure:"url,omitempty" yaml:"url,omitempty"`
 	MaxIdleConn               int              `json:"maxIdleConn,omitempty" mapstructure:"max_idle_conn" yaml:"max_idle_conn,omitempty"`
 	MaxOpenConn               int              `json:"maxOpenConn,omitempty" mapstructure:"max_open_conn" yaml:"max_open_conn,omitempty"`
 	ConnMaxLifetime           time.Duration    `json:"connMaxLifetime,omitempty" mapstructure:"conn_max_lifetime" yaml:"conn_max_lifetime,omitempty"`
 	Name                      string           `json:"name,omitempty" mapstructure:"name,omitempty" yaml:"name,omitempty"`
-	User                      string           `json:"user,omitempty" mapstructure:"user,omitempty" yaml:"user,omitempty"`
+	User                      string           `json:"-" mapstructure:"user,omitempty" yaml:"user,omitempty"`
 	Password                  string           `json:"-" mapstructure:"password,omitempty" yaml:"-"`
 	Host                      string           `json:"host,omitempty" mapstructure:"host,omitempty" yaml:"host,omitempty"`
 	Port                      int              `json:"port,omitempty" mapstructure:"port,omitempty" yaml:"port,omitempty"`


### PR DESCRIPTION
Fix issue raised in Discord about url being return in meta/config endpoint which can contain db creds