### PR TITLE
feat: V2 flipt server

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,7 @@ RUN apt-get update && \
     curl \
     gnupg \
     sudo \
-    openssh-server \
-    postgresql-client && \
+    openssh-server && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -33,7 +32,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 COPY ./core ./core
 COPY ./errors ./errors
-COPY ./rpc/flipt ./rpc/flipt
+COPY ./rpc ./rpc
 COPY ./sdk ./sdk
 
 RUN go mod download -x
@@ -42,9 +41,6 @@ COPY . .
 
 ENV GOPATH=/workspace/go \
     PATH=/workspace/go/bin:$PATH
-
-# set the sqlite DB path to the user's home because of potential permission issues
-ENV FLIPT_DB_URL=file:$HOME/flipt/flipt.db
 
 EXPOSE 8080
 EXPOSE 9000

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,21 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cli:
-    name: CLI Integration Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run CLI Tests
-        uses: dagger/dagger-for-github@v7
-        with:
-          verb: call
-          version: ${{ env.DAGGER_VERSION }}
-          args: test --source .:default cli
-
   test:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -1,6 +1,6 @@
 # Deprecation Notices
 
-This page is used to list deprecation notices for Flipt.
+This page is used to list deprecation notices for Flipt v2.
 
 Deprecated configuration options will be removed after ~6 months from the time they were deprecated.
 
