### PR TITLE
chore: Cmd refactor

### DIFF
--- a/cmd/flipt/bundle.go
+++ b/cmd/flipt/bundle.go
@@ -15,12 +15,12 @@ import (
 )
 
 type bundleCommand struct {
-	root *rootCommand
+	configManager *configManager
 }
 
-func newBundleCommand(root *rootCommand) *cobra.Command {
+func newBundleCommand(configManager *configManager) *cobra.Command {
 	bundle := &bundleCommand{
-		root: root,
+		configManager: configManager,
 	}
 
 	cmd := &cobra.Command{
@@ -158,7 +158,7 @@ func (c *bundleCommand) pull(cmd *cobra.Command, args []string) error {
 }
 
 func (c *bundleCommand) getStore(ctx context.Context) (*oci.Store, error) {
-	logger, cfg, err := c.root.buildConfig(ctx)
+	logger, cfg, err := c.configManager.build(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/flipt/bundle.go
+++ b/cmd/flipt/bundle.go
@@ -14,10 +14,14 @@ import (
 	"go.flipt.io/flipt/internal/oci"
 )
 
-type bundleCommand struct{}
+type bundleCommand struct {
+	root *rootCommand
+}
 
-func newBundleCommand() *cobra.Command {
-	bundle := &bundleCommand{}
+func newBundleCommand(root *rootCommand) *cobra.Command {
+	bundle := &bundleCommand{
+		root: root,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "bundle",
@@ -154,7 +158,7 @@ func (c *bundleCommand) pull(cmd *cobra.Command, args []string) error {
 }
 
 func (c *bundleCommand) getStore(ctx context.Context) (*oci.Store, error) {
-	logger, cfg, err := buildConfig(ctx)
+	logger, cfg, err := c.root.buildConfig(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/flipt/config.go
+++ b/cmd/flipt/config.go
@@ -14,12 +14,13 @@ import (
 )
 
 type initCommand struct {
-	root  *rootCommand
+	configManager *configManager
+
 	force bool
 }
 
 func (c *initCommand) run(cmd *cobra.Command, args []string) error {
-	defaultFile := c.root.configFile
+	defaultFile := c.configManager.configFile
 
 	if defaultFile == "" {
 		defaultFile = userConfigFile
@@ -87,12 +88,12 @@ func (c *initCommand) run(cmd *cobra.Command, args []string) error {
 }
 
 type editCommand struct {
-	root *rootCommand
+	configManager *configManager
 }
 
 func (c *editCommand) run(cmd *cobra.Command, args []string) error {
 	// TODO: check if no TTY
-	file := c.root.configFile
+	file := c.configManager.configFile
 
 	if file == "" {
 		file = userConfigFile
@@ -130,7 +131,7 @@ func (c *editCommand) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func newConfigCommand(root *rootCommand) *cobra.Command {
+func newConfigCommand(configManager *configManager) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "config",
 		Short:   "Manage Flipt configuration",
@@ -139,10 +140,10 @@ func newConfigCommand(root *rootCommand) *cobra.Command {
 
 	var (
 		initCmd = &initCommand{
-			root: root,
+			configManager: configManager,
 		}
 		editCmd = &editCommand{
-			root: root,
+			configManager: configManager,
 		}
 	)
 
@@ -160,7 +161,6 @@ func newConfigCommand(root *rootCommand) *cobra.Command {
 		RunE:  editCmd.run,
 	}
 
-	cmd.PersistentFlags().StringVar(&root.configFile, "config", root.configFile, "path to config file")
 	cmd.AddCommand(init)
 	cmd.AddCommand(edit)
 

--- a/cmd/flipt/config.go
+++ b/cmd/flipt/config.go
@@ -14,19 +14,23 @@ import (
 )
 
 type initCommand struct {
+	root  *rootCommand
 	force bool
 }
 
 func (c *initCommand) run(cmd *cobra.Command, args []string) error {
-	defaultFile := providedConfigFile
+	defaultFile := c.root.configFile
 
 	if defaultFile == "" {
 		defaultFile = userConfigFile
 	}
 
-	file := defaultFile
+	var (
+		file string
+		ack  bool
+	)
 
-	ack := c.force
+	ack = c.force
 	if !ack {
 		q := []*survey.Question{
 			{
@@ -82,11 +86,13 @@ func (c *initCommand) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-type editCommand struct{}
+type editCommand struct {
+	root *rootCommand
+}
 
 func (c *editCommand) run(cmd *cobra.Command, args []string) error {
 	// TODO: check if no TTY
-	file := providedConfigFile
+	file := c.root.configFile
 
 	if file == "" {
 		file = userConfigFile
@@ -124,7 +130,7 @@ func (c *editCommand) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func newConfigCommand() *cobra.Command {
+func newConfigCommand(root *rootCommand) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "config",
 		Short:   "Manage Flipt configuration",
@@ -132,8 +138,12 @@ func newConfigCommand() *cobra.Command {
 	}
 
 	var (
-		initCmd = &initCommand{}
-		editCmd = &editCommand{}
+		initCmd = &initCommand{
+			root: root,
+		}
+		editCmd = &editCommand{
+			root: root,
+		}
 	)
 
 	var init = &cobra.Command{
@@ -150,7 +160,7 @@ func newConfigCommand() *cobra.Command {
 		RunE:  editCmd.run,
 	}
 
-	cmd.PersistentFlags().StringVar(&providedConfigFile, "config", "", "path to config file")
+	cmd.PersistentFlags().StringVar(&root.configFile, "config", root.configFile, "path to config file")
 	cmd.AddCommand(init)
 	cmd.AddCommand(edit)
 

--- a/cmd/flipt/config_manager.go
+++ b/cmd/flipt/config_manager.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"go.flipt.io/flipt/internal/config"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// configManager manages loading and building configuration
+type configManager struct {
+	configFile string
+	logger     *zap.Logger
+}
+
+// newConfigManager creates a new ConfigManager
+func newConfigManager(configFile string) *configManager {
+	return &configManager{
+		configFile: configFile,
+		logger:     defaultLogger,
+	}
+}
+
+// determineConfig will figure out which file to use for Flipt configuration.
+func (cm *configManager) determineConfig() (string, bool) {
+	// if config file is provided, use it
+	if cm.configFile != "" {
+		return cm.configFile, true
+	}
+
+	// otherwise, check if user config file exists on filesystem
+	_, err := os.Stat(userConfigFile)
+	if err == nil {
+		return userConfigFile, true
+	}
+
+	if !errors.Is(err, fs.ErrNotExist) {
+		cm.logger.Warn("unexpected error checking configuration file", zap.String("config_file", userConfigFile), zap.Error(err))
+	}
+
+	// finally, check if default config file exists on filesystem
+	_, err = os.Stat(defaultConfigFile)
+	if err == nil {
+		return defaultConfigFile, true
+	}
+
+	if !errors.Is(err, fs.ErrNotExist) {
+		cm.logger.Warn("unexpected error checking configuration file", zap.String("config_file", defaultConfigFile), zap.Error(err))
+	}
+
+	return "", false
+}
+
+// build builds the configuration for Flipt
+func (cm *configManager) build(ctx context.Context) (*zap.Logger, *config.Config, error) {
+	path, found := cm.determineConfig()
+
+	// read in config if it exists
+	// otherwise, use defaults
+	res, err := config.Load(ctx, path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading configuration: %w", err)
+	}
+
+	if !found {
+		cm.logger.Info("no configuration file found, using defaults")
+	}
+
+	cfg := res.Config
+
+	encoding := defaultEncoding
+	encoding.TimeKey = cfg.Log.Keys.Time
+	encoding.LevelKey = cfg.Log.Keys.Level
+	encoding.MessageKey = cfg.Log.Keys.Message
+
+	loggerConfig := loggerConfig(encoding)
+
+	// log to file if enabled
+	if cfg.Log.File != "" {
+		loggerConfig.OutputPaths = []string{cfg.Log.File}
+	}
+
+	// parse/set log level
+	loggerConfig.Level, err = zap.ParseAtomicLevel(cfg.Log.Level)
+	if err != nil {
+		cm.logger.Warn("parsing log level, defaulting to INFO", zap.String("level", cfg.Log.Level), zap.Error(err))
+		// default to info level
+		loggerConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	}
+
+	if cfg.Log.Encoding > config.LogEncodingConsole {
+		loggerConfig.Encoding = cfg.Log.Encoding.String()
+
+		// don't encode with colors if not using console log output
+		loggerConfig.EncoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	}
+
+	logger := zap.Must(loggerConfig.Build())
+
+	// print out any warnings from config parsing
+	for _, warning := range res.Warnings {
+		logger.Warn("configuration warning", zap.String("message", warning))
+	}
+
+	if found {
+		logger.Debug("configuration source", zap.String("path", path))
+	}
+
+	return logger, cfg, nil
+}

--- a/cmd/flipt/evaluate.go
+++ b/cmd/flipt/evaluate.go
@@ -20,7 +20,6 @@ import (
 )
 
 type evaluateCommand struct {
-	root          *rootCommand
 	address       string
 	requestID     string
 	entityID      string
@@ -31,73 +30,69 @@ type evaluateCommand struct {
 	contextValues []string
 }
 
-func newEvaluateCommand(root *rootCommand) *cobra.Command {
-	c := &evaluateCommand{
-		root: root,
-	}
+func newEvaluateCommand() *cobra.Command {
+	evaluate := &evaluateCommand{}
 
 	cmd := &cobra.Command{
 		Use:   "evaluate [flagKey]",
 		Short: "Evaluate a flag",
 		Args:  cobra.ExactArgs(1),
-		RunE:  c.run,
+		RunE:  evaluate.run,
 	}
 
 	cmd.Flags().StringVarP(
-		&c.namespace,
+		&evaluate.namespace,
 		"namespace", "n",
 		"default",
 		"flag namespace.",
 	)
 	cmd.Flags().StringVarP(
-		&c.entityID,
+		&evaluate.entityID,
 		"entity-id", "e",
 		uuid.NewString(),
 		"evaluation request entity id.",
 	)
 	cmd.Flags().StringVarP(
-		&c.requestID,
+		&evaluate.requestID,
 		"request-id", "r",
 		"",
 		"evaluation request id.",
 	)
 
 	cmd.Flags().StringArrayVarP(
-		&c.contextValues,
+		&evaluate.contextValues,
 		"context", "c",
 		[]string{},
 		"evaluation request context as key=value.",
 	)
 
 	cmd.Flags().StringVarP(
-		&c.address,
+		&evaluate.address,
 		"address", "a",
 		"http://localhost:8080",
 		"address of Flipt instance.",
 	)
 
 	cmd.Flags().StringVarP(
-		&c.token,
+		&evaluate.token,
 		"token", "t",
 		"",
 		"client token used to authenticate access to Flipt instance.",
 	)
 
 	cmd.Flags().BoolVarP(
-		&c.watch,
+		&evaluate.watch,
 		"watch", "w",
 		false,
 		"watch for changes to evaluations",
 	)
 
 	cmd.Flags().DurationVarP(
-		&c.interval,
+		&evaluate.interval,
 		"interval", "i",
 		5*time.Second,
 		"interval at which to poll for changes",
 	)
-
-	cmd.Flags().StringVar(&c.root.configFile, "config", c.root.configFile, "path to config file")
 
 	return cmd
 }

--- a/cmd/flipt/evaluate.go
+++ b/cmd/flipt/evaluate.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/signal"
+	"sort"
 	"strings"
+	"syscall"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"go.flipt.io/flipt/rpc/flipt"
@@ -15,6 +20,7 @@ import (
 )
 
 type evaluateCommand struct {
+	root          *rootCommand
 	address       string
 	requestID     string
 	entityID      string
@@ -25,8 +31,10 @@ type evaluateCommand struct {
 	contextValues []string
 }
 
-func newEvaluateCommand() *cobra.Command {
-	c := &evaluateCommand{}
+func newEvaluateCommand(root *rootCommand) *cobra.Command {
+	c := &evaluateCommand{
+		root: root,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "evaluate [flagKey]",
@@ -79,68 +87,75 @@ func newEvaluateCommand() *cobra.Command {
 		&c.watch,
 		"watch", "w",
 		false,
-		"enable watch mode.",
+		"watch for changes to evaluations",
 	)
 
 	cmd.Flags().DurationVarP(
 		&c.interval,
 		"interval", "i",
-		time.Second,
-		"interval between requests in watch mode.",
+		5*time.Second,
+		"interval at which to poll for changes",
 	)
+
+	cmd.Flags().StringVar(&c.root.configFile, "config", c.root.configFile, "path to config file")
 
 	return cmd
 }
 
 func (c *evaluateCommand) run(cmd *cobra.Command, args []string) error {
-	sdk, err := fliptSDK(c.address, c.token)
-	if err != nil {
-		return err
-	}
-
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
-	flagKey := strings.TrimSpace(args[0])
-	flag, err := sdk.Flipt().GetFlag(ctx, &flipt.GetFlagRequest{NamespaceKey: c.namespace, Key: flagKey})
+	if c.requestID == "" {
+		c.requestID = uuid.NewString()
+	}
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-signalCh
+		cancel()
+	}()
+
+	context := map[string]string{}
+	for _, c := range c.contextValues {
+		i := strings.Index(c, "=")
+		if i == -1 {
+			return fmt.Errorf("invalid context value %q, must be of form key=value", c)
+		}
+
+		k, v := c[0:i], c[i+1:]
+		context[k] = v
+	}
+
+	req := &evaluation.EvaluationRequest{
+		FlagKey:      args[0],
+		EntityId:     c.entityID,
+		Context:      context,
+		RequestId:    c.requestID,
+		NamespaceKey: c.namespace,
+	}
+
+	sdkClient, err := fliptSDK(c.address, c.token)
 	if err != nil {
 		return err
 	}
 
-	values := make(map[string]string, len(c.contextValues))
-	for _, v := range c.contextValues {
-		tokens := strings.SplitN(v, "=", 2)
-		if len(tokens) != 2 {
-			return fmt.Errorf("invalid context pair: %v", v)
-		}
-		values[strings.TrimSpace(tokens[0])] = tokens[1]
-	}
-
-	request := &evaluation.EvaluationRequest{
-		FlagKey:      flagKey,
+	client := sdkClient.Flipt()
+	resp, err := client.GetFlag(ctx, &flipt.GetFlagRequest{
+		Key:          args[0],
 		NamespaceKey: c.namespace,
-		EntityId:     c.entityID,
-		RequestId:    c.requestID,
-		Context:      values,
+	})
+	if err != nil {
+		return err
 	}
 
-	if !c.watch {
-		return c.evaluate(ctx, flag.Type, sdk, request)
+	if c.watch {
+		return c.evaluate(ctx, resp.Type, sdkClient, req)
 	}
 
-	ticker := time.NewTicker(c.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			err := c.evaluate(ctx, flag.Type, sdk, request)
-			if err != nil {
-				fmt.Printf("failed to evaluate: %s", err)
-			}
-		}
-	}
+	return c.evaluate(ctx, resp.Type, sdkClient, req)
 }
 
 type booleanEvaluateResponse struct {
@@ -164,59 +179,88 @@ type variantEvaluationResponse struct {
 	Timestamp             time.Time `json:"timestamp,omitempty"`
 }
 
-func (c *evaluateCommand) evaluate(ctx context.Context, flagType flipt.FlagType, sdk *sdk.SDK, req *evaluation.EvaluationRequest) error {
-	client := sdk.Evaluation()
-	switch flagType {
-	case flipt.FlagType_BOOLEAN_FLAG_TYPE:
-		response, err := client.Boolean(ctx, req)
-		if err != nil {
-			return err
+func (c *evaluateCommand) evaluate(ctx context.Context, flagType flipt.FlagType, sdkClient *sdk.SDK, req *evaluation.EvaluationRequest) error {
+	colorBool := color.New(color.FgCyan, color.Bold).SprintFunc()
+	colorFloat := color.New(color.FgGreen).SprintFunc()
+
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	evaluationClient := sdkClient.Evaluation()
+
+	for {
+		switch flagType {
+		case flipt.FlagType_BOOLEAN_FLAG_TYPE:
+			resp, err := evaluationClient.Boolean(ctx, req)
+			if err != nil {
+				return err
+			}
+
+			res := &booleanEvaluateResponse{
+				FlagKey:               resp.FlagKey,
+				Enabled:               resp.Enabled,
+				Reason:                resp.Reason.String(),
+				RequestID:             resp.RequestId,
+				Timestamp:             time.Now().UTC(),
+				RequestDurationMillis: resp.RequestDurationMillis,
+			}
+
+			b, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			if c.watch {
+				fmt.Printf("Evaluating flag %s at %s with request ID: %s\n", colorBool(resp.FlagKey), colorFloat(res.Timestamp.Format(time.RFC3339)), resp.RequestId)
+			}
+			fmt.Println(string(b))
+		case flipt.FlagType_VARIANT_FLAG_TYPE:
+			resp, err := evaluationClient.Variant(ctx, req)
+			if err != nil {
+				return err
+			}
+
+			segmentKeys := make([]string, 0, len(resp.SegmentKeys))
+			for _, s := range resp.SegmentKeys {
+				segmentKeys = append(segmentKeys, s)
+			}
+
+			sort.Strings(segmentKeys)
+
+			res := &variantEvaluationResponse{
+				FlagKey:               resp.FlagKey,
+				Match:                 resp.Match,
+				Reason:                resp.Reason.String(),
+				VariantKey:            resp.VariantKey,
+				VariantAttachment:     resp.VariantAttachment,
+				SegmentKeys:           segmentKeys,
+				RequestID:             resp.RequestId,
+				Timestamp:             time.Now().UTC(),
+				RequestDurationMillis: resp.RequestDurationMillis,
+			}
+
+			b, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			if c.watch {
+				fmt.Printf("Evaluating flag %s at %s with request ID: %s\n", colorBool(resp.FlagKey), colorFloat(res.Timestamp.Format(time.RFC3339)), resp.RequestId)
+			}
+			fmt.Println(string(b))
+		default:
+			return fmt.Errorf("unknown flag type: %s", flagType)
 		}
 
-		boolResponse := &booleanEvaluateResponse{
-			FlagKey:               response.FlagKey,
-			Enabled:               response.Enabled,
-			Reason:                response.Reason.String(),
-			RequestID:             response.RequestId,
-			RequestDurationMillis: response.RequestDurationMillis,
-			Timestamp:             response.Timestamp.AsTime(),
+		if !c.watch {
+			return nil
 		}
 
-		out, err := json.Marshal(boolResponse)
-		if err != nil {
-			return err
+		select {
+		case <-ticker.C:
+			continue
+		case <-ctx.Done():
+			return ctx.Err()
 		}
-
-		fmt.Println(string(out))
-
-		return nil
-	case flipt.FlagType_VARIANT_FLAG_TYPE:
-		response, err := client.Variant(ctx, req)
-		if err != nil {
-			return err
-		}
-
-		variantResponse := &variantEvaluationResponse{
-			FlagKey:               response.FlagKey,
-			Match:                 response.Match,
-			Reason:                response.Reason.String(),
-			VariantKey:            response.VariantKey,
-			VariantAttachment:     response.VariantAttachment,
-			SegmentKeys:           response.SegmentKeys,
-			RequestID:             response.RequestId,
-			RequestDurationMillis: response.RequestDurationMillis,
-			Timestamp:             response.Timestamp.AsTime(),
-		}
-
-		out, err := json.Marshal(variantResponse)
-		if err != nil {
-			return err
-		}
-
-		fmt.Println(string(out))
-
-		return nil
-	default:
-		return fmt.Errorf("unsupported flag type: %v", flagType)
 	}
 }

--- a/cmd/flipt/export.go
+++ b/cmd/flipt/export.go
@@ -14,7 +14,8 @@ import (
 )
 
 type exportCommand struct {
-	root          *rootCommand
+	configManager *configManager
+
 	filename      string
 	address       string
 	token         string
@@ -23,9 +24,9 @@ type exportCommand struct {
 	sortByKey     bool
 }
 
-func newExportCommand(root *rootCommand) *cobra.Command {
+func newExportCommand(configManager *configManager) *cobra.Command {
 	export := &exportCommand{
-		root: root,
+		configManager: configManager,
 	}
 
 	cmd := &cobra.Command{
@@ -83,8 +84,6 @@ func newExportCommand(root *rootCommand) *cobra.Command {
 		"sort exported resources by key",
 	)
 
-	cmd.Flags().StringVar(&export.root.configFile, "config", export.root.configFile, "path to config file")
-
 	cmd.MarkFlagsMutuallyExclusive("all-namespaces", "namespaces", "namespace")
 
 	// We can ignore the error here since "namespace" will be a flag that exists.
@@ -110,7 +109,7 @@ func (c *exportCommand) run(cmd *cobra.Command, _ []string) error {
 
 		defer fi.Close()
 
-		fmt.Fprintf(fi, "# exported by Flipt (%s) on %s\n\n", c.root.version, time.Now().UTC().Format(time.RFC3339))
+		fmt.Fprintf(fi, "# exported by Flipt (%s) on %s\n\n", version, time.Now().UTC().Format(time.RFC3339))
 
 		out = fi
 
@@ -129,7 +128,7 @@ func (c *exportCommand) run(cmd *cobra.Command, _ []string) error {
 		return c.export(ctx, enc, out, client)
 	}
 
-	logger, cfg, err := c.root.buildConfig(ctx)
+	logger, cfg, err := c.configManager.build(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/flipt/import.go
+++ b/cmd/flipt/import.go
@@ -16,7 +16,8 @@ import (
 )
 
 type importCommand struct {
-	root             *rootCommand
+	configManager *configManager
+
 	forceMigrate     bool
 	dropBeforeImport bool
 	skipExisting     bool
@@ -25,9 +26,9 @@ type importCommand struct {
 	token            string
 }
 
-func newImportCommand(root *rootCommand) *cobra.Command {
+func newImportCommand(configManager *configManager) *cobra.Command {
 	importCmd := &importCommand{
-		root: root,
+		configManager: configManager,
 	}
 
 	cmd := &cobra.Command{
@@ -78,8 +79,6 @@ func newImportCommand(root *rootCommand) *cobra.Command {
 		"",
 		"client token used to authenticate access to Flipt instance.",
 	)
-
-	cmd.Flags().StringVar(&importCmd.root.configFile, "config", importCmd.root.configFile, "path to config file")
 
 	return cmd
 }
@@ -132,7 +131,7 @@ func (c *importCommand) run(cmd *cobra.Command, args []string) error {
 		return ext.NewImporter(client).Import(ctx, enc, in, c.skipExisting)
 	}
 
-	logger, cfg, err := c.root.buildConfig(ctx)
+	logger, cfg, err := c.configManager.build(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/flipt/validate.go
+++ b/cmd/flipt/validate.go
@@ -13,6 +13,7 @@ import (
 )
 
 type validateCommand struct {
+	root          *rootCommand
 	issueExitCode int
 	format        string
 	extraPath     string
@@ -24,8 +25,10 @@ const (
 	textFormat = "text"
 )
 
-func newValidateCommand() *cobra.Command {
-	v := &validateCommand{}
+func newValidateCommand(root *rootCommand) *cobra.Command {
+	v := &validateCommand{
+		root: root,
+	}
 
 	cmd := &cobra.Command{
 		Use:   "validate",
@@ -61,7 +64,7 @@ func newValidateCommand() *cobra.Command {
 
 func (v *validateCommand) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	logger, _, err := buildConfig(ctx)
+	logger, _, err := v.root.buildConfig(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/flipt/validate.go
+++ b/cmd/flipt/validate.go
@@ -13,7 +13,8 @@ import (
 )
 
 type validateCommand struct {
-	root          *rootCommand
+	configManager *configManager
+
 	issueExitCode int
 	format        string
 	extraPath     string
@@ -25,35 +26,35 @@ const (
 	textFormat = "text"
 )
 
-func newValidateCommand(root *rootCommand) *cobra.Command {
-	v := &validateCommand{
-		root: root,
+func newValidateCommand(configManager *configManager) *cobra.Command {
+	validate := &validateCommand{
+		configManager: configManager,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "validate",
 		Short: "Validate Flipt flag state (.yaml, .yml) files",
-		RunE:  v.run,
+		RunE:  validate.run,
 	}
 
-	cmd.Flags().IntVar(&v.issueExitCode, "issue-exit-code", 1, "exit code to use when issues are found")
+	cmd.Flags().IntVar(&validate.issueExitCode, "issue-exit-code", 1, "exit code to use when issues are found")
 
 	cmd.Flags().StringVarP(
-		&v.format,
+		&validate.format,
 		"format", "F",
 		"text",
 		"output format: json, text",
 	)
 
 	cmd.Flags().StringVarP(
-		&v.extraPath,
+		&validate.extraPath,
 		"extra-schema", "e",
 		"",
 		"path to extra schema constraints",
 	)
 
 	cmd.Flags().StringVarP(
-		&v.workDirectory,
+		&validate.workDirectory,
 		"work-dir", "d",
 		".",
 		"set the working directory",
@@ -64,7 +65,7 @@ func newValidateCommand(root *rootCommand) *cobra.Command {
 
 func (v *validateCommand) run(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	logger, _, err := v.root.buildConfig(ctx)
+	logger, _, err := v.configManager.build(ctx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Refactor command package to share config between subcommand s using a new `configManager` type which handles the locating and parsing / building

The goal of this refactor is to remove global variables where possible in the cmd package