### PR TITLE
chore: change v2 nightly to v2 alpha

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,8 +1,6 @@
-name: Release (Nightly)
+name: Release (Alpha)
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "30 22 * * *" # nightly @ 10:30 PM UTC
 
 permissions:
   contents: write
@@ -12,7 +10,7 @@ env:
   GO_VERSION: "1.24"
 
 jobs:
-  nightly-build:
+  alpha-build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -90,9 +88,9 @@ jobs:
           name: flipt-nightly-${{ matrix.name }}
           path: dist/flipt_${{ matrix.name }}_*/flipt
 
-  nightly-release:
+  alpha-release:
     runs-on: ubuntu-latest
-    needs: nightly-build
+    needs: alpha-build
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.goreleaser.darwin.yml
+++ b/.goreleaser.darwin.yml
@@ -16,7 +16,7 @@ builds:
   - main: ./cmd/flipt/.
     ldflags:
       - -s -w
-      - -X main.v=v2.0.0
+      - -X main.version={{ .PrefixedTag }}
       - -X main.commit={{ .Commit }}
       - -X main.date={{ .Date }}
       - -X main.analyticsKey={{ .Env.ANALYTICS_WRITE_KEY }}

--- a/.goreleaser.linux.yml
+++ b/.goreleaser.linux.yml
@@ -16,7 +16,7 @@ builds:
   - main: ./cmd/flipt/.
     ldflags:
       - -s -w
-      - -X main.v=v2.0.0
+      - -X main.version={{ .PrefixedTag }}
       - -X main.commit={{ .Commit }}
       - -X main.date={{ .Date }}
       - -X main.analyticsKey={{ .Env.ANALYTICS_WRITE_KEY }}

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -9,12 +9,12 @@ changelog:
   disable: true
 
 docker_manifests:
-  - name_template: "flipt/flipt:v2-nightly"
+  - name_template: "flipt/flipt:v2-alpha"
     image_templates:
-      - "flipt/flipt:v2-nightly-amd64"
-      - "flipt/flipt:v2-nightly-arm64"
+      - "flipt/flipt:v2-alpha-amd64"
+      - "flipt/flipt:v2-alpha-arm64"
 
-  - name_template: "ghcr.io/flipt-io/flipt:v2-nightly"
+  - name_template: "ghcr.io/flipt-io/flipt:v2-alpha"
     image_templates:
-      - "ghcr.io/flipt-io/flipt:v2-nightly-amd64"
-      - "ghcr.io/flipt-io/flipt:v2-nightly-arm64"
+      - "ghcr.io/flipt-io/flipt:v2-alpha-amd64"
+      - "ghcr.io/flipt-io/flipt:v2-alpha-arm64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,7 +67,7 @@ snapshot:
 
 nightly:
   # Default is `{{ incpatch .Version }}-{{ .ShortCommit }}-nightly`.
-  version_template: "v2-nightly"
+  version_template: "{{ incmajor .Version }}-alpha"
 
 changelog:
   disable: true
