### PR TITLE
fix: issue with z-index in layout/banner; color issues with env listbox

### DIFF
--- a/ui/src/app/Layout.tsx
+++ b/ui/src/app/Layout.tsx
@@ -91,18 +91,22 @@ function InnerLayout() {
     <>
       <Sidebar setSidebarOpen={setSidebarOpen} sidebarOpen={sidebarOpen} />
       <div className="flex min-h-screen flex-col bg-background md:pl-64">
-        <Header setSidebarOpen={setSidebarOpen} />
-        {!dismissedBanner && (
-          <div className="sticky top-0 mt-16">
-            <Banner
-              title="Like Flipt? Give us a star on GitHub!"
-              description="It really means a lot to us. Thank you!"
-              href="https://github.com/flipt-io/flipt"
-              icon={<StarIcon className="mx-2 inline h-3 w-3" />}
-            />
-          </div>
-        )}
-        <main className={`flex flex-1 ${!dismissedBanner ? 'pt-8' : 'pt-24'}`}>
+        <div className="sticky top-0 z-40">
+          <Header setSidebarOpen={setSidebarOpen} />
+          {!dismissedBanner && (
+            <div className="mt-16 z-10">
+              <Banner
+                title="Like Flipt? Give us a star on GitHub!"
+                description="It really means a lot to us. Thank you!"
+                href="https://github.com/flipt-io/flipt"
+                icon={<StarIcon className="mx-2 inline h-3 w-3" />}
+              />
+            </div>
+          )}
+        </div>
+        <main
+          className={`flex flex-1 relative ${!dismissedBanner ? 'pt-8' : 'pt-24'}`}
+        >
           <div className="mx-auto w-full lg:max-w-(--breakpoint-lg) xl:max-w-(--breakpoint-xl) 2xl:max-w-(--breakpoint-2xl) overflow-x-auto px-4 sm:px-6 lg:px-8">
             <Outlet />
           </div>

--- a/ui/src/components/environments/EnvironmentListbox.tsx
+++ b/ui/src/components/environments/EnvironmentListbox.tsx
@@ -27,6 +27,13 @@ export default function EnvironmentListbox(props: EnvironmentListboxProps) {
   const dispatch = useAppDispatch();
   const environments = useSelector(selectEnvironments);
 
+  // Sort environments to show default first
+  const sortedEnvironments = [...environments].sort((a, b) => {
+    if (a.default) return -1;
+    if (b.default) return 1;
+    return a.key.localeCompare(b.key);
+  });
+
   return (
     <Listbox
       as="div"
@@ -37,7 +44,7 @@ export default function EnvironmentListbox(props: EnvironmentListboxProps) {
       data-testid="environment-listbox"
     >
       <div className={cls('relative', className)}>
-        <Listbox.Button className="group flex items-center gap-1 rounded px-2 py-1 text-sm text-white hover:bg-white/10 uppercase">
+        <Listbox.Button className="group flex items-center gap-1 rounded px-2 py-1 text-sm text-white hover:bg-white/10 uppercase focus:outline-none">
           <span>{environment?.key || 'Unknown Environment'}</span>
           {environments.length > 1 && (
             <ChevronDownIcon
@@ -53,16 +60,16 @@ export default function EnvironmentListbox(props: EnvironmentListboxProps) {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <Listbox.Options className="absolute right-0 z-50 mt-1 max-h-60 w-full min-w-[160px] overflow-auto rounded-md bg-white dark:bg-gray-800 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-hidden sm:text-sm">
-            {environments.map((env) => (
+          <Listbox.Options className="absolute right-0 z-50 mt-1 max-h-60 w-full min-w-[160px] overflow-auto rounded-lg bg-white dark:bg-gray-100 py-1 text-sm shadow-lg focus:outline-none">
+            {sortedEnvironments.map((env) => (
               <Listbox.Option
                 key={env.key}
                 className={({ active }) =>
                   cls(
-                    'relative cursor-default select-none px-4 py-2',
+                    'relative cursor-pointer select-none px-3 py-2',
                     active
-                      ? 'bg-gray-100 text-gray-900 dark:bg-violet-600 dark:text-white'
-                      : 'text-gray-700 dark:text-gray-100'
+                      ? 'bg-violet-500 text-white dark:bg-violet-400 dark:text-gray-100'
+                      : 'text-gray-900 dark:text-gray-900'
                   )
                 }
                 value={env}
@@ -71,7 +78,7 @@ export default function EnvironmentListbox(props: EnvironmentListboxProps) {
                   <span
                     className={cls(
                       'block truncate',
-                      selected ? 'font-medium' : ''
+                      selected ? 'font-semibold' : 'font-normal'
                     )}
                   >
                     {env.key}


### PR DESCRIPTION
Fixes a few ui layout/color issues including:

1. header not showing on top on scroll
2. env listbox not showing overtop banner
3. weird colors for env listbox in both light and darkmode
4. make default environment always the first in the env picker dropdown