### PR TITLE
fix: issue with redis not setting expires at on auth record

### DIFF
--- a/internal/storage/authn/memory/store.go
+++ b/internal/storage/authn/memory/store.go
@@ -290,6 +290,7 @@ func (s *Store) ExpireAuthenticationByID(ctx context.Context, id string, expires
 	}
 
 	authentication.ExpiresAt = expiresAt
+	authentication.UpdatedAt = s.now()
 	return nil
 }
 

--- a/internal/storage/authn/testing/testing.go
+++ b/internal/storage/authn/testing/testing.go
@@ -226,6 +226,6 @@ func TestAuthenticationStoreHarness(t *testing.T, fn func(t *testing.T) storagea
 
 		auth, err := store.GetAuthenticationByClientToken(ctx, created[0].Token)
 		require.NoError(t, err)
-		assert.True(t, auth.ExpiresAt.AsTime().Before(time.Now().UTC()))
+		assert.True(t, auth.ExpiresAt.AsTime().UTC().Before(time.Now().UTC()))
 	})
 }


### PR DESCRIPTION
This pull request introduces updates to the Redis-based authentication store and its associated tests. The changes focus on improving the handling of authentication record expiration and ensuring consistency in time comparisons.

### Updates to authentication record handling:

* [`internal/storage/authn/redis/store.go`](diffhunk://#diff-abeaff6900c1af1b4218b14af77f5d309fb0453899fb822992ab0ea870315f7cR350-R381): Enhanced the `ExpireAuthenticationByID` method to retrieve, unmarshal, update, and re-marshal the authentication record before updating its `ExpiresAt` and `UpdatedAt` fields. This ensures the record is properly updated in Redis with the new expiration time.

### Test improvements:

* [`internal/storage/authn/testing/testing.go`](diffhunk://#diff-4d5a2b55d592e1ca4b35d55ad0f71d0363067988a4e3cf1fa77d93377a5f750fL229-R229): Modified a test assertion to explicitly convert the `ExpiresAt` field to UTC before comparing it to the current time, ensuring consistent time zone handling in tests.