### PR TITLE
chore: fix config tests; make single env default; ensure atleast one default

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -584,6 +584,7 @@ func Default() *Config {
 			"default": &EnvironmentConfig{
 				Name:    "default",
 				Storage: "default",
+				Default: true,
 			},
 		},
 
@@ -592,7 +593,8 @@ func Default() *Config {
 				Backend: StorageBackendConfig{
 					Type: "memory",
 				},
-				Branch: "main",
+				Branch:       "main",
+				PollInterval: 30 * time.Second,
 			},
 		},
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -768,10 +768,31 @@ func TestLoad(t *testing.T) {
 					"default": {
 						Name:    "default",
 						Storage: "default",
+						Default: true,
 					},
 				}
 				return cfg
 			},
+		},
+		{
+			name: "environments single environment is default",
+			path: "./testdata/environments/single_is_default.yml",
+			expected: func() *Config {
+				cfg := Default()
+				cfg.Environments = EnvironmentsConfig{
+					"default": {
+						Name:    "default",
+						Storage: "default",
+						Default: true,
+					},
+				}
+				return cfg
+			},
+		},
+		{
+			name:    "environments no default",
+			path:    "./testdata/environments/no_default.yml",
+			wantErr: errors.New("no default environment configured"),
 		},
 	}
 

--- a/internal/config/environments.go
+++ b/internal/config/environments.go
@@ -27,6 +27,10 @@ func (e *EnvironmentsConfig) validate() error {
 		}
 	}
 
+	if defaults == 0 {
+		return fmt.Errorf("no default environment configured")
+	}
+
 	if defaults > 1 {
 		return fmt.Errorf("only one environment can be default")
 	}
@@ -40,6 +44,7 @@ func (e *EnvironmentsConfig) setDefaults(v *viper.Viper) error {
 		// Create default environment if no environments are configured
 		v.SetDefault("environments.default.name", "default")
 		v.SetDefault("environments.default.storage", "default")
+		v.SetDefault("environments.default.default", true)
 		return nil
 	}
 
@@ -56,6 +61,13 @@ func (e *EnvironmentsConfig) setDefaults(v *viper.Viper) error {
 
 		if getString("storage") == "" {
 			setDefault("storage", "default")
+		}
+	}
+
+	// if there is only one environment, set it as the default
+	if len(envs) == 1 {
+		for name := range envs {
+			v.SetDefault("environments."+name+".default", true)
 		}
 	}
 

--- a/internal/config/testdata/environments/no_default.yml
+++ b/internal/config/testdata/environments/no_default.yml
@@ -1,0 +1,5 @@
+environments:
+  first:
+    name: first
+  second:
+    name: second

--- a/internal/config/testdata/environments/single_is_default.yml
+++ b/internal/config/testdata/environments/single_is_default.yml
@@ -1,0 +1,3 @@
+environments:
+  default:
+    name: default

--- a/internal/config/testdata/marshal/yaml/default.yml
+++ b/internal/config/testdata/marshal/yaml/default.yml
@@ -33,6 +33,9 @@ environments:
   default:
     name: default
     storage: default
+  second:
+    name: second
+    storage: default
 
 storage:
   default:


### PR DESCRIPTION
we need to ensure that there is one and only one default environment for evaluation and UI purposes.

This change makes it so:

1. if there are no envs then we create an env called 'default' and set 'default.default = true'
2. if there is only one env, we set it as 'default'
3. if there are more than one env and none are marked as 'default' then we return an error

I'd love it if we could just make the first item in the env config the default env, but because ranging through Go maps do not guarantee order, I could not come up with a good way of doing this.. so just made it so the user/operator must be explicit