### PR TITLE
fix: logout in ui error

### DIFF
--- a/internal/cmd/authn.go
+++ b/internal/cmd/authn.go
@@ -93,7 +93,7 @@ func authenticationGRPC(
 	}
 
 	rpcauth.RegisterPublicAuthenticationServiceServer(handlers, public.NewServer(logger, authCfg))
-	rpcauth.RegisterAuthenticationServiceServer(handlers, authn.NewServer(logger, storageauthmemory.NewStore(logger)))
+	rpcauth.RegisterAuthenticationServiceServer(handlers, authn.NewServer(logger, store))
 
 	shutdown = store.Shutdown
 

--- a/internal/storage/authn/auth.go
+++ b/internal/storage/authn/auth.go
@@ -39,6 +39,7 @@ type Store interface {
 	// ExpireAuthenticationByID attempts to expire an Authentication by ID string and the provided expiry time.
 	ExpireAuthenticationByID(context.Context, string, *timestamppb.Timestamp) error
 	Shutdown(context.Context) error
+	fmt.Stringer
 }
 
 // CreateAuthenticationRequest is the argument passed when creating instances

--- a/internal/storage/authn/memory/store.go
+++ b/internal/storage/authn/memory/store.go
@@ -74,6 +74,10 @@ func NewStore(logger *zap.Logger, opts ...Option) *Store {
 	return store
 }
 
+func (s *Store) String() string {
+	return "memory"
+}
+
 // WithNowFunc overrides the stores now() function used to obtain
 // a protobuf timestamp representative of the current time of evaluation.
 func WithNowFunc(fn func() *timestamppb.Timestamp) Option {

--- a/internal/storage/authn/redis/store.go
+++ b/internal/storage/authn/redis/store.go
@@ -64,7 +64,7 @@ type Option func(*Store)
 func NewStore(c *goredis.Client, logger *zap.Logger, opts ...Option) *Store {
 	store := &Store{
 		client:             c,
-		logger:             logger,
+		logger:             logger.With(zap.String("store", "redis")),
 		now:                rpcflipt.Now,
 		generateID:         uuid.NewString,
 		generateToken:      authn.GenerateRandomToken,
@@ -76,6 +76,10 @@ func NewStore(c *goredis.Client, logger *zap.Logger, opts ...Option) *Store {
 	}
 
 	return store
+}
+
+func (s *Store) String() string {
+	return "redis"
 }
 
 // WithNowFunc overrides the stores now() function used to obtain


### PR DESCRIPTION
Fixes: #4093 

We were creating a new in-memory store for the auth service that handles logout instead of re-using the existing one. So creating the session auth would store the tokens either in memory or redis, but when trying to look them up to expire we would be looking in a different part of memory so they would never be found