### PR TITLE
fix(storage/git): support fs.WalkDir and current dir path

### DIFF
--- a/internal/server/environments/mock_environment.go
+++ b/internal/server/environments/mock_environment.go
@@ -84,6 +84,51 @@ func (_c *MockEnvironment_CreateNamespace_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// Default provides a mock function with no fields
+func (_m *MockEnvironment) Default() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Default")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockEnvironment_Default_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Default'
+type MockEnvironment_Default_Call struct {
+	*mock.Call
+}
+
+// Default is a helper method to define mock.On call
+func (_e *MockEnvironment_Expecter) Default() *MockEnvironment_Default_Call {
+	return &MockEnvironment_Default_Call{Call: _e.mock.On("Default")}
+}
+
+func (_c *MockEnvironment_Default_Call) Run(run func()) *MockEnvironment_Default_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockEnvironment_Default_Call) Return(_a0 bool) *MockEnvironment_Default_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockEnvironment_Default_Call) RunAndReturn(run func() bool) *MockEnvironment_Default_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DeleteNamespace provides a mock function with given fields: _a0, rev, key
 func (_m *MockEnvironment) DeleteNamespace(_a0 context.Context, rev string, key string) (string, error) {
 	ret := _m.Called(_a0, rev, key)

--- a/internal/server/evaluation/evaluation_test.go
+++ b/internal/server/evaluation/evaluation_test.go
@@ -28,7 +28,7 @@ func TestVariant_FlagNotFound(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -59,7 +59,7 @@ func TestVariant_NonVariantFlag(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -92,7 +92,7 @@ func TestVariant_FlagDisabled(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -131,7 +131,7 @@ func TestVariant_EvaluateFailure_OnGetEvaluationRules(t *testing.T) {
 		}
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(flag, nil)
@@ -166,7 +166,7 @@ func TestVariant_Success(t *testing.T) {
 		}
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(flag, nil)
@@ -228,7 +228,7 @@ func TestBoolean_FlagNotFoundError(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{}, errs.ErrNotFound("test-flag"))
@@ -257,7 +257,7 @@ func TestBoolean_NonBooleanFlagError(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -290,7 +290,7 @@ func TestBoolean_DefaultRule_NoRollouts(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -327,7 +327,7 @@ func TestBoolean_DefaultRuleFallthrough_WithPercentageRollout(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -374,7 +374,7 @@ func TestBoolean_PercentageRuleMatch(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -421,7 +421,7 @@ func TestBoolean_PercentageRuleFallthrough_SegmentMatch(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -491,7 +491,7 @@ func TestBoolean_SegmentMatch_MultipleConstraints(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -558,7 +558,7 @@ func TestBoolean_SegmentMatch_Constraint_EntityId(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -617,7 +617,7 @@ func TestBoolean_SegmentMatch_MultipleSegments_WithAnd(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -691,7 +691,7 @@ func TestBoolean_RulesOutOfOrder(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -759,7 +759,7 @@ func TestBatch_UnknownFlagType(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -797,7 +797,7 @@ func TestBatch_InternalError_GetFlag(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{}, errors.New("internal error"))
@@ -832,7 +832,7 @@ func TestBatch_Success(t *testing.T) {
 		s              = New(logger, envStore)
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{

--- a/internal/server/evaluation/mock_environmentstore.go
+++ b/internal/server/evaluation/mock_environmentstore.go
@@ -22,61 +22,50 @@ func (_m *MockEnvironmentStore) EXPECT() *MockEnvironmentStore_Expecter {
 	return &MockEnvironmentStore_Expecter{mock: &_m.Mock}
 }
 
-// Get provides a mock function with given fields: _a0, _a1
-func (_m *MockEnvironmentStore) Get(_a0 context.Context, _a1 string) (environments.Environment, error) {
-	ret := _m.Called(_a0, _a1)
+// GetDefault provides a mock function with given fields: _a0
+func (_m *MockEnvironmentStore) GetDefault(_a0 context.Context) environments.Environment {
+	ret := _m.Called(_a0)
 
 	if len(ret) == 0 {
-		panic("no return value specified for Get")
+		panic("no return value specified for GetDefault")
 	}
 
 	var r0 environments.Environment
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (environments.Environment, error)); ok {
-		return rf(_a0, _a1)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) environments.Environment); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context) environments.Environment); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(environments.Environment)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(_a0, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
-// MockEnvironmentStore_Get_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Get'
-type MockEnvironmentStore_Get_Call struct {
+// MockEnvironmentStore_GetDefault_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDefault'
+type MockEnvironmentStore_GetDefault_Call struct {
 	*mock.Call
 }
 
-// Get is a helper method to define mock.On call
+// GetDefault is a helper method to define mock.On call
 //   - _a0 context.Context
-//   - _a1 string
-func (_e *MockEnvironmentStore_Expecter) Get(_a0 interface{}, _a1 interface{}) *MockEnvironmentStore_Get_Call {
-	return &MockEnvironmentStore_Get_Call{Call: _e.mock.On("Get", _a0, _a1)}
+func (_e *MockEnvironmentStore_Expecter) GetDefault(_a0 interface{}) *MockEnvironmentStore_GetDefault_Call {
+	return &MockEnvironmentStore_GetDefault_Call{Call: _e.mock.On("GetDefault", _a0)}
 }
 
-func (_c *MockEnvironmentStore_Get_Call) Run(run func(_a0 context.Context, _a1 string)) *MockEnvironmentStore_Get_Call {
+func (_c *MockEnvironmentStore_GetDefault_Call) Run(run func(_a0 context.Context)) *MockEnvironmentStore_GetDefault_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
 
-func (_c *MockEnvironmentStore_Get_Call) Return(_a0 environments.Environment, _a1 error) *MockEnvironmentStore_Get_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *MockEnvironmentStore_GetDefault_Call) Return(_a0 environments.Environment) *MockEnvironmentStore_GetDefault_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockEnvironmentStore_Get_Call) RunAndReturn(run func(context.Context, string) (environments.Environment, error)) *MockEnvironmentStore_Get_Call {
+func (_c *MockEnvironmentStore_GetDefault_Call) RunAndReturn(run func(context.Context) environments.Environment) *MockEnvironmentStore_GetDefault_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/evaluation/ofrep_bridge_test.go
+++ b/internal/server/evaluation/ofrep_bridge_test.go
@@ -31,7 +31,7 @@ func TestOFREPFlagEvaluation_Variant(t *testing.T) {
 		}
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(flag, nil)
@@ -97,7 +97,7 @@ func TestOFREPFlagEvaluation_Boolean(t *testing.T) {
 		}
 	)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(flag, nil)

--- a/internal/server/evaluation/server.go
+++ b/internal/server/evaluation/server.go
@@ -12,7 +12,7 @@ import (
 
 // EnvironmentStore is the minimal abstraction for interacting with the storage layer for evaluation.
 type EnvironmentStore interface {
-	Get(context.Context, string) (environments.Environment, error)
+	GetDefault(context.Context) environments.Environment
 }
 
 // Server serves the Flipt evaluate v2 gRPC Server.
@@ -47,10 +47,5 @@ func (s *Server) SkipsAuthorization(ctx context.Context) bool {
 func (s *Server) getEvalStore(ctx context.Context) (storage.ReadOnlyStore, error) {
 	// TODO(georgemac): update this to support overriding default environment based
 	// on configuration or header metadata on the request
-	env, err := s.store.Get(ctx, "default")
-	if err != nil {
-		return nil, err
-	}
-
-	return env.EvaluationStore()
+	return s.store.GetDefault(ctx).EvaluationStore()
 }

--- a/internal/server/flag_test.go
+++ b/internal/server/flag_test.go
@@ -31,7 +31,7 @@ func TestListFlags_PaginationOffset(t *testing.T) {
 
 	defer store.AssertExpectations(t)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("ListFlags", mock.Anything, storage.ListWithOptions(storage.NewNamespace(""),
@@ -75,7 +75,7 @@ func TestListFlags_PaginationPageToken(t *testing.T) {
 
 	defer store.AssertExpectations(t)
 
-	envStore.On("Get", mock.Anything, "default").Return(environment, nil)
+	envStore.On("GetDefault", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("ListFlags", mock.Anything, storage.ListWithOptions(storage.NewNamespace(""),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,10 +12,9 @@ import (
 
 var _ flipt.FliptServer = &Server{}
 
-
 // EnvironmentStore is the minimal abstraction for interacting with the storage layer for evaluation.
 type EnvironmentStore interface {
-	Get(context.Context, string) (environments.Environment, error)
+	GetDefault(context.Context) environments.Environment
 }
 
 // Server serves the Flipt backend
@@ -43,11 +42,5 @@ func (s *Server) AllowsNamespaceScopedAuthentication(ctx context.Context) bool {
 }
 
 func (s *Server) getStore(ctx context.Context) (storage.ReadOnlyStore, error) {
-	const environment = "default"
-	env, err := s.store.Get(ctx, environment)
-	if err != nil {
-		return nil, err
-	}
-
-	return env.EvaluationStore()
+	return s.store.GetDefault(ctx).EvaluationStore()
 }

--- a/internal/storage/environments/environments.go
+++ b/internal/storage/environments/environments.go
@@ -60,7 +60,7 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config) (
 		}
 	}
 
-	return serverconfig.NewEnvironmentStore(envs...), nil
+	return serverconfig.NewEnvironmentStore(envs...)
 }
 
 type sourceBuilder struct {

--- a/internal/storage/fs/config.go
+++ b/internal/storage/fs/config.go
@@ -31,7 +31,7 @@ updated multiple resources
 )
 
 type Config struct {
-	Matches   []glob.Glob
+	Matchers  []glob.Glob
 	Templates ConfigTemplates
 }
 
@@ -43,7 +43,7 @@ type ConfigTemplates struct {
 // It used when a flipt.yml cannot be located.
 func DefaultFliptConfig() *Config {
 	return &Config{
-		Matches: []glob.Glob{
+		Matchers: []glob.Glob{
 			// must end in either yaml, yml or json
 			// must be nested a single directory below the root
 			glob.MustCompile("*/features.yaml"),
@@ -91,7 +91,7 @@ func (c *Config) List(src fs.FS) (paths []string, err error) {
 			return nil
 		}
 
-		for _, matcher := range c.Matches {
+		for _, matcher := range c.Matchers {
 			if matcher.Match(path) {
 				paths = append(paths, path)
 				break


### PR DESCRIPTION
This PR contains fixes for two things:

1. It supports the concept of a default env during evaluations

It adds a method `GetDefault` to the environment store to create a single path for legacy dependents.
This method handles picking the default env as per configuration.

2. Fixes empty snapshots

Since some recent refactors to remove `gitfs` in favour of `storage/git/filesystem` I created a situation where the snapshotting code silently fails to find any files. This caused empty snapshots to be used during evaluation.
This turned out to be due to the fact that there was no support for the `"."` path in the filesystems `Stat` implementation.

In the journey to fix this, I added support for `os.O_APPEND` to the implementation on writes (preserves original contents and simply appends).
As well as supporting `fs.ReadDirFile` when `OpenFile` encounters a directory.