### PR TITLE
fix: ui shadow missing in v2; remove unused authz configs for now

### DIFF
--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -237,6 +237,8 @@ type AuthenticationSessionStorageRedisConfig struct {
 	CaCertBytes     string        `json:"-" mapstructure:"ca_cert_bytes" yaml:"-"`
 	CaCertPath      string        `json:"-" mapstructure:"ca_cert_path" yaml:"-"`
 	InsecureSkipTLS bool          `json:"-" mapstructure:"insecure_skip_tls" yaml:"-"`
+	// TODO: add prefix support
+	// TODO: add cluster support
 }
 
 func (cfg *AuthenticationSessionStorageRedisConfig) validate() error {

--- a/internal/config/authorization.go
+++ b/internal/config/authorization.go
@@ -3,8 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"path"
-	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -19,11 +17,9 @@ var (
 type AuthorizationConfig struct {
 	// Required designates whether authorization credentials are validated.
 	// If required == true, then authorization is required for all API endpoints.
-	Required bool                             `json:"required,omitempty" mapstructure:"required" yaml:"required,omitempty"`
-	Backend  AuthorizationBackend             `json:"backend,omitempty" mapstructure:"backend" yaml:"backend,omitempty"`
-	Local    *AuthorizationLocalConfig        `json:"local,omitempty" mapstructure:"local,omitempty" yaml:"local,omitempty"`
-	Bundle   *AuthorizationSourceBundleConfig `json:"bundle,omitempty" mapstructure:"bundle,omitempty" yaml:"bundle,omitempty"`
-	Object   *AuthorizationSourceObjectConfig `json:"object,omitempty" mapstructure:"object,omitempty" yaml:"object,omitempty"`
+	Required bool                      `json:"required,omitempty" mapstructure:"required" yaml:"required,omitempty"`
+	Backend  AuthorizationBackend      `json:"backend,omitempty" mapstructure:"backend" yaml:"backend,omitempty"`
+	Local    *AuthorizationLocalConfig `json:"local,omitempty" mapstructure:"local,omitempty" yaml:"local,omitempty"`
 }
 
 func (c *AuthorizationConfig) setDefaults(v *viper.Viper) error {
@@ -66,23 +62,8 @@ func (c *AuthorizationConfig) validate() error {
 				return fmt.Errorf("authorization: local: %w", err)
 			}
 
-		case AuthorizationBackendBundle:
-			if c.Bundle == nil {
-				return errors.New("authorization: bundle backend must be configured")
-			}
-
-			if err := c.Bundle.validate(); err != nil {
-				return fmt.Errorf("authorization: bundle: %w", err)
-			}
-
-		case AuthorizationBackendObject:
-			if c.Object == nil {
-				return errors.New("authorization: object backend must be configured")
-			}
-
-			if err := c.Object.validate(); err != nil {
-				return fmt.Errorf("authorization: object: %w", err)
-			}
+		default:
+			return errString("authorization", "backend must be one of local")
 		}
 	}
 
@@ -94,17 +75,7 @@ func (c *AuthorizationConfig) validate() error {
 type AuthorizationBackend string
 
 const (
-	AuthorizationBackendLocal  = AuthorizationBackend("local")
-	AuthorizationBackendObject = AuthorizationBackend("object")
-	AuthorizationBackendBundle = AuthorizationBackend("bundle")
-)
-
-type ObjectAuthorizationBackendType string
-
-const (
-	S3ObjectAuthorizationBackendType = ObjectAuthorizationBackendType("s3")
-	// AZObjectSubAuthorizationBackendType = ObjectSubAuthorizationBackendType("azblob")
-	// GSObjectSubAuthorizationBackendType = ObjectSubAuthorizationBackendType("googlecloud")
+	AuthorizationBackendLocal = AuthorizationBackend("local")
 )
 
 // AuthorizationLocalConfig configures the local backend source
@@ -152,108 +123,3 @@ func (a *AuthorizationSourceLocalConfig) validate() error {
 
 	return nil
 }
-
-type AuthorizationSourceBundleConfig struct {
-	Configuration string `json:"configuration,omitempty" mapstructure:"configuration" yaml:"configuration,omitempty"`
-}
-
-func (a *AuthorizationSourceBundleConfig) validate() error {
-	if a == nil {
-		return nil
-	}
-
-	if a.Configuration == "" {
-		return errString("authorization", "configuration must be non-empty string")
-	}
-
-	return nil
-}
-
-// String returns the configuration as a string in the format expected by the OPA engine
-func (a *AuthorizationSourceBundleConfig) String() string {
-	return a.Configuration
-}
-
-// AuthorizationSourceObjectConfig contains authz bundle configuration from object storage.
-type AuthorizationSourceObjectConfig struct {
-	Type ObjectAuthorizationBackendType `json:"type,omitempty" mapstructure:"type" yaml:"type,omitempty"`
-	S3   *S3AuthorizationSource         `json:"s3,omitempty" mapstructure:"s3,omitempty" yaml:"s3,omitempty"`
-	// AZBlob *AZBlobAuthorizationSource        `json:"azblob,omitempty" mapstructure:"azblob,omitempty" yaml:"azblob,omitempty"`
-	// GS     *GSAuthorizationSource            `json:"googlecloud,omitempty" mapstructure:"googlecloud,omitempty" yaml:"googlecloud,omitempty"`
-}
-
-// validate is only called if authorization.backend == "object"
-func (a *AuthorizationSourceObjectConfig) validate() error {
-	if a == nil {
-		return nil
-	}
-
-	switch a.Type {
-	case S3ObjectAuthorizationBackendType:
-		if a.S3 == nil || a.S3.Bucket == "" {
-			return errString("authorization", "s3 bucket must be specified")
-		}
-
-	default:
-		return errFieldRequired("authorization", "type")
-	}
-	return nil
-}
-
-// String returns the configuration as a string in the format expected by the OPA engine
-func (a *AuthorizationSourceObjectConfig) String() string {
-	var (
-		url  strings.Builder
-		tmpl string
-	)
-
-	switch a.Type { //nolint
-	case S3ObjectAuthorizationBackendType:
-		if a.S3.Endpoint != "" {
-			url.WriteString(a.S3.Endpoint)
-		} else {
-			url.WriteString("https://s3")
-			if a.S3.Region != "" {
-				url.WriteString(".")
-				url.WriteString(a.S3.Region)
-			}
-			url.WriteString(".amazonaws.com")
-		}
-
-		tmpl = fmt.Sprintf(`
-services:
-  s3:
-    url: %s
-    credentials:
-      s3_signing:
-        environment_credentials: {}
-
-bundles:
-  flipt:
-    service: s3
-    resource: %s
-`, url.String(), path.Join(a.S3.Bucket, a.S3.Prefix, "bundle.tar.gz"))
-	}
-
-	return tmpl
-}
-
-// S3AuthorizationSource contains configuration for referencing a s3 bucket
-type S3AuthorizationSource struct {
-	Endpoint string `json:"-" mapstructure:"endpoint" yaml:"endpoint,omitempty"`
-	Bucket   string `json:"bucket,omitempty" mapstructure:"bucket" yaml:"bucket,omitempty"`
-	Prefix   string `json:"prefix,omitempty" mapstructure:"prefix" yaml:"prefix,omitempty"`
-	Region   string `json:"region,omitempty" mapstructure:"region" yaml:"region,omitempty"`
-}
-
-// AZBlobSAuthorizationSource contains configuration for referencing a Azure Blob Storage
-// type AZBlobAuthorizationSource struct {
-// 	Endpoint     string        `json:"-" mapstructure:"endpoint" yaml:"endpoint,omitempty"`
-// 	Container    string        `json:"container,omitempty" mapstructure:"container" yaml:"container,omitempty"`
-// }
-
-// GSAuthorizationSource contains configuration for referencing a Google Cloud Storage
-// type GSAuthorizationSource struct {
-// 	Bucket       string        `json:"-" mapstructure:"bucket" yaml:"bucket,omitempty"`
-// 	Prefix       string        `json:"prefix,omitempty" mapstructure:"prefix" yaml:"prefix,omitempty"`
-// }

--- a/ui/src/assets/colors/dark.css
+++ b/ui/src/assets/colors/dark.css
@@ -1,15 +1,15 @@
 :root.dark {
   --gray-50: 17 24 39;
-  --gray-100: 31 41 55;
-  --gray-200: 55 65 81;
-  --gray-300: 75 85 99;
-  --gray-400: 107 114 128;
-  --gray-500: 156 163 175;
-  --gray-600: 176 183 195;
-  --gray-700: 209 213 219;
-  --gray-800: 229 231 235;
+  --gray-100: 17 24 39;
+  --gray-200: 31 41 55;
+  --gray-300: 55 65 81;
+  --gray-400: 156 163 175;
+  --gray-500: 107 114 128;
+  --gray-600: 156 163 175;
+  --gray-700: 249 250 251;
+  --gray-800: 31 41 55;
   --gray-900: 243 244 246;
-  --gray-950: 249 250 251;
+  --gray-950: 243 244 246;
   --violet-600: 167 139 250;
   --violet-400: 139 92 246;
   --violet-300: 167 139 250;
@@ -28,10 +28,16 @@
   --red-100: 127 29 29;
   --red-50: 127 29 29;
 
-  .shadow {
+  .shadow-xs {
+    --tw-shadow-color: rgb(255 255 255 / 0.1);
     --tw-shadow:
       0 1px 3px 0 rgba(255, 255, 255, 0.1),
       0 1px 2px 0 rgba(255, 255, 255, 0.06);
+  }
+
+  .shadow {
+    --tw-shadow-color: rgb(255 255 255 / 0.05);
+    --tw-shadow: 0 1px 2px 0 rgba(255, 255, 255, 0.05);
   }
 
   .shadow-sm {
@@ -40,25 +46,28 @@
   }
 
   .shadow-md {
+    --tw-shadow-color: rgb(255 255 255 / 0.1);
     --tw-shadow:
       0 4px 6px -1px rgba(255, 255, 255, 0.1),
       0 2px 4px -1px rgba(255, 255, 255, 0.06);
   }
 
   .shadow-lg {
+    --tw-shadow-color: rgb(255 255 255 / 0.1);
     --tw-shadow:
       0 10px 15px -3px rgba(255, 255, 255, 0.1),
       0 4px 6px -2px rgba(255, 255, 255, 0.05);
+    box-shadow: var(--tw-shadow);
   }
 
   .shadow-xl {
+    --tw-shadow-color: rgb(255 255 255 / 0.1);
     --tw-shadow:
       0 20px 25px -5px rgba(255, 255, 255, 0.1),
       0 10px 10px -5px rgba(255, 255, 255, 0.04);
   }
 
   .shadow-2xl {
-    --tw-shadow-color: rgb(255 255 255 / 0.25);
     --tw-shadow: 0 25px 50px -12px rgba(255, 255, 255, 0.25);
   }
 }


### PR DESCRIPTION
- fixes missing shadows in v2 ui
- adds todos about redis cluster and prefix support for authn storage so I dont forget
- removes unused (for now) authz backends as we are only going to support local at initial release

## Before

![CleanShot 2025-04-23 at 11 50 44@2x](https://github.com/user-attachments/assets/295b34b3-7718-4ecf-b622-f84910b26d8f)

## After

![CleanShot 2025-04-23 at 11 50 06@2x](https://github.com/user-attachments/assets/a9d73ab6-b2d8-4922-aa98-f32bba55eefe)
