### PR TITLE
chore(deps): bump @playwright from 1.49.0 to 1.49.1

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -89,7 +89,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "package-changed": "^3.0.0",
-        "playwright": "^1.49.0",
+        "playwright": "^1.49.1",
         "postcss": "^8.4.49",
         "prettier": "^3.4.2",
         "prettier-plugin-organize-imports": "^3.2.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -95,7 +95,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "package-changed": "^3.0.0",
-    "playwright": "^1.49.0",
+    "playwright": "^1.49.1",
     "postcss": "^8.4.49",
     "prettier": "^3.4.2",
     "prettier-plugin-organize-imports": "^3.2.4",


### PR DESCRIPTION
There is a higher number for CI failures related to playwright tests
with no changes in Flipt UI. Few related bugs were fixed in 1.49.1 so
I hope it will help.
