### PR TITLE
fix(ui): use available namespace as selected before default fallback

### DIFF
--- a/ui/src/app/namespaces/namespacesSlice.ts
+++ b/ui/src/app/namespaces/namespacesSlice.ts
@@ -54,9 +54,22 @@ export const selectNamespaces = createSelector(
 
 export const selectCurrentNamespace = createSelector(
   [(state: RootState) => state.namespaces],
-  (namespaces) =>
-    namespaces.namespaces[namespaces.currentNamespace] ||
-    ({ key: 'default', name: 'Default', description: '' } as INamespace)
+  (state) => {
+    if (state.namespaces[state.currentNamespace]) {
+      return state.namespaces[state.currentNamespace];
+    }
+
+    if (state.namespaces.default) {
+      return state.namespaces.default;
+    }
+
+    const ns = Object.keys(state.namespaces);
+    if (ns.length > 0) {
+      return state.namespaces[ns[0]];
+    }
+
+    return { key: 'default', name: 'Default', description: '' } as INamespace;
+  }
 );
 
 export const namespaceApi = createApi({


### PR DESCRIPTION
There could be situations when previously selected or default
namespace is not available for user. It could be the case that
default namespace was deleted or authz has a specific rules.
This PR will try to get the first available namespace before
falling back to default mock.

related #3688