### PR TITLE
fix(ui): use segments instead of segmentKeys everywhere

### DIFF
--- a/ui/src/app/Layout.tsx
+++ b/ui/src/app/Layout.tsx
@@ -92,7 +92,7 @@ function InnerLayout() {
           />
         )}
         <main className="flex pt-1 sm:pt-4">
-          <div className="mx-auto w-full max-w-screen-lg overflow-x-auto px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto w-full lg:max-w-screen-lg xl:max-w-screen-xl 2xl:max-w-screen-2xl overflow-x-auto px-4 sm:px-6 lg:px-8">
             <Outlet />
           </div>
         </main>

--- a/ui/src/components/flags/FlagForm.tsx
+++ b/ui/src/components/flags/FlagForm.tsx
@@ -176,9 +176,9 @@ export default function FlagForm(props: { flag?: IFlag }) {
             ruleErrors.rollouts = 'Rollouts must add up to 100%';
           }
           if (!rule.segments || rule.segments.length <= 0) {
-            ruleErrors.segmentKeys = 'Segments length must be greater than 0';
+            ruleErrors.segments = 'Segments length must be greater than 0';
           }
-          if (ruleErrors.rollouts || ruleErrors.segmentKeys) {
+          if (ruleErrors.rollouts || ruleErrors.segments) {
             if (!errors.rules) {
               errors.rules = [];
             }

--- a/ui/src/components/flags/FlagForm.tsx
+++ b/ui/src/components/flags/FlagForm.tsx
@@ -15,6 +15,7 @@ import { selectCurrentNamespace } from '~/app/namespaces/namespacesApi';
 
 import { Button } from '~/components/Button';
 import Loading from '~/components/Loading';
+import { UnsavedChangesModalWrapper } from '~/components/UnsavedChangesModal';
 import Input from '~/components/forms/Input';
 import Toggle from '~/components/forms/Toggle';
 import Rollouts from '~/components/rollouts/Rollouts';
@@ -33,7 +34,6 @@ import {
   stringAsKey
 } from '~/utils/helpers';
 
-import { UnsavedChangesModalWrapper } from '../UnsavedChangesModal';
 import { FlagFormProvider } from './FlagFormContext';
 import { MetadataForm } from './MetadataForm';
 import MetadataFormErrorBoundary from './MetadataFormErrorBoundary';

--- a/ui/src/components/rollouts/EditRolloutForm.tsx
+++ b/ui/src/components/rollouts/EditRolloutForm.tsx
@@ -45,7 +45,7 @@ interface RolloutFormValues {
   description: string;
   operator?: SegmentOperatorType;
   percentage?: number;
-  segmentKeys?: FilterableSegment[];
+  segments?: FilterableSegment[];
   value: string;
 }
 
@@ -67,7 +67,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
       ...rolloutSegment,
       description: values.description,
       segment: {
-        segments: values.segmentKeys?.map((s) => s.key),
+        segments: values.segments?.map((s) => s.key),
         segmentOperator: values.operator,
         value: values.value === 'true'
       }
@@ -107,7 +107,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
       initialValues={{
         type: rollout.type,
         description: rollout.description || '',
-        segmentKeys: segments.flatMap((s) =>
+        segments: segments.flatMap((s) =>
           rollout.segment?.segments?.includes(s.key)
             ? {
                 ...s,
@@ -122,9 +122,9 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
       }}
       validate={(values) => {
         if (values.type === RolloutType.SEGMENT) {
-          if (values.segmentKeys.length <= 0) {
+          if (values.segments.length <= 0) {
             return {
-              segmentKeys: true
+              segments: true
             };
           }
         } else if (values.type === RolloutType.THRESHOLD) {
@@ -270,7 +270,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                 <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                   <div>
                     <label
-                      htmlFor="segmentKeys"
+                      htmlFor="segments"
                       className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
                     >
                       Segment
@@ -279,7 +279,7 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                   <div className="sm:col-span-2">
                     <div>
                       <FieldArray
-                        name="segmentKeys"
+                        name="segments"
                         render={(arrayHelpers) => (
                           <SegmentsPicker
                             segments={segments}
@@ -293,13 +293,13 @@ export default function EditRolloutForm(props: EditRolloutFormProps) {
                               index: number,
                               segment: FilterableSegment
                             ) => arrayHelpers.replace(index, segment)}
-                            selectedSegments={formik.values.segmentKeys}
+                            selectedSegments={formik.values.segments}
                           />
                         )}
                       />
                     </div>
                     <div className="mt-6 flex space-x-8">
-                      {formik.values.segmentKeys.length > 1 &&
+                      {formik.values.segments.length > 1 &&
                         segmentOperators.map((segmentOperator, index) => (
                           <div className="flex space-x-2" key={index}>
                             <div>

--- a/ui/src/components/rollouts/QuickEditRolloutForm.tsx
+++ b/ui/src/components/rollouts/QuickEditRolloutForm.tsx
@@ -19,7 +19,7 @@ type QuickEditRolloutFormProps = {
 export default function QuickEditRolloutForm(props: QuickEditRolloutFormProps) {
   const { rollout, segments } = props;
 
-  const rolloutSegmentKeys = rollout.segment?.segmentKeys || [];
+  const rolloutSegmentKeys = rollout.segment?.segments || [];
 
   const rolloutSegments = rolloutSegmentKeys.map((s) => {
     const segment = segments.find((seg) => seg.key === s);

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -44,7 +44,7 @@ type RolloutFormProps = {
 interface RolloutFormValues {
   type: string;
   description?: string;
-  segmentKeys?: FilterableSegment[];
+  segments?: FilterableSegment[];
   operator?: SegmentOperatorType;
   percentage?: number;
   value: string;
@@ -63,7 +63,7 @@ export default function RolloutForm(props: RolloutFormProps) {
       type: rolloutRuleType,
       description: values.description,
       segment: {
-        segments: values.segmentKeys?.map((s) => s.key),
+        segments: values.segments?.map((s) => s.key),
         segmentOperator: values.operator,
         value: values.value === 'true'
       }
@@ -90,16 +90,16 @@ export default function RolloutForm(props: RolloutFormProps) {
       initialValues={{
         type: rolloutRuleType,
         description: '',
-        segmentKeys: [],
+        segments: [],
         operator: SegmentOperatorType.OR,
         percentage: 50, // TODO: make this 0?
         value: 'true'
       }}
       validate={(values) => {
         if (values.type === RolloutType.SEGMENT) {
-          if (values.segmentKeys.length <= 0) {
+          if (values.segments.length <= 0) {
             return {
-              segmentKeys: true
+              segments: true
             };
           }
         } else if (values.type === RolloutType.THRESHOLD) {
@@ -253,7 +253,7 @@ export default function RolloutForm(props: RolloutFormProps) {
                   </div>
                   <div className="sm:col-span-2">
                     <FieldArray
-                      name="segmentKeys"
+                      name="segments"
                       render={(arrayHelpers) => (
                         <SegmentsPicker
                           segments={segments}
@@ -267,12 +267,12 @@ export default function RolloutForm(props: RolloutFormProps) {
                             index: number,
                             segment: FilterableSegment
                           ) => arrayHelpers.replace(index, segment)}
-                          selectedSegments={formik.values.segmentKeys}
+                          selectedSegments={formik.values.segments}
                         />
                       )}
                     />
                   </div>
-                  {formik.values.segmentKeys.length > 1 && (
+                  {formik.values.segments.length > 1 && (
                     <>
                       <div>
                         <label

--- a/ui/src/components/rollouts/Rollouts.tsx
+++ b/ui/src/components/rollouts/Rollouts.tsx
@@ -163,9 +163,9 @@ export default function Rollouts(props: RolloutsProps) {
   const rollouts = useMemo(() => {
     return props.rollouts!.map((rollout) => {
       if (rollout.segment) {
-        let segmentKeys: string[] = [];
+        let segments: string[] = [];
         if (rollout.segment.segments && rollout.segment.segments.length > 0) {
-          segmentKeys = rollout.segment.segments;
+          segments = rollout.segment.segments;
         }
 
         return {
@@ -173,7 +173,7 @@ export default function Rollouts(props: RolloutsProps) {
           segment: {
             segmentOperator:
               rollout.segment.segmentOperator || SegmentOperatorType.OR,
-            segmentKeys,
+            segments,
             value: rollout.segment.value
           }
         };

--- a/ui/src/types/Rollout.ts
+++ b/ui/src/types/Rollout.ts
@@ -19,7 +19,7 @@ export function rolloutTypeToLabel(rolloutType: RolloutType): string {
 
 export interface IRolloutRuleSegment {
   segmentOperator?: SegmentOperatorType;
-  segmentKeys?: string[];
+  segments?: string[];
   value: boolean;
 }
 


### PR DESCRIPTION
My attempt before didnt work.
It briefly did during a hot reload, but broke elsewhere in the site.
Then it became clear that it is `segments` in the API payload not segmentKeys.
Making it consistent everywhere seems to have it building again and working in my browser.