### PR TITLE
fix(ui): use correct field segmentKeys on rollout segment

### DIFF
--- a/ui/src/app/console/Console.tsx
+++ b/ui/src/app/console/Console.tsx
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import * as Yup from 'yup';
 
 import { useListAuthProvidersQuery } from '~/app/auth/authApi';
+import { selectCurrentEnvironment } from '~/app/environments/environmentsApi';
 import { useListFlagsQuery } from '~/app/flags/flagsApi';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesApi';
 
@@ -40,8 +41,6 @@ import {
   generateCurlCommand,
   getErrorMessage
 } from '~/utils/helpers';
-
-import { selectCurrentEnvironment } from '../environments/environmentsApi';
 
 function ResetOnNamespaceChange({ namespace }: { namespace: INamespace }) {
   const { resetForm } = useFormikContext();

--- a/ui/src/components/rollouts/QuickEditRolloutForm.tsx
+++ b/ui/src/components/rollouts/QuickEditRolloutForm.tsx
@@ -19,7 +19,7 @@ type QuickEditRolloutFormProps = {
 export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
   const { rollout, segments } = props;
 
-  const rolloutSegmentKeys = rollout.segment?.segments || [];
+  const rolloutSegmentKeys = rollout.segment?.segmentKeys || [];
 
   const rolloutSegments = rolloutSegmentKeys.map((s) => {
     const segment = segments.find((seg) => seg.key === s);

--- a/ui/src/components/rollouts/Rollouts.tsx
+++ b/ui/src/components/rollouts/Rollouts.tsx
@@ -26,6 +26,7 @@ import { ButtonWithPlus, TextButton } from '~/components/Button';
 import Loading from '~/components/Loading';
 import Modal from '~/components/Modal';
 import Slideover from '~/components/Slideover';
+import { FlagFormContext } from '~/components/flags/FlagFormContext';
 import Select from '~/components/forms/Select';
 import DeletePanel from '~/components/panels/DeletePanel';
 import EditRolloutForm from '~/components/rollouts/EditRolloutForm';
@@ -39,8 +40,6 @@ import { SegmentOperatorType } from '~/types/Segment';
 
 import { useError } from '~/data/hooks/error';
 import { cls } from '~/utils/helpers';
-
-import { FlagFormContext } from '../flags/FlagFormContext';
 
 type RolloutsProps = {
   flag: IFlag;

--- a/ui/src/types/Rollout.ts
+++ b/ui/src/types/Rollout.ts
@@ -19,7 +19,7 @@ export function rolloutTypeToLabel(rolloutType: RolloutType): string {
 
 export interface IRolloutRuleSegment {
   segmentOperator?: SegmentOperatorType;
-  segments?: string[];
+  segmentKeys?: string[];
   value: boolean;
 }
 


### PR DESCRIPTION
Based on #3907 

This fixes the the rollout segment quick form so that the available segments are listed.