### PR TITLE
fix: regression with setting ui to readonly

### DIFF
--- a/internal/info/flipt.go
+++ b/internal/info/flipt.go
@@ -44,7 +44,7 @@ func WithOS(os, arch string) Option {
 func WithConfig(cfg *config.Config) Option {
 	return func(f *Flipt) {
 		f.Authentication = authentication{Required: cfg.Authentication.Required}
-		f.Storage = storage{Type: cfg.Storage.Type, Metadata: cfg.Storage.Info()}
+		f.Storage = storage{Type: cfg.Storage.Type, ReadOnly: cfg.Storage.ReadOnly != nil && *cfg.Storage.ReadOnly, Metadata: cfg.Storage.Info()}
 		f.Analytics = &analytics{Enabled: cfg.Analytics.Enabled()}
 		f.UI = &ui{Theme: cfg.UI.DefaultTheme, TopbarColor: cfg.UI.Topbar.Color}
 	}
@@ -62,6 +62,7 @@ type analytics struct {
 
 type storage struct {
 	Type     config.StorageType `json:"type"`
+	ReadOnly bool               `json:"readOnly,omitempty"`
 	Metadata map[string]string  `json:"metadata,omitempty"`
 }
 

--- a/ui/src/app/meta/metaSlice.ts
+++ b/ui/src/app/meta/metaSlice.ts
@@ -52,8 +52,9 @@ export const metaSlice = createSlice({
           state.config.storage.type = action.payload.storage?.type;
           state.config.storage.git = action.payload.storage?.metadata;
           state.config.storage.readOnly =
-            action.payload.storage &&
-            action.payload.storage.type !== StorageType.DATABASE;
+            action.payload.storage.readOnly ||
+            (action.payload.storage &&
+              action.payload.storage.type !== StorageType.DATABASE);
         }
         state.config.ui = {
           defaultTheme: action.payload.ui?.theme || Theme.SYSTEM,


### PR DESCRIPTION
Fixes part of #4056 

I need to add tests and we also need to think about what this means for API requests, as currently this only puts the UI in readonly mode, not the actual API