@@ -31,44 +31,3 @@ Description.
     ```
 
 -->
-
-### Jaeger Tracing Exporter
-
-> since [v1.36.0](https://github.com/flipt-io/flipt/releases/tag/v1.36.0)
-
-This module is no longer supported. OpenTelemetry dropped support for Jaeger exporter in July 2023. Jaeger officially accepts and recommends using OTLP.
-
-### API ListFlagRequest, ListSegmentRequest, ListRuleRequest offset
-
-> since [v1.13.0](https://github.com/flipt-io/flipt/releases/tag/v1.13.0)
-
-`offset` has been deprecated in favor of `page_token`/`next_page_token` for `ListFlagRequest`, `ListSegmentRequest` and `ListRuleRequest`. See: [#936](https://github.com/flipt-io/flipt/issues/936).
-
-## Expired Deprecation Notices
-
-The following options were deprecated in the past and were already removed.
-
-### tracing.jaeger.enabled
-
-> deprecated in [v1.18.2](https://github.com/flipt-io/flipt/releases/tag/v1.18.2)
-> removed in [v1.36.0](https://github.com/flipt-io/flipt/releases/tag/v1.36.0)
-
-### ui.enabled
-
-> deprecated in [v1.17.0](https://github.com/flipt-io/flipt/releases/tag/v1.17.0)
-> removed in [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0)
-
-### db.migrations.path and db.migrations_path
-
-> deprecated in [v1.14.0](https://github.com/flipt-io/flipt/releases/tag/v1.14.0)
-> removed in [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0)
-
-### cache.memory.enabled
-
-> deprecated in [v1.10.0](https://github.com/flipt-io/flipt/releases/tag/v1.10.0)
-> removed in [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0)
-
-### cache.memory.expiration
-
-> deprecated in [v1.10.0](https://github.com/flipt-io/flipt/releases/tag/v1.10.0)
-> removed in [v1.28.0](https://github.com/flipt-io/flipt/releases/tag/v1.28.0)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,33 +12,10 @@ Also check out our [Contributing](CONTRIBUTING.md) guide for more information on
 Before starting, make sure you have the following installed:
 
 - [GCC Compiler](https://gcc.gnu.org/install/binaries.html)
-- [SQLite](https://sqlite.org/index.html)
 - [Go 1.23+](https://golang.org/doc/install)
 - [NodeJS >= 18](https://nodejs.org/en/ )
 - [Mage](https://magefile.org/)
 - [Docker](https://docs.docker.com/install/) (for running tests)
-
-## CGO
-
-Flipt uses [CGO](https://golang.org/cmd/cgo/) to compile SQLite.
-
-If you run into errors such as:
-
-```console
-undefined: sqlite3.Error
-```
-
-Then you need to enable CGO. 
-
-### Windows
-
-- Make sure you have the [GCC Compiler](https://gcc.gnu.org/install/binaries.html) installed and in your PATH.
-- `set CGO_ENABLED=1`
-
-### Linux/Mac
-
-- Make sure you have the [GCC Compiler](https://gcc.gnu.org/install/binaries.html) installed and in your PATH.
-- `export CGO_ENABLED=1`
 
 ## Setup
 
@@ -68,7 +45,7 @@ The `bootstrap` task will install all of the necessary tools used for developmen
 
 A sample configuration for running and developing against Flipt can be found at `./config/local.yml`. To run Flipt with this configuration, run:
 
-`./bin/flipt [--config ./config/local.yml`]
+`./bin/flipt server [--config ./config/local.yml]`
 
 To prevent providing the config via config flag every time, you have the option of writing configuration at the location:
 
@@ -78,7 +55,7 @@ To prevent providing the config via config flag every time, you have the option 
 
 The flipt binary will check in that location if a `--config` override is not provided, so you can just invoke the binary:
 
-`./bin/flipt`
+`./bin/flipt server [--config ./config/local.yml]`
 
 The `USER_CONFIG_DIR` is different based on your architecture, and specified [here](https://pkg.go.dev/os#UserConfigDir).
 
@@ -88,7 +65,7 @@ Changing certain types of files such as the proto or ui files require re-buildin
 
 ### Updating .proto Files
 
-After changing `flipt.proto`, you'll need to run `mage proto`. This will regenerate the necessary files in the `rpc` directory.
+After changing any proto files, you'll need to run `mage proto`. This will regenerate the necessary files in the `rpc` directory.
 
 ## UI
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,13 @@ RUN git clone https://github.com/magefile/mage && \
 COPY go.mod .
 COPY go.sum .
 COPY ./errors ./errors
-COPY ./rpc/flipt ./rpc/flipt
+COPY ./rpc ./rpc
 COPY ./sdk ./sdk
 COPY ./core ./core
 
 RUN go mod download
 
 COPY . /home/flipt
-
-ENV CGO_ENABLED=1
 
 RUN mage bootstrap && \
     mage build
@@ -30,7 +28,7 @@ LABEL maintainer="dev@flipt.io"
 LABEL org.opencontainers.image.name="flipt"
 LABEL org.opencontainers.image.source="https://github.com/flipt-io/flipt"
 
-RUN apk add --update --no-cache postgresql-client \
+RUN apk add --update --no-cache \
     openssl \
     ca-certificates
 
@@ -50,4 +48,4 @@ EXPOSE 9000
 
 USER flipt
 
-CMD ["./flipt"]
+CMD ["./flipt", "server"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,8 +4,7 @@ WORKDIR /server
 
 RUN apk add --update --no-cache git bash gcc build-base binutils-gold \
     openssl \
-    ca-certificates \
-    postgresql-client
+    ca-certificates
 
 RUN git clone https://github.com/magefile/mage && \
     cd mage && \
@@ -14,7 +13,7 @@ RUN git clone https://github.com/magefile/mage && \
 COPY go.mod .
 COPY go.sum .
 COPY ./errors ./errors
-COPY ./rpc/flipt ./rpc/flipt
+COPY ./rpc ./rpc
 COPY ./sdk ./sdk
 COPY ./core ./core
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -37,6 +37,7 @@ If you'd like to discuss this plan or add any additional ideas, please open an i
 - [x] Refactor and consolidate configuration options
 - [ ] Fix and improve unit test coverage
 - [ ] Fix and improve integration test coverage
+- [ ] Update CI/CD pipeline
 - [ ] Package and release
     - [ ] Binary
     - [ ] Docker image
@@ -45,4 +46,8 @@ If you'd like to discuss this plan or add any additional ideas, please open an i
 - [ ] Documentation
     - [ ] Create v2 docs site
     - [ ] Migrate applicable docs from v1
+    - [ ] Update README
+    - [ ] Update Development docs
+    - [ ] Update Contributing docs
 - [ ] Update examples
+- [ ] Update Development flow (Codespaces, Devcontainer, Docker-compose, etc)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer="dev@flipt.io"
 LABEL org.opencontainers.image.name="flipt"
 LABEL org.opencontainers.image.source="https://github.com/flipt-io/flipt"
 
-RUN apk add --no-cache postgresql-client \
+RUN apk add --no-cache \
     openssl \
     ca-certificates
 
@@ -27,4 +27,4 @@ EXPOSE 9000
 
 USER flipt
 
-CMD ["./flipt"]
+CMD ["./flipt", "server"]

--- a/build/internal/flipt.go
+++ b/build/internal/flipt.go
@@ -75,8 +75,7 @@ func Base(ctx context.Context, dag *dagger.Client, source, uiDist *dagger.Direct
 		WithoutDirectory("./ui/").
 		WithoutDirectory("./bin/")
 
-	golang = golang.WithEnvVariable("CGO_ENABLED", "1").
-		WithMountedDirectory(".", project)
+	golang = golang.WithMountedDirectory(".", project)
 
 	// fetch and add ui/embed.go on its own
 	embed := dag.Directory().WithFiles("./ui", []*dagger.File{
@@ -127,5 +126,5 @@ func Package(ctx context.Context, client *dagger.Client, flipt *dagger.Container
 		WithExec([]string{"addgroup", "flipt"}).
 		WithExec([]string{"adduser", "-S", "-D", "-g", "''", "-G", "flipt", "-s", "/bin/sh", "flipt"}).
 		WithUser("flipt").
-		WithDefaultArgs([]string{"/flipt"}), nil
+		WithDefaultArgs([]string{"/flipt", "server"}), nil
 }

--- a/magefile.go
+++ b/magefile.go
@@ -73,7 +73,7 @@ func Build() error {
 
 	fmt.Println("Done.")
 	fmt.Printf("\nRun the following to start Flipt:\n")
-	fmt.Printf("\n%v\n", color.CyanString(`./bin/flipt [--config config/local.yml]`))
+	fmt.Printf("\n%v\n", color.CyanString(`./bin/flipt server [--config config/local.yml]`))
 	return nil
 }
 
@@ -159,7 +159,7 @@ func (g Go) Bench() error {
 
 // Runs the Go server in development mode using the local config, without bundling assets
 func (g Go) Run() error {
-	return sh.RunV("go", "run", "./cmd/flipt/...", "--config", "config/local.yml")
+	return sh.RunV("go", "run", "./cmd/flipt/...", "server", "--config", "config/local.yml")
 }
 
 // Builds the Go server for development, without bundling assets
@@ -173,7 +173,7 @@ func (g Go) Build() error {
 
 	fmt.Println("Done.")
 	fmt.Printf("\nRun the following to start Flipt server:\n")
-	fmt.Printf("\n%v\n", color.CyanString(`./bin/flipt [--config config/local.yml]`))
+	fmt.Printf("\n%v\n", color.CyanString(`./bin/flipt server [--config config/local.yml]`))
 	fmt.Printf("\nIn another shell, run the following to start the UI in dev mode:\n")
 	fmt.Printf("\n%v\n", color.CyanString(`cd ui && npm run dev`))
 	return nil
@@ -242,14 +242,6 @@ func (g Go) Proto() error {
 func (g Go) Test() error {
 	fmt.Println("Testing...")
 
-	env := map[string]string{
-		"FLIPT_TEST_DATABASE_PROTOCOL": "sqlite3",
-	}
-
-	if os.Getenv("FLIPT_TEST_DATABASE_PROTOCOL") != "" {
-		env["FLIPT_TEST_DATABASE_PROTOCOL"] = os.Getenv("FLIPT_TEST_DATABASE_PROTOCOL")
-	}
-
 	var (
 		testCmd  = "gotest"
 		testArgs = []string{}
@@ -269,7 +261,7 @@ func (g Go) Test() error {
 	}
 
 	testArgs = append(testArgs, "./...")
-	return sh.RunWithV(env, testCmd, testArgs...)
+	return sh.RunV(testCmd, testArgs...)
 }
 
 type UI mg.Namespace


### PR DESCRIPTION
prob going to break a bunch of things temporarily.. but I've always regretted having the server run with the root command and would prefer if for v2 we make it explicit like `flipt server`

also updates our dockerfiles to remove postgres lib and updates docs to rm notice for CGO since we arent using SQLite anymore