### PR TITLE
fix: rollout metadata handling

### DIFF
--- a/ui/src/app/flags/rolloutsApi.ts
+++ b/ui/src/app/flags/rolloutsApi.ts
@@ -67,10 +67,14 @@ export const rolloutsApi = createApi({
       }
     >({
       query({ namespaceKey, flagKey, rolloutId, values }) {
+        const update = {
+          ...values,
+          metadata: values.metadata && Object.keys(values.metadata).length === 0 ? {} : values.metadata
+        };
         return {
           url: `/namespaces/${namespaceKey}/flags/${flagKey}/rollouts/${rolloutId}`,
           method: 'PUT',
-          body: values
+          body: update
         };
       },
       invalidatesTags: (_result, _error, arg) => [rolloutTag(arg)]


### PR DESCRIPTION
Fixes #3789

Fix the issue where updating the rollout from the UI does not work correctly when a flag has no metadata.

* Update the `updateRollout` mutation in `ui/src/app/flags/rolloutsApi.ts` to handle empty metadata by sending an empty object instead of an empty array.
* Modify the `updateRollout` mutation to create an `update` object that includes the metadata check and use this object in the `body` of the request.

