### PR TITLE
fix(ui): ui.topbar.color config setting has been broken since v1.53.0

### DIFF
--- a/ui/src/app/meta/metaSlice.ts
+++ b/ui/src/app/meta/metaSlice.ts
@@ -56,9 +56,9 @@ export const metaSlice = createSlice({
             action.payload.storage.type !== StorageType.DATABASE;
         }
         state.config.ui = {
-          defaultTheme: action.payload.ui?.Theme || Theme.SYSTEM,
+          defaultTheme: action.payload.ui?.theme || Theme.SYSTEM,
           topbar: {
-            color: action.payload.ui?.TopbarColor || ''
+            color: action.payload.ui?.topbarColor || ''
           }
         };
       });


### PR DESCRIPTION
The regression when `/meta/config` was replaced with `/meta/info` for UI.

Refs: #3684