@@ -93,10 +93,10 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:v2-nightly-amd64{{ else }}flipt/flipt:v{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}flipt/flipt:v2-nightly-amd64{{ else }}flipt/flipt:v{{ .Major }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:v2-alpha-amd64{{ else }}flipt/flipt:v{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:v2-alpha-amd64{{ else }}flipt/flipt:v{{ .Major }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}-amd64{{ end }}"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -108,10 +108,10 @@ dockers:
     goos: linux
     goarch: arm64
     image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:v2-nightly-arm64{{ else }}flipt/flipt:v{{ .Tag }}-arm64{{ end }}"
-      - "{{ if .IsNightly }}flipt/flipt:v2-nightly-arm64{{ else }}flipt/flipt:v{{ .Major }}-arm64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-arm64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:v2-alpha-arm64{{ else }}flipt/flipt:v{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:v2-alpha-arm64{{ else }}flipt/flipt:v{{ .Major }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}-arm64{{ end }}"
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -119,25 +119,25 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
 
 docker_manifests:
-  - name_template: "{{ if .IsNightly }}flipt/flipt:v2-nightly{{ else }}flipt/flipt:v{{ .Tag }}{{ end }}"
+  - name_template: "{{ if .IsNightly }}flipt/flipt:v2-alpha{{ else }}flipt/flipt:v{{ .Tag }}{{ end }}"
     image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:v2-nightly-amd64{{ else }}flipt/flipt:v{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}flipt/flipt:v2-nightly-arm64{{ else }}flipt/flipt:v{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:v2-alpha-amd64{{ else }}flipt/flipt:v{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:v2-alpha-arm64{{ else }}flipt/flipt:v{{ .Tag }}-arm64{{ end }}"
 
-  - name_template: "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}{{ end }}"
+  - name_template: "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}{{ end }}"
     image_templates:
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Tag }}-arm64{{ end }}"
 
-  - name_template: "{{ if .IsNightly }}flipt/flipt:v2-nightly{{ else }}flipt/flipt:v{{ .Major }}{{ end }}"
+  - name_template: "{{ if .IsNightly }}flipt/flipt:v2-alpha{{ else }}flipt/flipt:v{{ .Major }}{{ end }}"
     image_templates:
-      - "{{ if .IsNightly }}flipt/flipt:v2-nightly-amd64{{ else }}flipt/flipt:v{{ .Major }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}flipt/flipt:v2-nightly-arm64{{ else }}flipt/flipt:v{{ .Major }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:v2-alpha-amd64{{ else }}flipt/flipt:v{{ .Major }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}flipt/flipt:v2-alpha-arm64{{ else }}flipt/flipt:v{{ .Major }}-arm64{{ end }}"
 
-  - name_template: "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}{{ end }}"
+  - name_template: "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}{{ end }}"
     image_templates:
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}-amd64{{ end }}"
-      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-nightly-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}-arm64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha-amd64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}-amd64{{ end }}"
+      - "{{ if .IsNightly }}ghcr.io/flipt-io/flipt:v2-alpha-arm64{{ else }}ghcr.io/flipt-io/flipt:v{{ .Major }}-arm64{{ end }}"
 
 announce:
   discord:

--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -39,7 +39,7 @@ import (
 var (
 	providedConfigFile string
 	forceMigrate       bool
-	v                  = "dev"
+	version            = "dev"
 	commit             string
 	date               string
 	goVersion          = runtime.Version()
@@ -101,7 +101,7 @@ func exec() error {
 			$ flipt config init
 			$ flipt --config /path/to/config.yml migrate
 		`),
-		Version: v,
+		Version: version,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
@@ -114,7 +114,7 @@ func exec() error {
 	)
 
 	if err := t.Execute(buf, &bannerOpts{
-		Version:   v,
+		Version:   version,
 		Commit:    commit,
 		Date:      date,
 		GoVersion: goVersion,
@@ -271,7 +271,7 @@ func run(ctx context.Context, logger *zap.Logger, cfg *config.Config) error {
 	var err error
 
 	if os.Getenv("OTEL_LOGS_EXPORTER") != "" {
-		otelResource, err := otel.NewResource(ctx, v)
+		otelResource, err := otel.NewResource(ctx, version)
 		if err != nil {
 			return fmt.Errorf("creating otel resource: %w", err)
 		}
@@ -309,18 +309,18 @@ func run(ctx context.Context, logger *zap.Logger, cfg *config.Config) error {
 	if isConsole {
 		color.Cyan("%s\n", banner)
 	} else {
-		logger.Info("flipt starting", zap.String("version", v), zap.String("commit", commit), zap.String("date", date), zap.String("go_version", goVersion))
+		logger.Info("flipt starting", zap.String("version", version), zap.String("commit", commit), zap.String("date", date), zap.String("go_version", goVersion))
 	}
 
 	var (
-		isRelease   = release.Is(v)
+		isRelease   = release.Is(version)
 		releaseInfo release.Info
 	)
 
 	if cfg.Meta.CheckForUpdates && isRelease {
 		logger.Debug("checking for updates")
 
-		releaseInfo, err = release.Check(ctx, v)
+		releaseInfo, err = release.Check(ctx, version)
 		if err != nil {
 			logger.Warn("checking for updates", zap.Error(err))
 		}
@@ -368,7 +368,7 @@ func run(ctx context.Context, logger *zap.Logger, cfg *config.Config) error {
 	}
 
 	info := info.New(
-		info.WithBuild(commit, date, goVersion, v, isRelease),
+		info.WithBuild(commit, date, goVersion, version, isRelease),
 		info.WithLatestRelease(releaseInfo),
 		info.WithConfig(cfg),
 	)


### PR DESCRIPTION
rename the nightly build to alpha for now as we wont be running it nightly as github doesnt let you use cron actions against non-main branches