### PR TITLE
fix(authz): support namespaces filtering

### DIFF
--- a/internal/server/authz/authz.go
+++ b/internal/server/authz/authz.go
@@ -3,6 +3,14 @@ package authz
 import "context"
 
 type Verifier interface {
+	// IsAllowed returns whether the user is allowed to access the resource
 	IsAllowed(ctx context.Context, input map[string]any) (bool, error)
+	// Namespaces returns the list of namespaces the user has access to
+	Namespaces(ctx context.Context, input map[string]any) ([]string, error)
+	// Shutdown is called when the server is shutting down
 	Shutdown(ctx context.Context) error
 }
+
+type contextKey string
+
+const ViewableNamespacesKey contextKey = "viewable_namespaces"

--- a/internal/server/authz/authz.go
+++ b/internal/server/authz/authz.go
@@ -13,4 +13,4 @@ type Verifier interface {
 
 type contextKey string
 
-const ViewableNamespacesKey contextKey = "viewable_namespaces"
+const NamespacesKey contextKey = "namespaces"

--- a/internal/server/authz/engine/testdata/viewable_namespaces.json
+++ b/internal/server/authz/engine/testdata/viewable_namespaces.json
@@ -1,0 +1,6 @@
+{
+  "roles_to_namespaces": {
+    "devs": ["local", "staging"],
+    "ops": ["staging", "production"]
+  }
+}

--- a/internal/server/authz/engine/testdata/viewable_namespaces.rego
+++ b/internal/server/authz/engine/testdata/viewable_namespaces.rego
@@ -1,0 +1,16 @@
+
+package flipt.authz.v1
+
+import rego.v1
+import data
+
+viewable_namespaces contains namespace if {
+	some role in input.roles
+	some namespace in data.roles_to_namespaces[role]
+}
+
+default allow := false
+
+allow if {
+	input.request.namespace in viewable_namespaces
+}

--- a/internal/server/authz/middleware/grpc/middleware.go
+++ b/internal/server/authz/middleware/grpc/middleware.go
@@ -109,7 +109,7 @@ func AuthorizationRequiredInterceptor(logger *zap.Logger, policyVerifier authz.V
 					// if user has no access to `default` namespace the api call to list namespaces
 					// will return unauthorized error even if user has access to other namespaces.
 					// This is a workaround to allow user to list namespaces in this case.
-					ctx = context.WithValue(ctx, authz.ViewableNamespacesKey, namespaces)
+					ctx = context.WithValue(ctx, authz.NamespacesKey, namespaces)
 				}
 				continue
 			}

