### PR TITLE
chore: rm dot between enabled badge on flags table

### DIFF
--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -35,7 +35,6 @@ function FlagDetails({ item }: { item: IFlag }) {
       <Badge variant={enabled ? 'enabled' : 'muted'}>
         {enabled ? 'Enabled' : 'Disabled'}
       </Badge>
-      <span>•</span>
       <span className="flex items-center gap-1">
         {item.type === FlagType.BOOLEAN ? (
           <ToggleLeftIcon className="h-4 w-4" />


### PR DESCRIPTION
small ui tweak on flags table, i think it looks better without the dot between the enabled badge on flags table

![CleanShot 2024-12-03 at 15 40 26](https://github.com/user-attachments/assets/35235402-5705-4cf7-8762-4fadfb25667b)
