### PR TITLE
fix(ui): use table skeleton while flags or segments are loading

### DIFF
--- a/ui/src/app/flags/Flags.tsx
+++ b/ui/src/app/flags/Flags.tsx
@@ -1,33 +1,19 @@
-import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { selectReadonly } from '~/app/meta/metaSlice';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
-import { useError } from '~/data/hooks/error';
-import { useListFlagsQuery } from './flagsApi';
 import { Plus } from 'lucide-react';
 import { Button } from '~/components/ui/button';
 import FlagTable from '~/components/flags/FlagTable';
-import Guide from '~/components/ui/guide';
 import { PageHeader } from '~/components/ui/page';
 
 export default function Flags() {
   const namespace = useSelector(selectCurrentNamespace);
   const path = `/namespaces/${namespace.key}/flags`;
 
-  const { data, error } = useListFlagsQuery(namespace.key);
-  const flags = data?.flags || [];
-
   const navigate = useNavigate();
-  const { setError } = useError();
 
   const readOnly = useSelector(selectReadonly);
-
-  useEffect(() => {
-    if (error) {
-      setError(error);
-    }
-  }, [error, setError]);
 
   return (
     <>
@@ -38,14 +24,7 @@ export default function Flags() {
         </Button>
       </PageHeader>
       <div className="flex flex-col gap-1 space-y-2 py-2">
-        {flags && flags.length > 0 ? (
-          <FlagTable flags={flags} />
-        ) : (
-          <Guide className="mt-6">
-            Flags enable you to control and roll out new functionality
-            dynamically. Create a new flag to get started.
-          </Guide>
-        )}
+        <FlagTable namespace={namespace} />
       </div>
     </>
   );

--- a/ui/src/app/segments/Segments.tsx
+++ b/ui/src/app/segments/Segments.tsx
@@ -1,34 +1,20 @@
 import { Plus } from 'lucide-react';
-import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { selectReadonly } from '~/app/meta/metaSlice';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesSlice';
-import { useListSegmentsQuery } from '~/app/segments/segmentsApi';
 import SegmentTable from '~/components/segments/SegmentTable';
 import { Button } from '~/components/ui/button';
-import Guide from '~/components/ui/guide';
 import { PageHeader } from '~/components/ui/page';
-import { useError } from '~/data/hooks/error';
 
 export default function Segments() {
   const namespace = useSelector(selectCurrentNamespace);
 
   const path = `/namespaces/${namespace.key}/segments`;
 
-  const { data, error } = useListSegmentsQuery(namespace.key);
-  const segments = data?.segments || [];
   const navigate = useNavigate();
-  const { setError } = useError();
 
   const readOnly = useSelector(selectReadonly);
-
-  useEffect(() => {
-    if (error) {
-      setError(error);
-      return;
-    }
-  }, [error, setError]);
 
   return (
     <>
@@ -39,13 +25,7 @@ export default function Segments() {
         </Button>
       </PageHeader>
       <div className="flex flex-col gap-1 space-y-2 py-2">
-        {segments && segments.length > 0 ? (
-          <SegmentTable segments={segments} />
-        ) : (
-          <Guide className="mt-6">
-            Segments enable request targeting based on defined criteria.
-          </Guide>
-        )}
+        <SegmentTable namespace={namespace} />
       </div>
     </>
   );

--- a/ui/src/components/ui/skeleton.tsx
+++ b/ui/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from '~/lib/utils';
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-primary/10', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/ui/src/components/ui/table-skeleton.tsx
+++ b/ui/src/components/ui/table-skeleton.tsx
@@ -1,0 +1,19 @@
+import { Skeleton } from '~/components/ui/skeleton';
+
+const TableSkeleton = () => {
+  return (
+    <>
+      <div className="flex items-center justify-between">
+        <div className="flex flex-1 items-center justify-between space-x-2 py-4">
+          <Skeleton className="h-8 w-[150px] text-xs lg:w-[250px]" />
+          <Skeleton className="h-8 w-[75px] text-xs" />
+        </div>
+      </div>
+      <Skeleton className="h-[96px] w-full" />
+    </>
+  );
+};
+
+TableSkeleton.displayName = 'TableSkeleton';
+
+export { TableSkeleton };


### PR DESCRIPTION
If there is small network delay the flags or segments table could show
intro message, which could mislead a bit. Instead of using loader I
would like to use skeleton idea.