--- a/internal/server/authz/middleware/grpc/middleware_test.go
+++ b/internal/server/authz/middleware/grpc/middleware_test.go
@@ -15,14 +15,22 @@ import (
 )
 
 type mockPolicyVerifier struct {
-	isAllowed bool
-	wantErr   error
-	input     map[string]any
+	isAllowed          bool
+	wantErr            error
+	input              map[string]any
+	viewableNamespaces []string
 }
 
 func (v *mockPolicyVerifier) IsAllowed(ctx context.Context, input map[string]any) (bool, error) {
 	v.input = input
 	return v.isAllowed, v.wantErr
+}
+
+func (v *mockPolicyVerifier) Namespaces(_ context.Context, _ map[string]any) ([]string, error) {
+	if v.viewableNamespaces != nil {
+		return v.viewableNamespaces, nil
+	}
+	return nil, errors.ErrUnsupported
 }
 
 func (v *mockPolicyVerifier) Shutdown(_ context.Context) error {
@@ -38,24 +46,24 @@ func (s *mockServer) SkipsAuthorization(ctx context.Context) bool {
 	return s.skipsAuthz
 }
 
-var (
-	adminAuth = &authrpc.Authentication{
-		Metadata: map[string]string{
-			"io.flipt.auth.role": "admin",
-		},
-	}
-)
+var adminAuth = &authrpc.Authentication{
+	Metadata: map[string]string{
+		"io.flipt.auth.role": "admin",
+	},
+}
 
 func TestAuthorizationRequiredInterceptor(t *testing.T) {
-	var tests = []struct {
-		name             string
-		server           any
-		req              any
-		authn            *authrpc.Authentication
-		validatorAllowed bool
-		validatorErr     error
-		wantAllowed      bool
-		authzInput       map[string]any
+	tests := []struct {
+		name               string
+		server             any
+		req                any
+		authn              *authrpc.Authentication
+		validatorAllowed   bool
+		validatorErr       error
+		wantAllowed        bool
+		authzInput         map[string]any
+		viewableNamespaces []string
+		serverFullMethod   string
 	}{
 		{
 			name:  "allowed",
@@ -122,11 +130,26 @@ func TestAuthorizationRequiredInterceptor(t *testing.T) {
 			validatorErr: errors.New("error"),
 			wantAllowed:  false,
 		},
+		{
+			name:               "list namespaces",
+			authn:              adminAuth,
+			req:                &flipt.ListNamespaceRequest{},
+			wantAllowed:        true,
+			viewableNamespaces: []string{"special"},
+			serverFullMethod:   "/flipt.Flipt/ListNamespaces",
+			authzInput: map[string]any{
+				"request": flipt.Request{
+					Resource: flipt.ResourceNamespace,
+					Action:   flipt.ActionRead,
+					Status:   flipt.StatusSuccess,
+				},
+				"authentication": adminAuth,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			var (
 				logger  = zap.NewNop()
 				allowed = false
@@ -139,14 +162,16 @@ func TestAuthorizationRequiredInterceptor(t *testing.T) {
 
 				srv           = &grpc.UnaryServerInfo{Server: &mockServer{}}
 				policyVerfier = &mockPolicyVerifier{
-					isAllowed: tt.validatorAllowed,
-					wantErr:   tt.validatorErr,
+					isAllowed:          tt.validatorAllowed,
+					wantErr:            tt.validatorErr,
+					viewableNamespaces: tt.viewableNamespaces,
 				}
 			)
 
 			if tt.server != nil {
 				srv.Server = tt.server
 			}
+			srv.FullMethod = tt.serverFullMethod
 
 			_, err := AuthorizationRequiredInterceptor(logger, policyVerfier)(ctx, tt.req, srv, handler)
 

--- a/internal/server/namespace.go
+++ b/internal/server/namespace.go
@@ -37,7 +37,7 @@ func (s *Server) ListNamespaces(ctx context.Context, r *flipt.ListNamespaceReque
 		return nil, err
 	}
 
-	viewableNamespaces, ok := ctx.Value(authz.ViewableNamespacesKey).([]string)
+	viewableNamespaces, ok := ctx.Value(authz.NamespacesKey).([]string)
 	if viewableNamespaces != nil && ok {
 		filtered := make([]*flipt.Namespace, 0)
 		for _, n := range namespaces {

--- a/internal/server/namespace.go
+++ b/internal/server/namespace.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"slices"
 
 	"go.flipt.io/flipt/errors"
+	"go.flipt.io/flipt/internal/server/authz"
 	"go.flipt.io/flipt/internal/storage"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 	"go.uber.org/zap"
@@ -28,17 +30,30 @@ func (s *Server) ListNamespaces(ctx context.Context, r *flipt.ListNamespaceReque
 		return nil, err
 	}
 
-	resp := flipt.NamespaceList{
-		Namespaces: results.Results,
-	}
+	namespaces := results.Results
 
 	total, err := s.store.CountNamespaces(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 
-	resp.TotalCount = int32(total)
-	resp.NextPageToken = results.NextPageToken
+	viewableNamespaces, ok := ctx.Value(authz.ViewableNamespacesKey).([]string)
+	if viewableNamespaces != nil && ok {
+		filtered := make([]*flipt.Namespace, 0)
+		for _, n := range namespaces {
+			if slices.Contains(viewableNamespaces, n.Key) {
+				filtered = append(filtered, n)
+			}
+		}
+		namespaces = filtered
+		total = uint64(len(filtered))
+	}
+
+	resp := flipt.NamespaceList{
+		Namespaces:    namespaces,
+		TotalCount:    int32(total),
+		NextPageToken: results.NextPageToken,
+	}
 
 	s.logger.Debug("list namespaces", zap.Stringer("response", &resp))
 	return &resp, nil

--- a/internal/server/namespace_test.go
+++ b/internal/server/namespace_test.go
@@ -124,7 +124,7 @@ func TestListNamespaces_WithAuthz(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.WithValue(context.TODO(), authz.ViewableNamespacesKey, tt.viewable)
+			ctx := context.WithValue(context.TODO(), authz.NamespacesKey, tt.viewable)
 
 			got, err := s.ListNamespaces(ctx, &flipt.ListNamespaceRequest{
 				Offset: 10,

--- a/internal/server/namespace_test.go
+++ b/internal/server/namespace_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/flipt/internal/common"
+	"go.flipt.io/flipt/internal/server/authz"
 	"go.flipt.io/flipt/internal/storage"
 	flipt "go.flipt.io/flipt/rpc/flipt"
 	"go.uber.org/zap/zaptest"
@@ -74,6 +75,71 @@ func TestListNamespaces_PaginationOffset(t *testing.T) {
 	assert.NotEmpty(t, got.Namespaces)
 	assert.Equal(t, "YmFy", got.NextPageToken)
 	assert.Equal(t, int32(1), got.TotalCount)
+}
+
+func TestListNamespaces_WithAuthz(t *testing.T) {
+	var (
+		store  = &common.StoreMock{}
+		logger = zaptest.NewLogger(t)
+		s      = &Server{
+			logger: logger,
+			store:  store,
+		}
+	)
+
+	defer store.AssertExpectations(t)
+
+	store.On("ListNamespaces", mock.Anything, storage.ListWithOptions(storage.ReferenceRequest{},
+		storage.ListWithQueryParamOptions[storage.ReferenceRequest](
+			storage.WithLimit(0),
+			storage.WithOffset(10),
+		),
+	)).Return(
+		storage.ResultSet[*flipt.Namespace]{
+			Results: []*flipt.Namespace{
+				{
+					Key: "foo",
+				},
+				{
+					Key: "bar",
+				},
+				{
+					Key: "sub",
+				},
+			},
+			NextPageToken: "YmFy",
+		}, nil)
+
+	store.On("CountNamespaces", mock.Anything, storage.ReferenceRequest{}).Return(uint64(9), nil)
+
+	tests := []struct {
+		name     string
+		viewable []string
+		expected []string
+	}{
+		{"empty", []string{}, []string{}},
+		{"foo", []string{"foo"}, []string{"foo"}},
+		{"foo, bar", []string{"foo", "bar"}, []string{"foo", "bar"}},
+		{"foo, bar, ext", []string{"foo", "bar", "ext"}, []string{"foo", "bar"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.WithValue(context.TODO(), authz.ViewableNamespacesKey, tt.viewable)
+
+			got, err := s.ListNamespaces(ctx, &flipt.ListNamespaceRequest{
+				Offset: 10,
+			})
+
+			require.NoError(t, err)
+
+			out := make([]string, len(got.Namespaces))
+			for i, ns := range got.Namespaces {
+				out[i] = ns.Key
+			}
+			assert.Equal(t, tt.expected, out)
+			assert.Equal(t, len(tt.expected), int(got.TotalCount))
+		})
+	}
 }
 
 func TestListNamespaces_PaginationPageToken(t *testing.T) {
@@ -276,7 +342,6 @@ func TestDeleteNamespace_HasFlags(t *testing.T) {
 	assert.Nil(t, got)
 }
 
-
 func TestDeleteNamespace_ProtectedWithForce(t *testing.T) {
 	var (
 		store  = &common.StoreMock{}
@@ -286,7 +351,7 @@ func TestDeleteNamespace_ProtectedWithForce(t *testing.T) {
 			store:  store,
 		}
 		req = &flipt.DeleteNamespaceRequest{
-			Key: "foo",
+			Key:   "foo",
 			Force: true,
 		}
 	)
@@ -302,7 +367,7 @@ func TestDeleteNamespace_ProtectedWithForce(t *testing.T) {
 
 	got, err := s.DeleteNamespace(context.TODO(), req)
 	require.NoError(t, err)
-	
+
 	assert.NotNil(t, got)
 }
 
@@ -315,7 +380,7 @@ func TestDeleteNamespace_HasFlagsWithForce(t *testing.T) {
 			store:  store,
 		}
 		req = &flipt.DeleteNamespaceRequest{
-			Key: "foo",
+			Key:   "foo",
 			Force: true,
 		}
 	)


### PR DESCRIPTION
This PR enables the ListNamespaces API call, which is critical for the UI functionality. By default, the API will return all namespaces in the response. To ensure the response includes only the namespaces a user is permitted to access, the policy should specify a `viewable_namespaces` array containing the appropriate namespace strings.

closes #3688