### PR TITLE
fix(tests/middleware): ensure eval interceptor noop tests valid rpc

### DIFF
--- a/internal/server/middleware/grpc/middleware_test.go
+++ b/internal/server/middleware/grpc/middleware_test.go
@@ -152,13 +152,16 @@ func TestErrorUnaryInterceptor(t *testing.T) {
 
 func TestEvaluationUnaryInterceptor_Noop(t *testing.T) {
 	var (
-		req = &flipt.GetFlagRequest{
-			Key: "foo",
+		req = &flipt.ListFlagRequest{
+			NamespaceKey: "foo",
 		}
 
 		handler = func(ctx context.Context, r interface{}) (interface{}, error) {
-			return &flipt.Flag{
-				Key: "foo",
+			return &flipt.FlagList{
+				Flags: []*flipt.Flag{
+					{Key: "foo"},
+				},
+				TotalCount: 1,
 			}, nil
 		}
 
@@ -172,10 +175,10 @@ func TestEvaluationUnaryInterceptor_Noop(t *testing.T) {
 
 	assert.NotNil(t, got)
 
-	resp, ok := got.(*flipt.Flag)
+	resp, ok := got.(*flipt.FlagList)
 	assert.True(t, ok)
 	assert.NotNil(t, resp)
-	assert.Equal(t, "foo", resp.Key)
+	assert.Equal(t, "foo", resp.Flags[0].Key)
 }
 
 func TestEvaluationUnaryInterceptor_Evaluation(t *testing.T) {

--- a/internal/server/middleware/grpc/support_test.go
+++ b/internal/server/middleware/grpc/support_test.go
@@ -41,3 +41,7 @@ func (a *authStoreMock) DeleteAuthentications(ctx context.Context, r *storageaut
 func (a *authStoreMock) ExpireAuthenticationByID(ctx context.Context, id string, expireAt *timestamppb.Timestamp) error {
 	return nil
 }
+
+func (a *authStoreMock) Shutdown(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
Lots of little fixes. Bit by bit.