### PR TITLE
feat(ui): support larger screen widths

### DIFF
--- a/ui/src/app/Layout.tsx
+++ b/ui/src/app/Layout.tsx
@@ -92,7 +92,7 @@ function InnerLayout() {
           />
         )}
         <main className="flex pt-1 sm:pt-4">
-          <div className="mx-auto w-full max-w-screen-lg overflow-x-auto px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto w-full lg:max-w-screen-lg xl:max-w-screen-xl 2xl:max-w-screen-2xl overflow-x-auto px-4 sm:px-6 lg:px-8">
             <Outlet />
           </div>
         </main>

--- a/ui/src/components/flags/FlagForm.tsx
+++ b/ui/src/components/flags/FlagForm.tsx
@@ -15,6 +15,7 @@ import { selectCurrentNamespace } from '~/app/namespaces/namespacesApi';
 
 import { Button } from '~/components/Button';
 import Loading from '~/components/Loading';
+import { UnsavedChangesModalWrapper } from '~/components/UnsavedChangesModal';
 import Input from '~/components/forms/Input';
 import Toggle from '~/components/forms/Toggle';
 import Rollouts from '~/components/rollouts/Rollouts';
@@ -33,7 +34,6 @@ import {
   stringAsKey
 } from '~/utils/helpers';
 
-import { UnsavedChangesModalWrapper } from '../UnsavedChangesModal';
 import { FlagFormProvider } from './FlagFormContext';
 import { MetadataForm } from './MetadataForm';
 import MetadataFormErrorBoundary from './MetadataFormErrorBoundary';


### PR DESCRIPTION
Depends on https://github.com/flipt-io/flipt/pull/3909

Makes it a little wider for wider screens.

<img width="2992" alt="Screenshot 2025-02-11 at 14 28 43" src="https://github.com/user-attachments/assets/1487e3f0-1f72-483c-b3ab-7e451787bff9" />
