### PR TITLE
feat: V2 env analytics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -27,7 +27,7 @@ func init() {
 
 // This is memoized in the OTEL library to avoid creating multiple instances of the same exporter.
 func meter() metric.Meter {
-	return otel.Meter("github.com/flipt-io/flipt")
+	return otel.Meter("go.flipt.io/flipt/v2")
 }
 
 // MustInt64 returns an instrument provider based on the global Meter.
@@ -232,6 +232,7 @@ func GetResources(ctx context.Context) (*resource.Resource, error) {
 		resource.WithSchemaURL(semconv.SchemaURL),
 		resource.WithAttributes(
 			semconv.ServiceName("flipt"),
+			// semconv.ServiceVersion("v2"), TODO: set this from the semver of the flipt binary
 		),
 		resource.WithFromEnv(),
 		resource.WithTelemetrySDK(),

--- a/internal/migrations/clickhouse/20250121202120_create_table_counter_analytics.down.sql
+++ b/internal/migrations/clickhouse/20250121202120_create_table_counter_analytics.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS flipt_counter_analytics;
+DROP TABLE IF EXISTS flipt_counter_analytics_v2;

--- a/internal/migrations/clickhouse/20250121202120_create_table_counter_analytics.up.sql
+++ b/internal/migrations/clickhouse/20250121202120_create_table_counter_analytics.up.sql
@@ -1,6 +1,7 @@
-CREATE TABLE IF NOT EXISTS flipt_counter_analytics (
+CREATE TABLE IF NOT EXISTS flipt_counter_analytics_v2 (
     `timestamp` DateTime('UTC'),
     `analytic_name` String,
+    `environment_key` String,
     `namespace_key` String,
     `flag_key` String,
     `flag_type` Enum(

--- a/internal/migrations/clickhouse/20250121202326_create_table_counter_aggregated_analytics.down.sql
+++ b/internal/migrations/clickhouse/20250121202326_create_table_counter_aggregated_analytics.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS flipt_counter_aggregated_analytics;
+DROP TABLE IF EXISTS flipt_counter_aggregated_analytics_v2;

--- a/internal/migrations/clickhouse/20250121202326_create_table_counter_aggregated_analytics.up.sql
+++ b/internal/migrations/clickhouse/20250121202326_create_table_counter_aggregated_analytics.up.sql
@@ -1,7 +1,8 @@
-CREATE TABLE flipt_counter_aggregated_analytics
+CREATE TABLE flipt_counter_aggregated_analytics_v2
 (
     `timestamp` DateTime('UTC'),
     `analytic_name` LowCardinality(String),
+    `environment_key` LowCardinality(String),
     `namespace_key` LowCardinality(String),
     `flag_key` LowCardinality(String),
     `reason` LowCardinality(String),
@@ -12,6 +13,7 @@ ENGINE = SummingMergeTree
 ORDER BY (
     timestamp,
     analytic_name,
+    environment_key,
     namespace_key,
     flag_key,
     reason,

--- a/internal/migrations/clickhouse/20250121202552_create_view_counter_aggregated_analytics.down.sql
+++ b/internal/migrations/clickhouse/20250121202552_create_view_counter_aggregated_analytics.down.sql
@@ -1,1 +1,1 @@
-DROP VIEW IF EXISTS flipt_counter_aggregated_analytics_mv;
+DROP VIEW IF EXISTS flipt_counter_aggregated_analytics_mv_v2;

--- a/internal/migrations/clickhouse/20250121202552_create_view_counter_aggregated_analytics.up.sql
+++ b/internal/migrations/clickhouse/20250121202552_create_view_counter_aggregated_analytics.up.sql
@@ -1,18 +1,20 @@
-CREATE MATERIALIZED VIEW flipt_counter_aggregated_analytics_mv
-TO flipt_counter_aggregated_analytics
+CREATE MATERIALIZED VIEW flipt_counter_aggregated_analytics_mv_v2
+TO flipt_counter_aggregated_analytics_v2
 AS
 SELECT
     `timestamp`,
     analytic_name,
+    environment_key,
     namespace_key,
     flag_key,
     reason,
     evaluation_value,
     sum(`value`) AS `value`
-FROM flipt_counter_analytics
+FROM flipt_counter_analytics_v2
 GROUP BY
     timestamp,
     analytic_name,
+    environment_key,
     namespace_key,
     flag_key,
     reason,

--- a/internal/server/analytics/analytics.go
+++ b/internal/server/analytics/analytics.go
@@ -28,11 +28,12 @@ func (s *Server) GetFlagEvaluationsCount(ctx context.Context, req *analytics.Get
 	}
 
 	r := &FlagEvaluationsCountRequest{
-		NamespaceKey: req.NamespaceKey,
-		FlagKey:      req.FlagKey,
-		From:         fromTime,
-		To:           toTime,
-		StepMinutes:  getStepFromDuration(toTime.Sub(fromTime)),
+		EnvironmentKey: req.EnvironmentKey,
+		NamespaceKey:   req.NamespaceKey,
+		FlagKey:        req.FlagKey,
+		From:           fromTime,
+		To:             toTime,
+		StepMinutes:    getStepFromDuration(toTime.Sub(fromTime)),
 	}
 
 	timestamps, values, err := s.client.GetFlagEvaluationsCount(ctx, r)

--- a/internal/server/analytics/analytics_test.go
+++ b/internal/server/analytics/analytics_test.go
@@ -54,14 +54,16 @@ func TestGetFlagEvaluationsCountWithInvalidInput(t *testing.T) {
 	service := New(logger, client)
 
 	_, err := service.GetFlagEvaluationsCount(context.Background(), &analytics.GetFlagEvaluationsCountRequest{
-		NamespaceKey: "bar",
-		FlagKey:      "foo",
+		EnvironmentKey: "default",
+		NamespaceKey:   "bar",
+		FlagKey:        "foo",
 	})
 	require.Error(t, err)
 	_, err = service.GetFlagEvaluationsCount(context.Background(), &analytics.GetFlagEvaluationsCountRequest{
-		NamespaceKey: "bar",
-		FlagKey:      "foo",
-		From:         time.Now().Format(time.DateTime),
+		EnvironmentKey: "default",
+		NamespaceKey:   "bar",
+		FlagKey:        "foo",
+		From:           time.Now().Format(time.DateTime),
 	})
 	require.Error(t, err)
 }
@@ -73,11 +75,12 @@ func TestGetFlagEvaluationsCountClientError(t *testing.T) {
 	ctx := context.Background()
 
 	client.EXPECT().GetFlagEvaluationsCount(ctx, &FlagEvaluationsCountRequest{
-		NamespaceKey: "bar",
-		FlagKey:      "foo",
-		From:         time.Date(2022, 6, 9, 11, 0, 0, 0, time.UTC),
-		To:           time.Date(2022, 6, 9, 11, 30, 0, 0, time.UTC),
-		StepMinutes:  1,
+		EnvironmentKey: "default",
+		NamespaceKey:   "bar",
+		FlagKey:        "foo",
+		From:           time.Date(2022, 6, 9, 11, 0, 0, 0, time.UTC),
+		To:             time.Date(2022, 6, 9, 11, 30, 0, 0, time.UTC),
+		StepMinutes:    1,
 	}).Return(nil, nil, errors.New("client error"))
 
 	t.Run("old date format", func(t *testing.T) {
@@ -85,10 +88,11 @@ func TestGetFlagEvaluationsCountClientError(t *testing.T) {
 		from := "2022-06-09 11:00:00"
 		to := "2022-06-09 11:30:00"
 		_, err := service.GetFlagEvaluationsCount(ctx, &analytics.GetFlagEvaluationsCountRequest{
-			NamespaceKey: "bar",
-			FlagKey:      "foo",
-			From:         from,
-			To:           to,
+			EnvironmentKey: "default",
+			NamespaceKey:   "bar",
+			FlagKey:        "foo",
+			From:           from,
+			To:             to,
 		})
 
 		require.Error(t, err)
@@ -100,10 +104,11 @@ func TestGetFlagEvaluationsCountClientError(t *testing.T) {
 		from := "2022-06-09T11:00:00Z"
 		to := "2022-06-09T11:30:00.000Z"
 		_, err := service.GetFlagEvaluationsCount(ctx, &analytics.GetFlagEvaluationsCountRequest{
-			NamespaceKey: "bar",
-			FlagKey:      "foo",
-			From:         from,
-			To:           to,
+			EnvironmentKey: "default",
+			NamespaceKey:   "bar",
+			FlagKey:        "foo",
+			From:           from,
+			To:             to,
 		})
 
 		require.Error(t, err)

--- a/internal/server/analytics/clickhouse/client_test.go
+++ b/internal/server/analytics/clickhouse/client_test.go
@@ -55,47 +55,53 @@ func (a *AnalyticsDBTestSuite) TestAnalyticsMutationAndQuery() {
 	t := a.T()
 
 	now := time.Now().UTC()
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		err := a.client.IncrementFlagEvaluationCounts(context.TODO(), []*panalytics.EvaluationResponse{
 			{
-				NamespaceKey: "default",
-				FlagKey:      "flag1",
-				Reason:       "MATCH_EVALUATION_REASON",
-				Timestamp:    now,
+				EnvironmentKey: "default",
+				NamespaceKey:   "default",
+				FlagKey:        "flag1",
+				Reason:         "MATCH_EVALUATION_REASON",
+				Timestamp:      now,
 			},
 			{
-				NamespaceKey: "default",
-				FlagKey:      "flag1",
-				Reason:       "MATCH_EVALUATION_REASON",
-				Timestamp:    now,
+				EnvironmentKey: "default",
+				NamespaceKey:   "default",
+				FlagKey:        "flag1",
+				Reason:         "MATCH_EVALUATION_REASON",
+				Timestamp:      now,
 			},
 			{
-				NamespaceKey: "default",
-				FlagKey:      "flag1",
-				Reason:       "MATCH_EVALUATION_REASON",
-				Timestamp:    now,
+				EnvironmentKey: "default",
+				NamespaceKey:   "default",
+				FlagKey:        "flag1",
+				Reason:         "MATCH_EVALUATION_REASON",
+				Timestamp:      now,
 			},
 			{
-				NamespaceKey: "default",
-				FlagKey:      "flag1",
-				Reason:       "MATCH_EVALUATION_REASON",
-				Timestamp:    now,
+				EnvironmentKey: "default",
+				NamespaceKey:   "default",
+				FlagKey:        "flag1",
+				Reason:         "MATCH_EVALUATION_REASON",
+				Timestamp:      now,
 			},
 			{
-				NamespaceKey: "default",
-				FlagKey:      "flag1",
-				Reason:       "MATCH_EVALUATION_REASON",
-				Timestamp:    now,
+				EnvironmentKey: "default",
+				NamespaceKey:   "default",
+				FlagKey:        "flag1",
+				Reason:         "MATCH_EVALUATION_REASON",
+				Timestamp:      now,
 			},
 		})
 		require.NoError(t, err)
 	}
 
 	res, err := a.service.GetFlagEvaluationsCount(context.TODO(), &analytics.GetFlagEvaluationsCountRequest{
-		NamespaceKey: "default",
-		FlagKey:      "flag1",
-		From:         now.Add(-time.Hour).Format(time.DateTime),
-		To:           now.Format(time.DateTime),
+		EnvironmentKey: "default",
+		NamespaceKey:   "default",
+		FlagKey:        "flag1",
+		From:           now.Add(-time.Hour).Format(time.DateTime),
+		To:             now.Format(time.DateTime),
 	})
 	require.NoError(t, err)
 

--- a/internal/server/analytics/clickhouse/mutation.go
+++ b/internal/server/analytics/clickhouse/mutation.go
@@ -22,6 +22,7 @@ func (c *Client) IncrementFlagEvaluationCounts(ctx context.Context, responses []
 		valuePlaceHolders = append(valuePlaceHolders, "(toDateTime(?, 'UTC'),?,?,?,?,?,?,?,?,?)")
 		valueArgs = append(valueArgs, response.Timestamp.Format(time.DateTime))
 		valueArgs = append(valueArgs, counterAnalyticsName)
+		valueArgs = append(valueArgs, response.EnvironmentKey)
 		valueArgs = append(valueArgs, response.NamespaceKey)
 		valueArgs = append(valueArgs, response.FlagKey)
 		valueArgs = append(valueArgs, response.FlagType)

--- a/internal/server/analytics/prometheus/client.go
+++ b/internal/server/analytics/prometheus/client.go
@@ -44,7 +44,8 @@ func New(logger *zap.Logger, cfg *config.Config) (*client, error) {
 
 func (c *client) GetFlagEvaluationsCount(ctx context.Context, req *panalytics.FlagEvaluationsCountRequest) ([]string, []float32, error) {
 	query := fmt.Sprintf(
-		`sum(increase(flipt_evaluations_requests_total{namespace="%s", flag="%s"}[%dm])) or vector(0)`,
+		`sum(increase(flipt_evaluations_requests_total{environment="%s", namespace="%s", flag="%s"}[%dm])) or vector(0)`,
+		req.EnvironmentKey,
 		req.NamespaceKey,
 		req.FlagKey,
 		req.StepMinutes,

--- a/internal/server/analytics/prometheus/client.go
+++ b/internal/server/analytics/prometheus/client.go
@@ -44,7 +44,7 @@ func New(logger *zap.Logger, cfg *config.Config) (*client, error) {
 
 func (c *client) GetFlagEvaluationsCount(ctx context.Context, req *panalytics.FlagEvaluationsCountRequest) ([]string, []float32, error) {
 	query := fmt.Sprintf(
-		`sum(increase(flipt_evaluations_requests_total{environment="%s", namespace="%s", flag="%s"}[%dm])) or vector(0)`,
+		`sum(increase(flipt_evaluations_requests_total{flipt_environment="%s", flipt_namespace="%s", flipt_flag="%s"}[%dm])) or vector(0)`,
 		req.EnvironmentKey,
 		req.NamespaceKey,
 		req.FlagKey,

--- a/internal/server/analytics/prometheus/client_test.go
+++ b/internal/server/analytics/prometheus/client_test.go
@@ -71,7 +71,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="bar", flag="foo"}[1m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{flipt_environment="default", flipt_namespace="bar", flipt_flag="foo"}[1m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(time.Minute),
@@ -117,7 +117,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="victoria", flag="metrics"}[1m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{flipt_environment="default", flipt_namespace="victoria", flipt_flag="metrics"}[1m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(time.Minute),
@@ -148,7 +148,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 	t.Run("no data type", func(t *testing.T) {
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="no-data", flag="foo"}[1m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{flipt_environment="default", flipt_namespace="no-data", flipt_flag="foo"}[1m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(time.Minute),
@@ -176,7 +176,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 	t.Run("wrong data type", func(t *testing.T) {
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="wrong-data", flag="foo"}[1m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{flipt_environment="default", flipt_namespace="wrong-data", flipt_flag="foo"}[1m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(time.Minute),
@@ -204,7 +204,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="error", flag="foo"}[5m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{flipt_environment="default", flipt_namespace="error", flipt_flag="foo"}[5m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(5 * time.Minute),

--- a/internal/server/analytics/prometheus/client_test.go
+++ b/internal/server/analytics/prometheus/client_test.go
@@ -71,7 +71,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{namespace="bar", flag="foo"}[1m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="bar", flag="foo"}[1m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(time.Minute),
@@ -85,11 +85,12 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 
 		labels, values, err := client.GetFlagEvaluationsCount(ctx, &panalytics.FlagEvaluationsCountRequest{
-			NamespaceKey: "bar",
-			FlagKey:      "foo",
-			From:         from,
-			To:           to,
-			StepMinutes:  1,
+			EnvironmentKey: "default",
+			NamespaceKey:   "bar",
+			FlagKey:        "foo",
+			From:           from,
+			To:             to,
+			StepMinutes:    1,
 		})
 
 		require.NoError(t, err)
@@ -116,7 +117,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{namespace="victoria", flag="metrics"}[1m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="victoria", flag="metrics"}[1m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(time.Minute),
@@ -130,11 +131,12 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 
 		labels, values, err := client.GetFlagEvaluationsCount(ctx, &panalytics.FlagEvaluationsCountRequest{
-			NamespaceKey: "victoria",
-			FlagKey:      "metrics",
-			From:         from,
-			To:           to,
-			StepMinutes:  1,
+			EnvironmentKey: "default",
+			NamespaceKey:   "victoria",
+			FlagKey:        "metrics",
+			From:           from,
+			To:             to,
+			StepMinutes:    1,
 		})
 
 		require.NoError(t, err)
@@ -146,7 +148,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 	t.Run("no data type", func(t *testing.T) {
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{namespace="no-data", flag="foo"}[1m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="no-data", flag="foo"}[1m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(time.Minute),
@@ -160,11 +162,12 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 
 		_, _, err := client.GetFlagEvaluationsCount(ctx, &panalytics.FlagEvaluationsCountRequest{
-			NamespaceKey: "no-data",
-			FlagKey:      "foo",
-			From:         from,
-			To:           to,
-			StepMinutes:  1,
+			EnvironmentKey: "default",
+			NamespaceKey:   "no-data",
+			FlagKey:        "foo",
+			From:           from,
+			To:             to,
+			StepMinutes:    1,
 		})
 
 		require.Error(t, err)
@@ -173,7 +176,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 	t.Run("wrong data type", func(t *testing.T) {
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{namespace="wrong-data", flag="foo"}[1m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="wrong-data", flag="foo"}[1m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(time.Minute),
@@ -187,11 +190,12 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 
 		_, _, err := client.GetFlagEvaluationsCount(ctx, &panalytics.FlagEvaluationsCountRequest{
-			NamespaceKey: "wrong-data",
-			FlagKey:      "foo",
-			From:         from,
-			To:           to,
-			StepMinutes:  1,
+			EnvironmentKey: "default",
+			NamespaceKey:   "wrong-data",
+			FlagKey:        "foo",
+			From:           from,
+			To:             to,
+			StepMinutes:    1,
 		})
 
 		require.Error(t, err)
@@ -200,7 +204,7 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		mock.EXPECT().QueryRange(
 			ctx,
-			`sum(increase(flipt_evaluations_requests_total{namespace="error", flag="foo"}[5m])) or vector(0)`,
+			`sum(increase(flipt_evaluations_requests_total{environment="default", namespace="error", flag="foo"}[5m])) or vector(0)`,
 			promapi.Range{
 				Start: from,
 				End:   to.Add(5 * time.Minute),
@@ -214,11 +218,12 @@ func TestGetFlagEvaluationsCount(t *testing.T) {
 		}
 
 		_, _, err := client.GetFlagEvaluationsCount(ctx, &panalytics.FlagEvaluationsCountRequest{
-			NamespaceKey: "error",
-			FlagKey:      "foo",
-			From:         from,
-			To:           to,
-			StepMinutes:  5,
+			EnvironmentKey: "default",
+			NamespaceKey:   "error",
+			FlagKey:        "foo",
+			From:           from,
+			To:             to,
+			StepMinutes:    5,
 		})
 
 		require.Error(t, err)

--- a/internal/server/analytics/server.go
+++ b/internal/server/analytics/server.go
@@ -11,11 +11,12 @@ import (
 )
 
 type FlagEvaluationsCountRequest struct {
-	NamespaceKey string
-	FlagKey      string
-	From         time.Time
-	To           time.Time
-	StepMinutes  int
+	EnvironmentKey string
+	NamespaceKey   string
+	FlagKey        string
+	From           time.Time
+	To             time.Time
+	StepMinutes    int
 }
 
 // Client is a contract that each analytics store needs to conform to for

--- a/internal/server/analytics/server_test.go
+++ b/internal/server/analytics/server_test.go
@@ -24,10 +24,11 @@ func TestServer(t *testing.T) {
 	server := New(zap.NewNop(), &testClient{})
 
 	res, err := server.GetFlagEvaluationsCount(context.TODO(), &analytics.GetFlagEvaluationsCountRequest{
-		NamespaceKey: "default",
-		FlagKey:      "flag1",
-		From:         "2024-01-01 00:00:00",
-		To:           "2024-01-01 00:00:00",
+		EnvironmentKey: "default",
+		NamespaceKey:   "default",
+		FlagKey:        "flag1",
+		From:           "2024-01-01 00:00:00",
+		To:             "2024-01-01 00:00:00",
 	})
 	require.NoError(t, err)
 

--- a/internal/server/analytics/sink.go
+++ b/internal/server/analytics/sink.go
@@ -20,6 +20,7 @@ type AnalyticsStoreMutator interface {
 type EvaluationResponse struct {
 	FlagKey         string    `json:"flagKey,omitempty"`
 	FlagType        string    `json:"flagType,omitempty"`
+	EnvironmentKey  string    `json:"environmentKey,omitempty"`
 	NamespaceKey    string    `json:"namespaceKey,omitempty"`
 	Reason          string    `json:"reason,omitempty"`
 	Match           *bool     `json:"match,omitempty"`
@@ -83,5 +84,9 @@ func (a *AnalyticsSinkSpanExporter) ExportSpans(ctx context.Context, spans []sdk
 
 // Shutdown closes resources for an AnalyticsStoreMutator.
 func (a *AnalyticsSinkSpanExporter) Shutdown(_ context.Context) error {
-	return a.analyticsStoreMutator.Close()
+	if a != nil && a.analyticsStoreMutator != nil {
+		return a.analyticsStoreMutator.Close()
+	}
+
+	return nil
 }

--- a/internal/server/environments/mock_environment.go
+++ b/internal/server/environments/mock_environment.go
@@ -362,6 +362,51 @@ func (_c *MockEnvironment_GetNamespace_Call) RunAndReturn(run func(context.Conte
 	return _c
 }
 
+// Key provides a mock function with no fields
+func (_m *MockEnvironment) Key() string {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Key")
+	}
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// MockEnvironment_Key_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Key'
+type MockEnvironment_Key_Call struct {
+	*mock.Call
+}
+
+// Key is a helper method to define mock.On call
+func (_e *MockEnvironment_Expecter) Key() *MockEnvironment_Key_Call {
+	return &MockEnvironment_Key_Call{Call: _e.mock.On("Key")}
+}
+
+func (_c *MockEnvironment_Key_Call) Run(run func()) *MockEnvironment_Key_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockEnvironment_Key_Call) Return(_a0 string) *MockEnvironment_Key_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockEnvironment_Key_Call) RunAndReturn(run func() string) *MockEnvironment_Key_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListNamespaces provides a mock function with given fields: _a0
 func (_m *MockEnvironment) ListNamespaces(_a0 context.Context) (*v2environments.ListNamespacesResponse, error) {
 	ret := _m.Called(_a0)
@@ -416,51 +461,6 @@ func (_c *MockEnvironment_ListNamespaces_Call) Return(_a0 *v2environments.ListNa
 }
 
 func (_c *MockEnvironment_ListNamespaces_Call) RunAndReturn(run func(context.Context) (*v2environments.ListNamespacesResponse, error)) *MockEnvironment_ListNamespaces_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// Name provides a mock function with no fields
-func (_m *MockEnvironment) Name() string {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Name")
-	}
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// MockEnvironment_Name_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Name'
-type MockEnvironment_Name_Call struct {
-	*mock.Call
-}
-
-// Name is a helper method to define mock.On call
-func (_e *MockEnvironment_Expecter) Name() *MockEnvironment_Name_Call {
-	return &MockEnvironment_Name_Call{Call: _e.mock.On("Name")}
-}
-
-func (_c *MockEnvironment_Name_Call) Run(run func()) *MockEnvironment_Name_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockEnvironment_Name_Call) Return(_a0 string) *MockEnvironment_Name_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockEnvironment_Name_Call) RunAndReturn(run func() string) *MockEnvironment_Name_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/environments/server.go
+++ b/internal/server/environments/server.go
@@ -37,8 +37,8 @@ func (s *Server) ListEnvironments(ctx context.Context, req *environments.ListEnv
 
 	for env := range s.envs.List(ctx) {
 		el.Environments = append(el.Environments, &environments.Environment{
-			Key:     env.Name(),
-			Name:    env.Name(),
+			Key:     env.Key(),
+			Name:    env.Key(),
 			Default: ptr(env.Default()),
 		})
 	}

--- a/internal/server/environments/storage.go
+++ b/internal/server/environments/storage.go
@@ -41,7 +41,7 @@ func (r ResourceType) String() string {
 }
 
 type Environment interface {
-	Name() string
+	Key() string
 	Default() bool
 	// Namespaces
 
@@ -92,7 +92,7 @@ func NewEnvironmentStore(logger *zap.Logger, envs ...Environment) (*EnvironmentS
 	}
 
 	for _, env := range envs {
-		store.byName[env.Name()] = env
+		store.byName[env.Key()] = env
 		if env.Default() {
 			store.defaultEnv = env
 		}

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -50,7 +50,7 @@ func (s *Server) Variant(ctx context.Context, r *rpcevaluation.EvaluationRequest
 	}
 
 	spanAttrs := []attribute.KeyValue{
-		fliptotel.AttributeEnvironment.String(env.Name()),
+		fliptotel.AttributeEnvironment.String(env.Key()),
 		fliptotel.AttributeNamespace.String(r.NamespaceKey),
 		fliptotel.AttributeFlag.String(r.FlagKey),
 		fliptotel.AttributeEntityID.String(r.EntityId),
@@ -81,7 +81,7 @@ func (s *Server) variant(ctx context.Context, store storage.ReadOnlyStore, env e
 		lastRank int32
 
 		startTime       = time.Now().UTC()
-		environmentAttr = metrics.AttributeEnvironment.String(env.Name())
+		environmentAttr = metrics.AttributeEnvironment.String(env.Key())
 		namespaceAttr   = metrics.AttributeNamespace.String(r.NamespaceKey)
 		flagAttr        = metrics.AttributeFlag.String(r.FlagKey)
 	)
@@ -100,7 +100,7 @@ func (s *Server) variant(ctx context.Context, store storage.ReadOnlyStore, env e
 						metrics.AttributeSegments.StringSlice(resp.SegmentKeys),
 						metrics.AttributeReason.String(resp.Reason.String()),
 						metrics.AttributeValue.String(resp.VariantKey),
-						metrics.AttributeType.String("variant"),
+						metrics.AttributeFlagType.String("variant"),
 					),
 				),
 			)
@@ -285,7 +285,7 @@ func (s *Server) Boolean(ctx context.Context, r *rpcevaluation.EvaluationRequest
 	}
 
 	spanAttrs := []attribute.KeyValue{
-		fliptotel.AttributeEnvironment.String(env.Name()),
+		fliptotel.AttributeEnvironment.String(env.Key()),
 		fliptotel.AttributeNamespace.String(r.NamespaceKey),
 		fliptotel.AttributeFlag.String(r.FlagKey),
 		fliptotel.AttributeEntityID.String(r.EntityId),
@@ -319,7 +319,7 @@ func (s *Server) boolean(ctx context.Context, store storage.ReadOnlyStore, env e
 
 	var (
 		startTime       = time.Now().UTC()
-		environmentAttr = metrics.AttributeEnvironment.String(env.Name())
+		environmentAttr = metrics.AttributeEnvironment.String(env.Key())
 		namespaceAttr   = metrics.AttributeNamespace.String(r.NamespaceKey)
 		flagAttr        = metrics.AttributeFlag.String(r.FlagKey)
 	)
@@ -336,7 +336,7 @@ func (s *Server) boolean(ctx context.Context, store storage.ReadOnlyStore, env e
 						flagAttr,
 						metrics.AttributeValue.Bool(resp.Enabled),
 						metrics.AttributeReason.String(resp.Reason.String()),
-						metrics.AttributeType.String("boolean"),
+						metrics.AttributeFlagType.String("boolean"),
 					),
 				),
 			)

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -86,7 +86,7 @@ func (s *Server) variant(ctx context.Context, store storage.ReadOnlyStore, env e
 		flagAttr        = metrics.AttributeFlag.String(r.FlagKey)
 	)
 
-	metrics.EvaluationsTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(namespaceAttr, flagAttr)))
+	metrics.EvaluationsTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(environmentAttr, namespaceAttr, flagAttr)))
 
 	defer func() {
 		if err == nil {
@@ -105,7 +105,7 @@ func (s *Server) variant(ctx context.Context, store storage.ReadOnlyStore, env e
 				),
 			)
 		} else {
-			metrics.EvaluationErrorsTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(namespaceAttr, flagAttr)))
+			metrics.EvaluationErrorsTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(environmentAttr, namespaceAttr, flagAttr)))
 		}
 
 		metrics.EvaluationLatency.Record(
@@ -324,7 +324,7 @@ func (s *Server) boolean(ctx context.Context, store storage.ReadOnlyStore, env e
 		flagAttr        = metrics.AttributeFlag.String(r.FlagKey)
 	)
 
-	metrics.EvaluationsTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(namespaceAttr, flagAttr)))
+	metrics.EvaluationsTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(environmentAttr, namespaceAttr, flagAttr)))
 
 	defer func() {
 		if err == nil {
@@ -341,7 +341,7 @@ func (s *Server) boolean(ctx context.Context, store storage.ReadOnlyStore, env e
 				),
 			)
 		} else {
-			metrics.EvaluationErrorsTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(namespaceAttr, flagAttr)))
+			metrics.EvaluationErrorsTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(environmentAttr, namespaceAttr, flagAttr)))
 		}
 
 		metrics.EvaluationLatency.Record(

--- a/internal/server/evaluation/evaluation_test.go
+++ b/internal/server/evaluation/evaluation_test.go
@@ -29,7 +29,6 @@ func TestVariant_FlagNotFound(t *testing.T) {
 	)
 
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
-
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{}, errs.ErrNotFound("test-flag"))
@@ -83,15 +82,17 @@ func TestVariant_NonVariantFlag(t *testing.T) {
 
 func TestVariant_FlagDisabled(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -117,20 +118,22 @@ func TestVariant_FlagDisabled(t *testing.T) {
 
 func TestVariant_EvaluateFailure_OnGetEvaluationRules(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
-		flag         = &core.Flag{
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
+		flag           = &core.Flag{
 			Key:     flagKey,
 			Enabled: true,
 			Type:    core.FlagType_VARIANT_FLAG_TYPE,
 		}
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -152,20 +155,22 @@ func TestVariant_EvaluateFailure_OnGetEvaluationRules(t *testing.T) {
 
 func TestVariant_Success(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
-		flag         = &core.Flag{
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
+		flag           = &core.Flag{
 			Key:     flagKey,
 			Enabled: true,
 			Type:    core.FlagType_VARIANT_FLAG_TYPE,
 		}
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -281,15 +286,17 @@ func TestBoolean_NonBooleanFlagError(t *testing.T) {
 
 func TestBoolean_DefaultRule_NoRollouts(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -318,15 +325,17 @@ func TestBoolean_DefaultRule_NoRollouts(t *testing.T) {
 
 func TestBoolean_DefaultRuleFallthrough_WithPercentageRollout(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -365,15 +374,17 @@ func TestBoolean_DefaultRuleFallthrough_WithPercentageRollout(t *testing.T) {
 
 func TestBoolean_PercentageRuleMatch(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -412,15 +423,17 @@ func TestBoolean_PercentageRuleMatch(t *testing.T) {
 
 func TestBoolean_PercentageRuleFallthrough_SegmentMatch(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -433,11 +446,25 @@ func TestBoolean_PercentageRuleFallthrough_SegmentMatch(t *testing.T) {
 	store.On("GetEvaluationRollouts", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return([]*storage.EvaluationRollout{
 		{
 			NamespaceKey: namespaceKey,
-			Rank:         1,
 			RolloutType:  core.RolloutType_THRESHOLD_ROLLOUT_TYPE,
-			Threshold: &storage.RolloutThreshold{
-				Percentage: 5,
-				Value:      false,
+			Rank:         1,
+			Segment: &storage.RolloutSegment{
+				Value:           true,
+				SegmentOperator: core.SegmentOperator_OR_SEGMENT_OPERATOR,
+				Segments: map[string]*storage.EvaluationSegment{
+					"test-segment": {
+						SegmentKey: "test-segment",
+						MatchType:  core.MatchType_ANY_MATCH_TYPE,
+						Constraints: []storage.EvaluationConstraint{
+							{
+								Type:     core.ComparisonType_STRING_COMPARISON_TYPE,
+								Property: "hello",
+								Operator: flipt.OpEQ,
+								Value:    "world",
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -482,15 +509,17 @@ func TestBoolean_PercentageRuleFallthrough_SegmentMatch(t *testing.T) {
 
 func TestBoolean_SegmentMatch_MultipleConstraints(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -549,15 +578,17 @@ func TestBoolean_SegmentMatch_MultipleConstraints(t *testing.T) {
 
 func TestBoolean_SegmentMatch_Constraint_EntityId(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -608,15 +639,17 @@ func TestBoolean_SegmentMatch_Constraint_EntityId(t *testing.T) {
 
 func TestBoolean_SegmentMatch_MultipleSegments_WithAnd(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -682,15 +715,17 @@ func TestBoolean_SegmentMatch_MultipleSegments_WithAnd(t *testing.T) {
 
 func TestBoolean_RulesOutOfOrder(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 
@@ -822,6 +857,7 @@ func TestBatch_InternalError_GetFlag(t *testing.T) {
 func TestBatch_Success(t *testing.T) {
 	var (
 		flagKey        = "test-flag"
+		environmentKey = "test-environment"
 		anotherFlagKey = "another-test-flag"
 		variantFlagKey = "variant-test-flag"
 		namespaceKey   = "test-namespace"
@@ -832,6 +868,7 @@ func TestBatch_Success(t *testing.T) {
 		s              = New(logger, envStore)
 	)
 
+	environment.On("Key").Return(environmentKey)
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
 

--- a/internal/server/evaluation/ofrep_bridge.go
+++ b/internal/server/evaluation/ofrep_bridge.go
@@ -51,17 +51,18 @@ func (s *Server) OFREPFlagEvaluation(ctx context.Context, r *ofrep.EvaluateFlagR
 	}
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
-		fliptotel.AttributeEnvironment.String(env.Name()),
+		fliptotel.AttributeEnvironment.String(env.Key()),
 		fliptotel.AttributeNamespace.String(namespaceKey),
 		fliptotel.AttributeFlag.String(r.Key),
 		fliptotel.AttributeProviderName,
 	)
 
 	req := &rpcevaluation.EvaluationRequest{
-		NamespaceKey: namespaceKey,
-		FlagKey:      r.Key,
-		EntityId:     entityId,
-		Context:      r.Context,
+		EnvironmentKey: env.Key(),
+		NamespaceKey:   namespaceKey,
+		FlagKey:        r.Key,
+		EntityId:       entityId,
+		Context:        r.Context,
 	}
 
 	switch flag.Type {

--- a/internal/server/evaluation/ofrep_bridge_test.go
+++ b/internal/server/evaluation/ofrep_bridge_test.go
@@ -17,19 +17,22 @@ import (
 
 func TestOFREPFlagEvaluation_Variant(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
-		flag         = &core.Flag{
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
+		flag           = &core.Flag{
 			Key:     flagKey,
 			Enabled: true,
 			Type:    core.FlagType_VARIANT_FLAG_TYPE,
 		}
 	)
+
+	environment.On("Key").Return(environmentKey)
 
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
@@ -66,7 +69,8 @@ func TestOFREPFlagEvaluation_Variant(t *testing.T) {
 	}, nil)
 
 	ctx := metadata.NewIncomingContext(context.TODO(), metadata.New(map[string]string{
-		"x-flipt-namespace": namespaceKey,
+		"x-flipt-environment": environmentKey,
+		"x-flipt-namespace":   namespaceKey,
 	}))
 
 	output, err := s.OFREPFlagEvaluation(ctx, &ofrep.EvaluateFlagRequest{
@@ -86,19 +90,22 @@ func TestOFREPFlagEvaluation_Variant(t *testing.T) {
 
 func TestOFREPFlagEvaluation_Boolean(t *testing.T) {
 	var (
-		flagKey      = "test-flag"
-		namespaceKey = "test-namespace"
-		envStore     = NewMockEnvironmentStore(t)
-		environment  = environments.NewMockEnvironment(t)
-		store        = storage.NewMockReadOnlyStore(t)
-		logger       = zaptest.NewLogger(t)
-		s            = New(logger, envStore)
-		flag         = &core.Flag{
+		flagKey        = "test-flag"
+		environmentKey = "test-environment"
+		namespaceKey   = "test-namespace"
+		envStore       = NewMockEnvironmentStore(t)
+		environment    = environments.NewMockEnvironment(t)
+		store          = storage.NewMockReadOnlyStore(t)
+		logger         = zaptest.NewLogger(t)
+		s              = New(logger, envStore)
+		flag           = &core.Flag{
 			Key:     flagKey,
 			Enabled: true,
 			Type:    core.FlagType_BOOLEAN_FLAG_TYPE,
 		}
 	)
+
+	environment.On("Key").Return(environmentKey)
 
 	envStore.On("GetFromContext", mock.Anything).Return(environment)
 	environment.On("EvaluationStore").Return(store, nil)
@@ -108,7 +115,8 @@ func TestOFREPFlagEvaluation_Boolean(t *testing.T) {
 	store.On("GetEvaluationRollouts", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return([]*storage.EvaluationRollout{}, nil)
 
 	ctx := metadata.NewIncomingContext(context.TODO(), metadata.New(map[string]string{
-		"x-flipt-namespace": namespaceKey,
+		"x-flipt-environment": environmentKey,
+		"x-flipt-namespace":   namespaceKey,
 	}))
 
 	output, err := s.OFREPFlagEvaluation(ctx, &ofrep.EvaluateFlagRequest{

--- a/internal/server/evaluation/server.go
+++ b/internal/server/evaluation/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"go.flipt.io/flipt/internal/server/environments"
-	"go.flipt.io/flipt/internal/storage"
 	"go.flipt.io/flipt/rpc/flipt/evaluation"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -37,9 +36,4 @@ func (s *Server) RegisterGRPC(server *grpc.Server) {
 
 func (s *Server) SkipsAuthorization(ctx context.Context) bool {
 	return true
-}
-
-// getEvalStore returns the relevant instance of storage used to fetch data for evaluations.
-func (s *Server) getEvalStore(ctx context.Context) (storage.ReadOnlyStore, error) {
-	return s.store.GetFromContext(ctx).EvaluationStore()
 }

--- a/internal/server/metrics/metrics.go
+++ b/internal/server/metrics/metrics.go
@@ -57,7 +57,7 @@ var (
 	//nolint
 	AttributeMatch       = attribute.Key("flipt.match")
 	AttributeFlag        = attribute.Key("flipt.flag")
-	AttributeType        = attribute.Key("flipt.type")
+	AttributeFlagType    = attribute.Key("flipt.flag_type")
 	AttributeSegments    = attribute.Key("flipt.segments")
 	AttributeReason      = attribute.Key("flipt.reason")
 	AttributeValue       = attribute.Key("flipt.value")

--- a/internal/server/middleware/grpc/middleware_test.go
+++ b/internal/server/middleware/grpc/middleware_test.go
@@ -209,6 +209,7 @@ func TestFliptHeadersInterceptor(t *testing.T) {
 				ctx = metadata.NewIncomingContext(ctx, tt.md)
 			}
 
+			//nolint:all
 			spyHandler := grpc.UnaryHandler(func(ctx context.Context, req any) (any, error) {
 				environment, _ := cctx.FliptEnvironmentFromContext(ctx)
 				assert.Equal(t, tt.want.environment, environment)
@@ -230,6 +231,7 @@ func TestEvaluationUnaryInterceptor_Noop(t *testing.T) {
 			NamespaceKey: "foo",
 		}
 
+		//nolint:all
 		handler = func(ctx context.Context, r any) (any, error) {
 			return &flipt.FlagList{
 				Flags: []*flipt.Flag{
@@ -317,6 +319,7 @@ func TestEvaluationUnaryInterceptor_EnvironmentAndNamespace(t *testing.T) {
 		ctx = cctx.WithFliptNamespace(ctx, "test-namespace")
 
 		var (
+			//nolint:all
 			handler = func(_ context.Context, r any) (any, error) {
 				// ensure request has ID once it reaches the handler
 				req, ok := r.(*evaluation.EvaluationRequest)
@@ -385,6 +388,7 @@ func TestEvaluationUnaryInterceptor_RequestID(t *testing.T) {
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			var (
+				//nolint:all
 				handler = func(ctx context.Context, r any) (any, error) {
 					// ensure request has ID once it reaches the handler
 					req, ok := r.(request)

--- a/internal/storage/environments/git/store.go
+++ b/internal/storage/environments/git/store.go
@@ -60,7 +60,7 @@ func NewEnvironmentFromRepo(
 	}, nil
 }
 
-func (e *Environment) Name() string {
+func (e *Environment) Key() string {
 	return e.cfg.Name
 }
 

--- a/rpc/flipt/analytics/analytics.pb.go
+++ b/rpc/flipt/analytics/analytics.pb.go
@@ -23,13 +23,14 @@ const (
 )
 
 type GetFlagEvaluationsCountRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	NamespaceKey  string                 `protobuf:"bytes,1,opt,name=namespace_key,json=namespaceKey,proto3" json:"namespace_key,omitempty"`
-	FlagKey       string                 `protobuf:"bytes,2,opt,name=flag_key,json=flagKey,proto3" json:"flag_key,omitempty"`
-	From          string                 `protobuf:"bytes,3,opt,name=from,proto3" json:"from,omitempty"`
-	To            string                 `protobuf:"bytes,4,opt,name=to,proto3" json:"to,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	NamespaceKey   string                 `protobuf:"bytes,1,opt,name=namespace_key,json=namespaceKey,proto3" json:"namespace_key,omitempty"`
+	FlagKey        string                 `protobuf:"bytes,2,opt,name=flag_key,json=flagKey,proto3" json:"flag_key,omitempty"`
+	From           string                 `protobuf:"bytes,3,opt,name=from,proto3" json:"from,omitempty"`
+	To             string                 `protobuf:"bytes,4,opt,name=to,proto3" json:"to,omitempty"`
+	EnvironmentKey string                 `protobuf:"bytes,5,opt,name=environment_key,json=environmentKey,proto3" json:"environment_key,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *GetFlagEvaluationsCountRequest) Reset() {
@@ -90,6 +91,13 @@ func (x *GetFlagEvaluationsCountRequest) GetTo() string {
 	return ""
 }
 
+func (x *GetFlagEvaluationsCountRequest) GetEnvironmentKey() string {
+	if x != nil {
+		return x.EnvironmentKey
+	}
+	return ""
+}
+
 type GetFlagEvaluationsCountResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Timestamps    []string               `protobuf:"bytes,1,rep,name=timestamps,proto3" json:"timestamps,omitempty"`
@@ -146,12 +154,13 @@ var File_analytics_analytics_proto protoreflect.FileDescriptor
 
 const file_analytics_analytics_proto_rawDesc = "" +
 	"\n" +
-	"\x19analytics/analytics.proto\x12\x0fflipt.analytics\x1a\x1bgoogle/api/visibility.proto\"\x84\x01\n" +
+	"\x19analytics/analytics.proto\x12\x0fflipt.analytics\x1a\x1bgoogle/api/visibility.proto\"\xad\x01\n" +
 	"\x1eGetFlagEvaluationsCountRequest\x12#\n" +
 	"\rnamespace_key\x18\x01 \x01(\tR\fnamespaceKey\x12\x19\n" +
 	"\bflag_key\x18\x02 \x01(\tR\aflagKey\x12\x12\n" +
 	"\x04from\x18\x03 \x01(\tR\x04from\x12\x0e\n" +
-	"\x02to\x18\x04 \x01(\tR\x02to\"Y\n" +
+	"\x02to\x18\x04 \x01(\tR\x02to\x12'\n" +
+	"\x0fenvironment_key\x18\x05 \x01(\tR\x0eenvironmentKey\"Y\n" +
 	"\x1fGetFlagEvaluationsCountResponse\x12\x1e\n" +
 	"\n" +
 	"timestamps\x18\x01 \x03(\tR\n" +

--- a/rpc/flipt/analytics/analytics.proto
+++ b/rpc/flipt/analytics/analytics.proto
@@ -11,6 +11,7 @@ message GetFlagEvaluationsCountRequest {
   string flag_key = 2;
   string from = 3;
   string to = 4;
+  string environment_key = 5;
 }
 
 message GetFlagEvaluationsCountResponse {

--- a/rpc/flipt/evaluation/evaluation.go
+++ b/rpc/flipt/evaluation/evaluation.go
@@ -6,6 +6,28 @@ import (
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// SetEnvironmentKeyIfNotBlank attempts to set the provided environment key on the instance
+// If the environment key was blank, it returns the environment key provided to this call.
+// If the environment key was not blank, it returns the environment key found on the instance.
+func (x *EvaluationRequest) SetEnvironmentKeyIfNotBlank(key string) string {
+	if x.EnvironmentKey == "" {
+		x.EnvironmentKey = key
+	}
+
+	return x.EnvironmentKey
+}
+
+// SetNamespaceKeyIfNotBlank attempts to set the provided namespace key on the instance
+// If the namespace key was blank, it returns the namespace key provided to this call.
+// If the namespace key was not blank, it returns the namespace key found on the instance.
+func (x *EvaluationRequest) SetNamespaceKeyIfNotBlank(key string) string {
+	if x.NamespaceKey == "" {
+		x.NamespaceKey = key
+	}
+
+	return x.NamespaceKey
+}
+
 // SetRequestIDIfNotBlank attempts to set the provided ID on the instance
 // If the ID was blank, it returns the ID provided to this call.
 // If the ID was not blank, it returns the ID found on the instance.

--- a/rpc/flipt/evaluation/evaluation.pb.go
+++ b/rpc/flipt/evaluation/evaluation.pb.go
@@ -418,15 +418,16 @@ func (EvaluationConstraintComparisonType) EnumDescriptor() ([]byte, []int) {
 }
 
 type EvaluationRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	RequestId     string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
-	NamespaceKey  string                 `protobuf:"bytes,2,opt,name=namespace_key,json=namespaceKey,proto3" json:"namespace_key,omitempty"`
-	FlagKey       string                 `protobuf:"bytes,3,opt,name=flag_key,json=flagKey,proto3" json:"flag_key,omitempty"`
-	EntityId      string                 `protobuf:"bytes,4,opt,name=entity_id,json=entityId,proto3" json:"entity_id,omitempty"`
-	Context       map[string]string      `protobuf:"bytes,5,rep,name=context,proto3" json:"context,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Reference     string                 `protobuf:"bytes,6,opt,name=reference,proto3" json:"reference,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	RequestId      string                 `protobuf:"bytes,1,opt,name=request_id,json=requestId,proto3" json:"request_id,omitempty"`
+	NamespaceKey   string                 `protobuf:"bytes,2,opt,name=namespace_key,json=namespaceKey,proto3" json:"namespace_key,omitempty"`
+	FlagKey        string                 `protobuf:"bytes,3,opt,name=flag_key,json=flagKey,proto3" json:"flag_key,omitempty"`
+	EntityId       string                 `protobuf:"bytes,4,opt,name=entity_id,json=entityId,proto3" json:"entity_id,omitempty"`
+	Context        map[string]string      `protobuf:"bytes,5,rep,name=context,proto3" json:"context,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Reference      string                 `protobuf:"bytes,6,opt,name=reference,proto3" json:"reference,omitempty"`
+	EnvironmentKey string                 `protobuf:"bytes,7,opt,name=environment_key,json=environmentKey,proto3" json:"environment_key,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *EvaluationRequest) Reset() {
@@ -497,6 +498,13 @@ func (x *EvaluationRequest) GetContext() map[string]string {
 func (x *EvaluationRequest) GetReference() string {
 	if x != nil {
 		return x.Reference
+	}
+	return ""
+}
+
+func (x *EvaluationRequest) GetEnvironmentKey() string {
+	if x != nil {
+		return x.EnvironmentKey
 	}
 	return ""
 }
@@ -1903,7 +1911,7 @@ var File_evaluation_evaluation_proto protoreflect.FileDescriptor
 
 const file_evaluation_evaluation_proto_rawDesc = "" +
 	"\n" +
-	"\x1bevaluation/evaluation.proto\x12\x10flipt.evaluation\x1a$gnostic/openapi/v3/annotations.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a\x1bgoogle/api/visibility.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc9\x02\n" +
+	"\x1bevaluation/evaluation.proto\x12\x10flipt.evaluation\x1a$gnostic/openapi/v3/annotations.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a\x1bgoogle/api/visibility.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf7\x02\n" +
 	"\x11EvaluationRequest\x12\x1d\n" +
 	"\n" +
 	"request_id\x18\x01 \x01(\tR\trequestId\x12(\n" +
@@ -1911,7 +1919,8 @@ const file_evaluation_evaluation_proto_rawDesc = "" +
 	"\bflag_key\x18\x03 \x01(\tB\x03\xe0A\x02R\aflagKey\x12 \n" +
 	"\tentity_id\x18\x04 \x01(\tB\x03\xe0A\x02R\bentityId\x12O\n" +
 	"\acontext\x18\x05 \x03(\v20.flipt.evaluation.EvaluationRequest.ContextEntryB\x03\xe0A\x02R\acontext\x12\x1c\n" +
-	"\treference\x18\x06 \x01(\tR\treference\x1a:\n" +
+	"\treference\x18\x06 \x01(\tR\treference\x12,\n" +
+	"\x0fenvironment_key\x18\a \x01(\tB\x03\xe0A\x02R\x0eenvironmentKey\x1a:\n" +
 	"\fContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x9b\x01\n" +

--- a/rpc/flipt/evaluation/evaluation.proto
+++ b/rpc/flipt/evaluation/evaluation.proto
@@ -17,6 +17,7 @@ message EvaluationRequest {
   string entity_id = 4 [(google.api.field_behavior) = REQUIRED];
   map<string, string> context = 5 [(google.api.field_behavior) = REQUIRED];
   string reference = 6;
+  string environment_key = 7 [(google.api.field_behavior) = REQUIRED];
 }
 
 message BatchEvaluationRequest {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -157,7 +157,7 @@ export default function App() {
   const environment = useSelector(selectCurrentEnvironment);
   const namespace = useSelector(selectCurrentNamespace);
 
-  let title = `Flipt | ${environment.name} · ${namespace.name}`;
+  let title = `Flipt | ${environment.key} · ${namespace.name}`;
 
   return (
     <>

--- a/ui/src/app/Layout.tsx
+++ b/ui/src/app/Layout.tsx
@@ -54,7 +54,7 @@ function InnerLayout() {
   const info = useSelector(selectInfo);
 
   const namespaces = useListNamespacesQuery({
-    environmentKey: currentEnvironment.name
+    environmentKey: currentEnvironment.key
   });
 
   useEffect(() => {

--- a/ui/src/app/console/Console.tsx
+++ b/ui/src/app/console/Console.tsx
@@ -77,7 +77,7 @@ export default function Console() {
   const namespace = useSelector(selectCurrentNamespace);
 
   const { data, error } = useListFlagsQuery({
-    environmentKey: environment.name,
+    environmentKey: environment.key,
     namespaceKey: namespace.key
   });
 
@@ -135,7 +135,7 @@ export default function Console() {
       context: parsed
     };
 
-    evaluate(environment.name, namespace.key, flag.key, flag.type, rest)
+    evaluate(environment.key, namespace.key, flag.key, flag.type, rest)
       .then((resp) => {
         setHasEvaluationError(false);
         setResponse(JSON.stringify(resp, null, 2));

--- a/ui/src/app/environments/environmentsApi.ts
+++ b/ui/src/app/environments/environmentsApi.ts
@@ -29,13 +29,13 @@ export const environmentsSlice = createSlice({
   reducers: {
     currentEnvironmentChanged: (state, action) => {
       const environment = action.payload;
-      state.currentEnvironment = environment.name;
+      state.currentEnvironment = environment.key;
     },
     environmentsChanged: (state, action) => {
       const environments: { [key: string]: IEnvironment } = {};
       // First, build the environments map
       action.payload.environments.forEach((environment: IEnvironment) => {
-        environments[environment.name] = environment;
+        environments[environment.key] = environment;
       });
       state.environments = environments;
       state.status = LoadingStatus.SUCCEEDED;
@@ -88,7 +88,7 @@ export const selectCurrentEnvironment = createSelector(
       return state.environments[envs[0]];
     }
 
-    return { name: 'default', storage: '', directory: '' } as IEnvironment;
+    return { key: 'default', storage: '', directory: '' } as IEnvironment;
   }
 );
 
@@ -100,7 +100,7 @@ export const environmentsApi = createApi({
     listEnvironments: builder.query<{ environments: IEnvironment[] }, void>({
       query: () => '',
       providesTags: (result, _error) =>
-        result?.environments.map(({ name }) => ({
+        result?.environments.map(({ key: name }) => ({
           type: 'Environment' as const,
           id: name
         })) || []

--- a/ui/src/app/flags/Flag.tsx
+++ b/ui/src/app/flags/Flag.tsx
@@ -51,7 +51,7 @@ export default function Flag() {
     isLoading,
     isError
   } = useGetFlagQuery({
-    environmentKey: environment.name,
+    environmentKey: environment.key,
     namespaceKey: namespace.key,
     flagKey: flagKey || ''
   });
@@ -85,7 +85,7 @@ export default function Flag() {
           setOpen={setShowDeleteFlagModal}
           handleDelete={() =>
             deleteFlag({
-              environmentKey: environment.name,
+              environmentKey: environment.key,
               namespaceKey: namespace.key,
               flagKey: flag.key,
               revision
@@ -112,7 +112,7 @@ export default function Flag() {
           setOpen={setShowCopyFlagModal}
           handleCopy={(namespaceKey: string) =>
             copyFlag({
-              environmentKey: environment.name,
+              environmentKey: environment.key,
               from: { namespaceKey: namespace.key, flagKey: flag.key },
               to: { namespaceKey: namespaceKey, flagKey: flag.key }
             }).unwrap()

--- a/ui/src/app/flags/rules/Rules.tsx
+++ b/ui/src/app/flags/rules/Rules.tsx
@@ -138,7 +138,7 @@ export default function Rules({ flag, rules }: RulesProps) {
   const namespace = useSelector(selectCurrentNamespace);
 
   const segmentsList = useListSegmentsQuery({
-    environmentKey: environment.name,
+    environmentKey: environment.key,
     namespaceKey: namespace.key
   });
   const segments = useMemo(

--- a/ui/src/app/namespaces/Namespaces.tsx
+++ b/ui/src/app/namespaces/Namespaces.tsx
@@ -76,7 +76,7 @@ export default function Namespaces() {
           setOpen={setShowDeleteNamespaceModal}
           handleDelete={() =>
             deleteNamespace({
-              environmentKey: environment.name,
+              environmentKey: environment.key,
               namespaceKey: deletingNamespace?.key!,
               revision: revision
             }).unwrap()

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -52,7 +52,7 @@ export default function Segment() {
     isLoading,
     isError
   } = useGetSegmentQuery({
-    environmentKey: environment.name,
+    environmentKey: environment.key,
     namespaceKey: namespace.key,
     segmentKey: segmentKey || ''
   });
@@ -86,7 +86,7 @@ export default function Segment() {
           setOpen={setShowDeleteSegmentModal}
           handleDelete={() =>
             deleteSegment({
-              environmentKey: environment.name,
+              environmentKey: environment.key,
               namespaceKey: namespace.key,
               segmentKey: segment.key,
               revision
@@ -113,7 +113,7 @@ export default function Segment() {
           setOpen={setShowCopySegmentModal}
           handleCopy={(namespaceKey: string) =>
             copySegment({
-              environmentKey: environment.name,
+              environmentKey: environment.key,
               from: { namespaceKey: namespace.key, segmentKey: segment.key },
               to: { namespaceKey: namespaceKey, segmentKey: segment.key }
             }).unwrap()

--- a/ui/src/components/command/CommandDialog.tsx
+++ b/ui/src/components/command/CommandDialog.tsx
@@ -107,7 +107,7 @@ export default function CommandMenu() {
   const dispatch = useAppDispatch();
 
   const environments = useSelector(selectEnvironments).filter(
-    (e) => e.name !== currentEnvironment?.name
+    (e) => e.key !== currentEnvironment?.key
   );
 
   const namespaces = useSelector(selectNamespaces).filter(
@@ -199,16 +199,16 @@ export default function CommandMenu() {
                     </Command.Item>
                     {environments.map((environment) => (
                       <CommandItem
-                        key={environment.name}
+                        key={environment.key}
                         item={{
-                          name: environment.name,
+                          name: environment.key,
                           onSelected: () => {
                             setOpen(false);
                             dispatch(currentEnvironmentChanged(environment));
                             setSearch('');
                             setPages((pages) => pages.slice(0, -1));
                           },
-                          keywords: [environment.name]
+                          keywords: [environment.key]
                         }}
                       />
                     ))}

--- a/ui/src/components/environments/EnvironmentListbox.tsx
+++ b/ui/src/components/environments/EnvironmentListbox.tsx
@@ -15,7 +15,7 @@ import { ISelectable } from '~/types/Selectable';
 import { useAppDispatch } from '~/data/hooks/store';
 import { cls } from '~/utils/helpers';
 
-export type SelectableEnvironment = Pick<IEnvironment, 'name'> & ISelectable;
+export type SelectableEnvironment = Pick<IEnvironment, 'key'> & ISelectable;
 
 type EnvironmentListboxProps = {
   className?: string;
@@ -38,7 +38,7 @@ export default function EnvironmentListbox(props: EnvironmentListboxProps) {
     >
       <div className={cls('relative', className)}>
         <Listbox.Button className="group flex items-center gap-1 rounded px-2 py-1 text-sm text-white hover:bg-white/10 uppercase">
-          <span>{environment?.name || 'Unknown Environment'}</span>
+          <span>{environment?.key || 'Unknown Environment'}</span>
           {environments.length > 1 && (
             <ChevronDownIcon
               className="h-4 w-4 text-gray-400 transition-transform duration-200 group-hover:text-white ui-open:rotate-180"
@@ -56,7 +56,7 @@ export default function EnvironmentListbox(props: EnvironmentListboxProps) {
           <Listbox.Options className="absolute right-0 z-50 mt-1 max-h-60 w-full min-w-[160px] overflow-auto rounded-md bg-white dark:bg-gray-800 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-hidden sm:text-sm">
             {environments.map((env) => (
               <Listbox.Option
-                key={env.name}
+                key={env.key}
                 className={({ active }) =>
                   cls(
                     'relative cursor-default select-none px-4 py-2',
@@ -74,7 +74,7 @@ export default function EnvironmentListbox(props: EnvironmentListboxProps) {
                       selected ? 'font-medium' : ''
                     )}
                   >
-                    {env.name}
+                    {env.key}
                   </span>
                 )}
               </Listbox.Option>

--- a/ui/src/components/flags/FlagForm.tsx
+++ b/ui/src/components/flags/FlagForm.tsx
@@ -108,7 +108,7 @@ export default function FlagForm(props: { flag?: IFlag }) {
 
     if (isNew) {
       return createFlag({
-        environmentKey: environment.name,
+        environmentKey: environment.key,
         namespaceKey: namespace.key,
         values: v,
         revision
@@ -116,7 +116,7 @@ export default function FlagForm(props: { flag?: IFlag }) {
     }
 
     return updateFlag({
-      environmentKey: environment.name,
+      environmentKey: environment.key,
       namespaceKey: namespace.key,
       flagKey: flag?.key,
       values: v,

--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -106,7 +106,7 @@ export default function FlagTable(props: FlagTableProps) {
   const sorting = useSelector(selectSorting);
 
   const { data, isLoading, error } = useListFlagsQuery({
-    environmentKey: environment.name,
+    environmentKey: environment.key,
     namespaceKey: namespace.key
   });
   const flags = useMemo(() => data?.flags || [], [data]);

--- a/ui/src/components/namespaces/NamespaceForm.tsx
+++ b/ui/src/components/namespaces/NamespaceForm.tsx
@@ -53,13 +53,13 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
   const handleSubmit = async (values: INamespace) => {
     if (isNew) {
       return createNamespace({
-        environmentKey: environment.name,
+        environmentKey: environment.key,
         values,
         revision
       }).unwrap();
     }
     return updateNamespace({
-      environmentKey: environment.name,
+      environmentKey: environment.key,
       values,
       revision
     }).unwrap();

--- a/ui/src/components/rollouts/Rollouts.tsx
+++ b/ui/src/components/rollouts/Rollouts.tsx
@@ -62,7 +62,7 @@ export default function Rollouts({ flag, rollouts }: RolloutsProps) {
   const namespace = useSelector(selectCurrentNamespace);
 
   const segmentsList = useListSegmentsQuery({
-    environmentKey: environment.name,
+    environmentKey: environment.key,
     namespaceKey: namespace.key
   });
   const segments = useMemo(

--- a/ui/src/components/segments/SegmentForm.tsx
+++ b/ui/src/components/segments/SegmentForm.tsx
@@ -74,14 +74,14 @@ export default function SegmentForm(props: SegmentFormProps) {
   const handleSubmit = (values: ISegment) => {
     if (isNew) {
       return createSegment({
-        environmentKey: environment.name,
+        environmentKey: environment.key,
         namespaceKey: namespace.key,
         values,
         revision
       }).unwrap();
     }
     return updateSegment({
-      environmentKey: environment.name,
+      environmentKey: environment.key,
       namespaceKey: namespace.key,
       segmentKey: segment?.key,
       values,

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -93,7 +93,7 @@ export default function SegmentTable(props: SegmentTableProps) {
   const sorting = useSelector(selectSorting);
 
   const { data, isLoading, error } = useListSegmentsQuery({
-    environmentKey: environment.name,
+    environmentKey: environment.key,
     namespaceKey: namespace.key
   });
   const segments = useMemo(() => data?.segments || [], [data]);

--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -15,7 +15,6 @@ export const metaURL = 'meta/info';
 export const sessionKey = 'session';
 
 const csrfTokenHeaderKey = 'x-csrf-token';
-const fliptEnvironmentHeaderKey = 'x-flipt-environment';
 
 export type Session = {
   required: boolean;
@@ -141,7 +140,7 @@ export async function expireAuthSelf() {
 //
 // evaluate
 export async function evaluate(
-  environmentName: string,
+  environmentKey: string,
   namespaceKey: string,
   flagKey: string,
   flagType: FlagType,
@@ -149,13 +148,12 @@ export async function evaluate(
 ) {
   let route = flagType === FlagType.BOOLEAN ? '/boolean' : '/variant';
   const body = {
+    environmentKey,
     namespaceKey,
     flagKey: flagKey,
     ...values
   };
-  return post(route, body, evaluateURL, {
-    [fliptEnvironmentHeaderKey]: environmentName
-  });
+  return post(route, body, evaluateURL);
 }
 
 //

--- a/ui/src/types/Environment.ts
+++ b/ui/src/types/Environment.ts
@@ -1,5 +1,5 @@
 export interface IEnvironment {
-  name: string;
+  key: string;
   storage: string;
   directory: string;
   default?: boolean;


### PR DESCRIPTION
Fixes: #3913

- updates clickhouse and prometheus to add `environmentKey`
- adds `environment` to otel traces
- adds `environmentKey` in evaluation and analytics protos
- renames `environmentName` to `environmentKey` in ui code
- map `X-Flipt-Environment` header to `environmentKey` in evaluation requests if not set
- map `X-Flipt-Namespace` header to `namespaceKey` in evaluation requests if not set

## TODO

- [x] map `X-Flipt-Environment` header to `environmentKey` in evaluation requests if not set
- [x] (maybe?) map `X-Flipt-Namespace` header to `namespaceKey` in evaluation requests if not set