### PR TITLE
fix: segment picker bugs

### DIFF
--- a/ui/src/components/forms/SegmentsPicker.tsx
+++ b/ui/src/components/forms/SegmentsPicker.tsx
@@ -37,19 +37,17 @@ export default function SegmentsPicker({
 
   // Update editing state when parent segments change
   useEffect(() => {
-    // Only update if the length has changed to avoid infinite loops
-    if (prevParentSegmentsLength.current !== parentSegments.length) {
-      setEditing(true);
+    // Set editing to true whenever segments change
+    setEditing(true);
 
-      // Update the set of selected segment keys
-      segmentsSet.current = new Set<string>(
-        parentSegments.map((s) => (typeof s === 'string' ? s : s.key))
-      );
+    // Update the set of selected segment keys
+    segmentsSet.current = new Set<string>(
+      parentSegments.map((s) => (typeof s === 'string' ? s : s.key))
+    );
 
-      // Update the previous length
-      prevParentSegmentsLength.current = parentSegments.length;
-    }
-  }, [parentSegments.length]); // Only depend on the length, not the whole array
+    // Update the previous length
+    prevParentSegmentsLength.current = parentSegments.length;
+  }, [parentSegments]); // Depend on the entire parentSegments array
 
   const handleSegmentRemove = (index: number) => {
     const filterableSegment = parentSegments[index];

--- a/ui/src/components/forms/SegmentsPicker.tsx
+++ b/ui/src/components/forms/SegmentsPicker.tsx
@@ -23,24 +23,47 @@ export default function SegmentsPicker({
   segmentReplace,
   segmentRemove
 }: SegmentPickerProps) {
+  // Track selected segment keys to avoid duplicates
   const segmentsSet = useRef<Set<string>>(
-    new Set<string>(parentSegments.map((s) => s.key))
+    new Set<string>(
+      parentSegments.map((s) => (typeof s === 'string' ? s : s.key))
+    )
   );
 
   const [editing, setEditing] = useState<boolean>(true);
 
+  // Store previous parent segments length to prevent unnecessary updates
+  const prevParentSegmentsLength = useRef(parentSegments.length);
+
+  // Update editing state when parent segments change
   useEffect(() => {
-    setEditing(true);
-  }, [parentSegments]);
+    // Only update if the length has changed to avoid infinite loops
+    if (prevParentSegmentsLength.current !== parentSegments.length) {
+      setEditing(true);
+
+      // Update the set of selected segment keys
+      segmentsSet.current = new Set<string>(
+        parentSegments.map((s) => (typeof s === 'string' ? s : s.key))
+      );
+
+      // Update the previous length
+      prevParentSegmentsLength.current = parentSegments.length;
+    }
+  }, [parentSegments.length]); // Only depend on the length, not the whole array
 
   const handleSegmentRemove = (index: number) => {
     const filterableSegment = parentSegments[index];
+    if (!filterableSegment) return;
 
     // Remove references to the segment that is being deleted.
-    segmentsSet.current!.delete(filterableSegment.key);
+    segmentsSet.current.delete(
+      typeof filterableSegment === 'string'
+        ? filterableSegment
+        : filterableSegment.key
+    );
     segmentRemove(index);
 
-    if (editing && parentSegments.length == 1) {
+    if (editing && parentSegments.length === 1) {
       setEditing(true);
     }
   };
@@ -54,12 +77,18 @@ export default function SegmentsPicker({
     }
 
     const selectedSegmentList = [...parentSegments];
-    const segmentSetCurrent = segmentsSet.current!;
+    const segmentSetCurrent = segmentsSet.current;
 
     if (index <= parentSegments.length - 1) {
       const previousSegment = selectedSegmentList[index];
-      if (segmentSetCurrent.has(previousSegment.key)) {
-        segmentSetCurrent.delete(previousSegment.key);
+      if (previousSegment) {
+        const prevKey =
+          typeof previousSegment === 'string'
+            ? previousSegment
+            : previousSegment.key;
+        if (segmentSetCurrent.has(prevKey)) {
+          segmentSetCurrent.delete(prevKey);
+        }
       }
 
       segmentSetCurrent.add(segment.key);
@@ -68,6 +97,17 @@ export default function SegmentsPicker({
       segmentSetCurrent.add(segment.key);
       segmentAdd(segment);
     }
+  };
+
+  // Create filtered segment options with proper display values
+  const getSegmentOptions = () => {
+    return segments
+      .filter((s) => !segmentsSet.current.has(s.key))
+      .map((s) => ({
+        ...s,
+        filterValue: truncateKey(s.key),
+        displayValue: s.name
+      }));
   };
 
   return (
@@ -79,13 +119,7 @@ export default function SegmentsPicker({
               id={`segmentKey-${index}`}
               name={`segmentKey-${index}`}
               placeholder="Select or search for a segment"
-              values={segments
-                .filter((s) => !segmentsSet.current!.has(s.key))
-                .map((s) => ({
-                  ...s,
-                  filterValue: truncateKey(s.key),
-                  displayValue: s.name
-                }))}
+              values={getSegmentOptions()}
               selected={selectedSegment}
               setSelected={(filterableSegment) => {
                 handleSegmentSelected(index, filterableSegment);
@@ -109,13 +143,7 @@ export default function SegmentsPicker({
               id={`segmentKey-${parentSegments.length}`}
               name={`segmentKey-${parentSegments.length}`}
               placeholder="Select or search for a segment"
-              values={segments
-                .filter((s) => !segmentsSet.current!.has(s.key))
-                .map((s) => ({
-                  ...s,
-                  filterValue: truncateKey(s.key),
-                  displayValue: s.name
-                }))}
+              values={getSegmentOptions()}
               selected={null}
               setSelected={(filterableSegment) => {
                 handleSegmentSelected(parentSegments.length, filterableSegment);

--- a/ui/src/components/rollouts/QuickEditRolloutForm.tsx
+++ b/ui/src/components/rollouts/QuickEditRolloutForm.tsx
@@ -8,7 +8,7 @@ import Select from '~/components/forms/Select';
 
 import { IFlag } from '~/types/Flag';
 import { IRollout, RolloutType } from '~/types/Rollout';
-import { FilterableSegment, ISegment, segmentOperators } from '~/types/Segment';
+import { ISegment, segmentOperators } from '~/types/Segment';
 
 import { createSegmentHandlers } from '~/utils/formik-helpers';
 

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -1,6 +1,6 @@
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import * as Dialog from '@radix-ui/react-dialog';
-import { FieldArray, Form, Formik, FormikProps } from 'formik';
+import { FieldArray, Form, Formik } from 'formik';
 import { useCallback, useState } from 'react';
 
 import { Button } from '~/components/Button';
@@ -19,7 +19,6 @@ import {
 } from '~/types/Segment';
 
 import { useError } from '~/data/hooks/error';
-import { createSegmentHandlers } from '~/utils/formik-helpers';
 
 const rolloutRuleTypes = [
   {
@@ -45,7 +44,7 @@ type RolloutFormProps = {
 interface RolloutFormValues {
   type: string;
   description?: string;
-  segments?: FilterableSegment[];
+  segments: FilterableSegment[];
   operator?: SegmentOperatorType;
   percentage?: number;
   value: string;
@@ -92,7 +91,7 @@ export default function RolloutForm(props: RolloutFormProps) {
   );
 
   return (
-    <Formik
+    <Formik<RolloutFormValues>
       enableReinitialize
       initialValues={{
         type: rolloutRuleType,
@@ -110,7 +109,8 @@ export default function RolloutForm(props: RolloutFormProps) {
             };
           }
         } else if (values.type === RolloutType.THRESHOLD) {
-          if (values.percentage < 0 || values.percentage > 100) {
+          const percentage = values.percentage ?? 0;
+          if (percentage < 0 || percentage > 100) {
             return {
               percentage: true
             };
@@ -140,32 +140,11 @@ export default function RolloutForm(props: RolloutFormProps) {
           });
       }}
     >
-      {(formik: FormikProps<RolloutFormValues>) => {
+      {(formik) => {
         // Helper function to handle segments with proper object representations
         const updateSegmentsValue = (segments: FilterableSegment[]) => {
           formik.setFieldValue('segments', segments);
         };
-
-        // Create segment handlers using our shared utility
-        const mockRollout = {
-          rank,
-          segments: formik.values.segments?.map((s) => s.key) || []
-        };
-        const { handleSegmentAdd, handleSegmentRemove, handleSegmentReplace } =
-          createSegmentHandlers(
-            formik as any,
-            mockRollout,
-            'segments',
-            (_, segments) =>
-              segments.map((key) => {
-                const segment = segments.find((s) => s === key);
-                if (!segment) {
-                  const realSegment = segments.find((s) => s.key === key);
-                  return realSegment;
-                }
-                return segment;
-              })
-          );
 
         // Custom segment handlers that work with the FormValues type
         const addSegment = (segment: FilterableSegment) => {

--- a/ui/src/components/rollouts/RolloutForm.tsx
+++ b/ui/src/components/rollouts/RolloutForm.tsx
@@ -1,7 +1,7 @@
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import * as Dialog from '@radix-ui/react-dialog';
-import { FieldArray, Form, Formik } from 'formik';
-import { useState } from 'react';
+import { FieldArray, Form, Formik, FormikProps } from 'formik';
+import { useCallback, useState } from 'react';
 
 import { Button } from '~/components/Button';
 import Loading from '~/components/Loading';
@@ -19,6 +19,7 @@ import {
 } from '~/types/Segment';
 
 import { useError } from '~/data/hooks/error';
+import { createSegmentHandlers } from '~/utils/formik-helpers';
 
 const rolloutRuleTypes = [
   {
@@ -57,32 +58,38 @@ export default function RolloutForm(props: RolloutFormProps) {
 
   const [rolloutRuleType, setRolloutRuleType] = useState(RolloutType.THRESHOLD);
 
-  const handleSegmentSubmit = (values: RolloutFormValues) => {
-    createRollout({
-      rank,
-      type: rolloutRuleType,
-      description: values.description,
-      segment: {
-        segments: values.segments?.map((s) => s.key),
-        segmentOperator: values.operator,
-        value: values.value === 'true'
-      }
-    });
-    return Promise.resolve();
-  };
+  const handleSegmentSubmit = useCallback(
+    (values: RolloutFormValues) => {
+      createRollout({
+        rank,
+        type: rolloutRuleType,
+        description: values.description,
+        segment: {
+          segments: values.segments?.map((s) => s.key) || [],
+          segmentOperator: values.operator,
+          value: values.value === 'true'
+        }
+      });
+      return Promise.resolve();
+    },
+    [createRollout, rank, rolloutRuleType]
+  );
 
-  const handleThresholdSubmit = (values: RolloutFormValues) => {
-    createRollout({
-      rank,
-      type: rolloutRuleType,
-      description: values.description,
-      threshold: {
-        percentage: values.percentage || 0,
-        value: values.value === 'true'
-      }
-    });
-    return Promise.resolve();
-  };
+  const handleThresholdSubmit = useCallback(
+    (values: RolloutFormValues) => {
+      createRollout({
+        rank,
+        type: rolloutRuleType,
+        description: values.description,
+        threshold: {
+          percentage: values.percentage || 0,
+          value: values.value === 'true'
+        }
+      });
+      return Promise.resolve();
+    },
+    [createRollout, rank, rolloutRuleType]
+  );
 
   return (
     <Formik
@@ -133,252 +140,294 @@ export default function RolloutForm(props: RolloutFormProps) {
           });
       }}
     >
-      {(formik) => (
-        <Form className="flex h-full flex-col overflow-y-scroll bg-background shadow-xl">
-          <div className="flex-1">
-            <div className="bg-gray-50 px-4 py-6 sm:px-6">
-              <div className="flex items-start justify-between space-x-3">
-                <div className="space-y-1">
-                  <Dialog.Title className="text-lg font-medium text-gray-900">
-                    New Rollout
-                  </Dialog.Title>
-                  <MoreInfo href="https://www.flipt.io/docs/concepts#rollouts">
-                    Learn more about rollouts
-                  </MoreInfo>
-                </div>
-                <div className="flex h-7 items-center">
-                  <button
-                    type="button"
-                    className="text-gray-400 hover:text-gray-500"
-                    onClick={() => setOpen(false)}
-                  >
-                    <span className="sr-only">Close panel</span>
-                    <XMarkIcon className="h-6 w-6" aria-hidden="true" />
-                  </button>
-                </div>
-              </div>
-            </div>
-            <div className="space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0">
-              <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
-                <div>
-                  <label
-                    htmlFor="type"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
-                  >
-                    Type
-                  </label>
-                </div>
-                <div className="sm:col-span-2">
-                  <fieldset>
-                    <legend className="sr-only">Type</legend>
-                    <div className="space-y-5">
-                      {rolloutRuleTypes.map((rolloutRule) => (
-                        <div
-                          key={rolloutRule.id}
-                          className="relative flex items-start"
-                        >
-                          <div className="flex h-5 items-center">
-                            <input
-                              id={rolloutRule.id}
-                              aria-describedby={`${rolloutRule.id}-description`}
-                              name="type"
-                              type="radio"
-                              className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
-                              onChange={() => {
-                                setRolloutRuleType(rolloutRule.id);
-                                formik.setFieldValue('type', rolloutRule.id);
-                              }}
-                              checked={rolloutRule.id === rolloutRuleType}
-                              value={rolloutRule.id}
-                            />
-                          </div>
-                          <div className="ml-3 text-sm">
-                            <label
-                              htmlFor={rolloutRule.id}
-                              className="font-medium text-gray-700"
-                            >
-                              {rolloutRule.name}
-                            </label>
-                            <p
-                              id={`${rolloutRule.id}-description`}
-                              className="text-gray-500"
-                            >
-                              {rolloutRule.description}
-                            </p>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-                  </fieldset>
-                </div>
-              </div>
-              {rolloutRuleType === RolloutType.THRESHOLD && (
-                <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
-                  <label
-                    htmlFor="percentage"
-                    className="mb-2 block text-sm font-medium text-gray-900"
-                  >
-                    Percentage
-                  </label>
-                  <Input
-                    id="percentage-slider"
-                    name="percentage"
-                    type="range"
-                    className="h-2 w-full cursor-pointer appearance-none self-center rounded-lg bg-gray-200 align-middle dark:bg-gray-700"
-                  />
-                  <div className="relative">
-                    <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-black">
-                      %
-                    </div>
-                    <Input
-                      type="number"
-                      id="percentage"
-                      max={100}
-                      min={0}
-                      name="percentage"
-                      className="text-center"
-                    />
+      {(formik: FormikProps<RolloutFormValues>) => {
+        // Helper function to handle segments with proper object representations
+        const updateSegmentsValue = (segments: FilterableSegment[]) => {
+          formik.setFieldValue('segments', segments);
+        };
+
+        // Create segment handlers using our shared utility
+        const mockRollout = {
+          rank,
+          segments: formik.values.segments?.map((s) => s.key) || []
+        };
+        const { handleSegmentAdd, handleSegmentRemove, handleSegmentReplace } =
+          createSegmentHandlers(
+            formik as any,
+            mockRollout,
+            'segments',
+            (_, segments) =>
+              segments.map((key) => {
+                const segment = segments.find((s) => s === key);
+                if (!segment) {
+                  const realSegment = segments.find((s) => s.key === key);
+                  return realSegment;
+                }
+                return segment;
+              })
+          );
+
+        // Custom segment handlers that work with the FormValues type
+        const addSegment = (segment: FilterableSegment) => {
+          const updatedSegments = [...(formik.values.segments || []), segment];
+          updateSegmentsValue(updatedSegments);
+        };
+
+        const removeSegment = (index: number) => {
+          const updatedSegments = [...(formik.values.segments || [])];
+          updatedSegments.splice(index, 1);
+          updateSegmentsValue(updatedSegments);
+        };
+
+        const replaceSegment = (index: number, segment: FilterableSegment) => {
+          const updatedSegments = [...(formik.values.segments || [])];
+          updatedSegments[index] = segment;
+          updateSegmentsValue(updatedSegments);
+        };
+
+        return (
+          <Form className="flex h-full flex-col overflow-y-scroll bg-background shadow-xl">
+            <div className="flex-1">
+              <div className="bg-gray-50 px-4 py-6 sm:px-6">
+                <div className="flex items-start justify-between space-x-3">
+                  <div className="space-y-1">
+                    <Dialog.Title className="text-lg font-medium text-gray-900">
+                      New Rollout
+                    </Dialog.Title>
+                    <MoreInfo href="https://www.flipt.io/docs/concepts#rollouts">
+                      Learn more about rollouts
+                    </MoreInfo>
+                  </div>
+                  <div className="flex h-7 items-center">
+                    <button
+                      type="button"
+                      className="text-gray-400 hover:text-gray-500"
+                      onClick={() => setOpen(false)}
+                    >
+                      <span className="sr-only">Close panel</span>
+                      <XMarkIcon className="h-6 w-6" aria-hidden="true" />
+                    </button>
                   </div>
                 </div>
-              )}
-              {rolloutRuleType === RolloutType.SEGMENT && (
+              </div>
+              <div className="space-y-6 py-6 sm:space-y-0 sm:divide-y sm:divide-gray-200 sm:py-0">
                 <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                   <div>
                     <label
-                      htmlFor="segmentKey"
+                      htmlFor="type"
                       className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
                     >
-                      Segment
+                      Type
                     </label>
                   </div>
                   <div className="sm:col-span-2">
-                    <FieldArray
-                      name="segments"
-                      render={(arrayHelpers) => (
-                        <SegmentsPicker
-                          segments={segments}
-                          segmentAdd={(segment: FilterableSegment) =>
-                            arrayHelpers.push(segment)
-                          }
-                          segmentRemove={(index: number) =>
-                            arrayHelpers.remove(index)
-                          }
-                          segmentReplace={(
-                            index: number,
-                            segment: FilterableSegment
-                          ) => arrayHelpers.replace(index, segment)}
-                          selectedSegments={formik.values.segments}
-                        />
-                      )}
-                    />
-                  </div>
-                  {formik.values.segments.length > 1 && (
-                    <>
-                      <div>
-                        <label
-                          htmlFor="operator"
-                          className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
-                        >
-                          Operator
-                        </label>
-                      </div>
-                      <div>
-                        <div className="sm:col-span-2">
-                          <div className="w-48 space-y-4">
-                            {segmentOperators.map((segmentOperator, index) => (
-                              <div className="flex space-x-4" key={index}>
-                                <div>
-                                  <input
-                                    id={segmentOperator.id}
-                                    name="operator"
-                                    type="radio"
-                                    className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
-                                    onChange={() => {
-                                      formik.setFieldValue(
-                                        'operator',
-                                        segmentOperator.id
-                                      );
-                                    }}
-                                    checked={
-                                      segmentOperator.id ===
-                                      formik.values.operator
-                                    }
-                                    value={segmentOperator.id}
-                                  />
-                                </div>
-                                <div className="mt-1">
-                                  <label
-                                    htmlFor={segmentOperator.id}
-                                    className="block text-sm text-gray-700"
-                                  >
-                                    {segmentOperator.name}{' '}
-                                    <span className="font-light">
-                                      {segmentOperator.meta}
-                                    </span>
-                                  </label>
-                                </div>
-                              </div>
-                            ))}
+                    <fieldset>
+                      <legend className="sr-only">Type</legend>
+                      <div className="space-y-5">
+                        {rolloutRuleTypes.map((rolloutRule) => (
+                          <div
+                            key={rolloutRule.id}
+                            className="relative flex items-start"
+                          >
+                            <div className="flex h-5 items-center">
+                              <input
+                                id={rolloutRule.id}
+                                aria-describedby={`${rolloutRule.id}-description`}
+                                name="type"
+                                type="radio"
+                                className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                                onChange={() => {
+                                  setRolloutRuleType(rolloutRule.id);
+                                  formik.setFieldValue('type', rolloutRule.id);
+                                }}
+                                checked={rolloutRule.id === rolloutRuleType}
+                                value={rolloutRule.id}
+                              />
+                            </div>
+                            <div className="ml-3 text-sm">
+                              <label
+                                htmlFor={rolloutRule.id}
+                                className="font-medium text-gray-700"
+                              >
+                                {rolloutRule.name}
+                              </label>
+                              <p
+                                id={`${rolloutRule.id}-description`}
+                                className="text-gray-500"
+                              >
+                                {rolloutRule.description}
+                              </p>
+                            </div>
                           </div>
-                        </div>
+                        ))}
                       </div>
-                    </>
-                  )}
+                    </fieldset>
+                  </div>
                 </div>
-              )}
-              <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
-                <label
-                  htmlFor="value"
-                  className="mb-2 block text-sm font-medium text-gray-900"
-                >
-                  Value
-                </label>
-                <Select
-                  id="value"
-                  name="value"
-                  options={[
-                    { label: 'True', value: 'true' },
-                    { label: 'False', value: 'false' }
-                  ]}
-                  className="w-full cursor-pointer appearance-none self-center rounded-lg align-middle"
-                />
-              </div>
-              <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
-                <div>
+                {rolloutRuleType === RolloutType.THRESHOLD && (
+                  <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+                    <label
+                      htmlFor="percentage"
+                      className="mb-2 block text-sm font-medium text-gray-900"
+                    >
+                      Percentage
+                    </label>
+                    <Input
+                      id="percentage-slider"
+                      name="percentage"
+                      type="range"
+                      className="h-2 w-full cursor-pointer appearance-none self-center rounded-lg bg-gray-200 align-middle dark:bg-gray-700"
+                    />
+                    <div className="relative">
+                      <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-black">
+                        %
+                      </div>
+                      <Input
+                        type="number"
+                        id="percentage"
+                        max={100}
+                        min={0}
+                        name="percentage"
+                        className="text-center"
+                      />
+                    </div>
+                  </div>
+                )}
+                {rolloutRuleType === RolloutType.SEGMENT && (
+                  <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+                    <div>
+                      <label
+                        htmlFor="segmentKey"
+                        className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                      >
+                        Segment
+                      </label>
+                    </div>
+                    <div className="sm:col-span-2">
+                      <FieldArray
+                        name="segments"
+                        render={() => (
+                          <SegmentsPicker
+                            segments={segments}
+                            segmentAdd={addSegment}
+                            segmentRemove={removeSegment}
+                            segmentReplace={replaceSegment}
+                            selectedSegments={formik.values.segments || []}
+                          />
+                        )}
+                      />
+                    </div>
+                    {formik.values.segments &&
+                      formik.values.segments.length > 1 && (
+                        <>
+                          <div>
+                            <label
+                              htmlFor="operator"
+                              className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                            >
+                              Operator
+                            </label>
+                          </div>
+                          <div>
+                            <div className="sm:col-span-2">
+                              <div className="w-48 space-y-4">
+                                {segmentOperators.map(
+                                  (segmentOperator, index) => (
+                                    <div className="flex space-x-4" key={index}>
+                                      <div>
+                                        <input
+                                          id={segmentOperator.id}
+                                          name="operator"
+                                          type="radio"
+                                          className="h-4 w-4 border-gray-300 text-violet-400 focus:ring-violet-400"
+                                          onChange={() => {
+                                            formik.setFieldValue(
+                                              'operator',
+                                              segmentOperator.id
+                                            );
+                                          }}
+                                          checked={
+                                            segmentOperator.id ===
+                                            formik.values.operator
+                                          }
+                                          value={segmentOperator.id}
+                                        />
+                                      </div>
+                                      <div className="mt-1">
+                                        <label
+                                          htmlFor={segmentOperator.id}
+                                          className="block text-sm text-gray-700"
+                                        >
+                                          {segmentOperator.name}{' '}
+                                          <span className="font-light">
+                                            {segmentOperator.meta}
+                                          </span>
+                                        </label>
+                                      </div>
+                                    </div>
+                                  )
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        </>
+                      )}
+                  </div>
+                )}
+                <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
                   <label
-                    htmlFor="description"
-                    className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    htmlFor="value"
+                    className="mb-2 block text-sm font-medium text-gray-900"
                   >
-                    Description
+                    Value
                   </label>
-                  <span
-                    className="text-xs text-gray-400"
-                    id="description-optional"
-                  >
-                    Optional
-                  </span>
+                  <Select
+                    id="value"
+                    name="value"
+                    options={[
+                      { label: 'True', value: 'true' },
+                      { label: 'False', value: 'false' }
+                    ]}
+                    className="w-full cursor-pointer appearance-none self-center rounded-lg align-middle"
+                  />
                 </div>
-                <div className="sm:col-span-2">
-                  <Input name="description" id="description" />
+                <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
+                  <div>
+                    <label
+                      htmlFor="description"
+                      className="block text-sm font-medium text-gray-900 sm:mt-px sm:pt-2"
+                    >
+                      Description
+                    </label>
+                    <span
+                      className="text-xs text-gray-400"
+                      id="description-optional"
+                    >
+                      Optional
+                    </span>
+                  </div>
+                  <div className="sm:col-span-2">
+                    <Input name="description" id="description" />
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div className="shrink-0 border-t border-gray-200 px-4 py-5 sm:px-6">
-            <div className="flex justify-end space-x-3">
-              <Button onClick={() => setOpen(false)}>Cancel</Button>
-              <Button
-                variant="primary"
-                type="submit"
-                className="min-w-[80px]"
-                disabled={!formik.isValid || formik.isSubmitting}
-              >
-                {formik.isSubmitting ? <Loading isPrimary /> : 'Add'}
-              </Button>
+            <div className="shrink-0 border-t border-gray-200 px-4 py-5 sm:px-6">
+              <div className="flex justify-end space-x-3">
+                <Button onClick={() => setOpen(false)}>Cancel</Button>
+                <Button
+                  variant="primary"
+                  type="submit"
+                  className="min-w-[80px]"
+                  disabled={!formik.isValid || formik.isSubmitting}
+                >
+                  {formik.isSubmitting ? <Loading isPrimary /> : 'Add'}
+                </Button>
+              </div>
             </div>
-          </div>
-        </Form>
-      )}
+          </Form>
+        );
+      }}
     </Formik>
   );
 }

--- a/ui/src/components/rules/MultiDistributionForm.tsx
+++ b/ui/src/components/rules/MultiDistributionForm.tsx
@@ -1,8 +1,8 @@
 import { IDistribution } from '~/types/Distribution';
 
 type MultiDistributionFormInputProps = {
-  distributions?: IDistribution[] | null;
-  setDistributions: (distributions: IDistribution[] | null) => void;
+  distributions: IDistribution[];
+  setDistributions: (distributions: IDistribution[]) => void;
 };
 
 export default function MultiDistributionFormInputs(
@@ -22,7 +22,7 @@ export default function MultiDistributionFormInputs(
           </label>
         </div>
       </div>
-      {distributions?.map((dist: IDistribution, index: number) => (
+      {distributions.map((dist: IDistribution, index: number) => (
         <div
           className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-1"
           key={dist.variant}

--- a/ui/src/components/rules/QuickEditRuleForm.tsx
+++ b/ui/src/components/rules/QuickEditRuleForm.tsx
@@ -7,7 +7,7 @@ import { DistributionType } from '~/types/Distribution';
 import { IDistribution } from '~/types/Distribution';
 import { IFlag } from '~/types/Flag';
 import { IRule } from '~/types/Rule';
-import { FilterableSegment, ISegment, segmentOperators } from '~/types/Segment';
+import { ISegment, segmentOperators } from '~/types/Segment';
 import { FilterableVariant } from '~/types/Variant';
 
 import { createSegmentHandlers } from '~/utils/formik-helpers';

--- a/ui/src/components/rules/QuickEditRuleForm.tsx
+++ b/ui/src/components/rules/QuickEditRuleForm.tsx
@@ -1,6 +1,7 @@
 import { Field, FieldArray, useFormikContext } from 'formik';
 import { useCallback, useMemo, useState } from 'react';
 
+import { TextButton } from '~/components/Button';
 import SegmentsPicker from '~/components/forms/SegmentsPicker';
 
 import { DistributionType } from '~/types/Distribution';
@@ -294,6 +295,16 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
               )}
             </div>
           )}
+        </div>
+      </div>
+      <div className="shrink-0 py-1">
+        <div className="flex justify-end space-x-3">
+          <TextButton
+            disabled={formik.isSubmitting || !formik.dirty}
+            onClick={() => formik.resetForm()}
+          >
+            Reset
+          </TextButton>
         </div>
       </div>
     </div>

--- a/ui/src/components/rules/QuickEditRuleForm.tsx
+++ b/ui/src/components/rules/QuickEditRuleForm.tsx
@@ -1,5 +1,5 @@
 import { Field, FieldArray, useFormikContext } from 'formik';
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import SegmentsPicker from '~/components/forms/SegmentsPicker';
 
@@ -10,6 +10,7 @@ import { IRule } from '~/types/Rule';
 import { FilterableSegment, ISegment, segmentOperators } from '~/types/Segment';
 import { FilterableVariant } from '~/types/Variant';
 
+import { createSegmentHandlers } from '~/utils/formik-helpers';
 import { cls } from '~/utils/helpers';
 
 import { distTypes } from './RuleForm';
@@ -33,22 +34,29 @@ export const validRollout = (rollouts: IDistribution[]): boolean => {
 export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
   const { flag, rule, segments } = props;
 
-  const ruleType =
-    rule.distributions.length === 0
+  // Ensure rule.distributions is always treated as an array
+  const distributions = useMemo(
+    () => rule.distributions || [],
+    [rule.distributions]
+  );
+
+  const ruleType = useMemo(() => {
+    return distributions.length === 0
       ? DistributionType.None
-      : rule.distributions.length === 1
+      : distributions.length === 1
         ? DistributionType.Single
         : DistributionType.Multi;
+  }, [distributions.length]);
 
   const [selectedVariant, setSelectedVariant] =
     useState<FilterableVariant | null>(() => {
       if (ruleType !== DistributionType.Single) return null;
 
-      if (rule.distributions.length !== 1) {
+      if (distributions.length !== 1) {
         return null;
       }
       let selected = flag.variants?.find(
-        (v) => v.key === rule.distributions[0].variant
+        (v) => v.key === distributions[0].variant
       );
       if (selected) {
         return {
@@ -60,23 +68,45 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
       return null;
     });
 
-  const ruleSegmentKeys = rule.segments || [];
+  const ruleSegmentKeys = useMemo(() => rule.segments || [], [rule.segments]);
 
-  const ruleSegments = ruleSegmentKeys.map((s) => {
-    const segment = segments.find((seg) => seg.key === s);
-    if (!segment) {
-      throw new Error(`Segment ${s} not found in segments`);
-    }
-    return {
-      ...segment,
-      displayValue: segment.name,
-      filterValue: segment.key
-    };
-  });
+  const ruleSegments = useMemo(() => {
+    return ruleSegmentKeys.map((s) => {
+      const segment = segments.find((seg) => seg.key === s);
+      if (!segment) {
+        throw new Error(`Segment ${s} not found in segments`);
+      }
+      return {
+        ...segment,
+        displayValue: segment.name,
+        filterValue: segment.key
+      };
+    });
+  }, [ruleSegmentKeys, segments]);
 
   const fieldPrefix = `rules.[${rule.rank}].`;
 
   const formik = useFormikContext<IFlag>();
+
+  // Initialize the rule with distributions if it doesn't have any
+  const initializeDistributions = useCallback(() => {
+    if (!rule.distributions) {
+      formik.setFieldValue(`${fieldPrefix}distributions`, []);
+    }
+  }, [formik, fieldPrefix, rule.distributions]);
+
+  // Use the shared segment handlers with the rule-specific update function
+  const { handleSegmentAdd, handleSegmentRemove, handleSegmentReplace } =
+    createSegmentHandlers<IRule, IFlag>(
+      formik,
+      rule,
+      'rules',
+      (original, segments) => ({
+        ...original,
+        segments
+      }),
+      initializeDistributions
+    );
 
   return (
     <div className="flex h-full w-full flex-col">
@@ -95,19 +125,12 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
               <div>
                 <FieldArray
                   name={fieldPrefix + 'segments'}
-                  render={(arrayHelpers) => (
+                  render={() => (
                     <SegmentsPicker
                       segments={segments}
-                      segmentAdd={(segment: FilterableSegment) =>
-                        arrayHelpers.push(segment)
-                      }
-                      segmentRemove={(index: number) =>
-                        arrayHelpers.remove(index)
-                      }
-                      segmentReplace={(
-                        index: number,
-                        segment: FilterableSegment
-                      ) => arrayHelpers.replace(index, segment)}
+                      segmentAdd={handleSegmentAdd}
+                      segmentRemove={handleSegmentRemove}
+                      segmentReplace={handleSegmentReplace}
                       selectedSegments={ruleSegments}
                     />
                   )}
@@ -222,9 +245,8 @@ export default function QuickEditRuleForm(props: QuickEditRuleFormProps) {
                 name="rollouts"
                 render={() => (
                   <>
-                    {rule.distributions &&
-                      rule.distributions.length > 0 &&
-                      rule.distributions?.map((dist, index) => (
+                    {distributions.length > 0 &&
+                      distributions.map((dist, index) => (
                         <div key={index}>
                           {dist && (
                             <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-1">

--- a/ui/src/components/rules/RuleForm.tsx
+++ b/ui/src/components/rules/RuleForm.tsx
@@ -1,7 +1,7 @@
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import * as Dialog from '@radix-ui/react-dialog';
 import { FieldArray, Form, Formik } from 'formik';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { v4 as uuid } from 'uuid';
 import * as Yup from 'yup';

--- a/ui/src/utils/formik-helpers.ts
+++ b/ui/src/utils/formik-helpers.ts
@@ -1,0 +1,139 @@
+import { FormikContextType } from 'formik';
+
+import { FilterableSegment } from '~/types/Segment';
+
+interface WithIdAndSegments {
+  id?: string;
+  segments?: string[];
+  rank: number;
+}
+
+// Define a type for the shape of formik values used in collections
+interface FormikValuesWithCollection<T> {
+  [key: string]: T[] | any;
+}
+
+/**
+ * Updates a collection item by ID or rank with new segment information.
+ * This helps manage segment operations consistently across different components.
+ *
+ * @param formik The Formik context to use for updates
+ * @param item The current item (rule/rollout) being updated
+ * @param currentSegments The array of segment keys to set
+ * @param collectionName The name of the collection in formik values (e.g. 'rules', 'rollouts')
+ * @param getUpdatedItem A function that returns the updated item with the new segments
+ */
+export function updateItemSegments<
+  T extends WithIdAndSegments,
+  V extends FormikValuesWithCollection<T>
+>(
+  formik: FormikContextType<V>,
+  item: T,
+  currentSegments: string[],
+  collectionName: string,
+  getUpdatedItem: (original: T, segments: string[]) => T
+): void {
+  // Use the correct item path to ensure we're updating the existing item
+  const fieldPrefix = `${collectionName}.[${item.rank}].`;
+
+  if (item.id) {
+    // First check if the item already exists in the formik values
+    const collection = (formik.values[collectionName] || []) as T[];
+    const itemIndex = collection.findIndex((r: T) => r.id === item.id);
+
+    if (itemIndex >= 0) {
+      // Update the existing item
+      const updatedCollection = [...collection];
+      updatedCollection[itemIndex] = getUpdatedItem(
+        updatedCollection[itemIndex],
+        currentSegments
+      );
+
+      // Update all items at once to prevent duplicates
+      formik.setFieldValue(collectionName, updatedCollection);
+    } else {
+      // Fallback to updating by rank if ID is not found
+      formik.setFieldValue(`${fieldPrefix}segments`, currentSegments);
+    }
+  } else {
+    // Fallback to the original method if no ID
+    formik.setFieldValue(`${fieldPrefix}segments`, currentSegments);
+  }
+}
+
+/**
+ * Creates handlers for segment operations (add, remove, replace) to be used with SegmentsPicker
+ *
+ * @param formik The Formik context
+ * @param item The current item (rule/rollout) with segments
+ * @param collectionName The name of the collection in formik values (e.g. 'rules', 'rollouts')
+ * @param getUpdatedItem Function to create an updated item with new segments
+ * @param initFn Optional initialization function to call before adding segments
+ */
+export function createSegmentHandlers<
+  T extends WithIdAndSegments,
+  V extends FormikValuesWithCollection<T>
+>(
+  formik: FormikContextType<V>,
+  item: T,
+  collectionName: string,
+  getUpdatedItem: (original: T, segments: string[]) => T,
+  initFn?: () => void
+) {
+  const handleSegmentAdd = (segment: FilterableSegment) => {
+    // Run the initialization function if provided
+    if (initFn) initFn();
+
+    // Get the current segments array
+    const currentSegments = [...(item.segments || [])];
+
+    // Add the new segment key to the array
+    currentSegments.push(segment.key);
+
+    updateItemSegments(
+      formik,
+      item,
+      currentSegments,
+      collectionName,
+      getUpdatedItem
+    );
+  };
+
+  const handleSegmentRemove = (index: number) => {
+    // Get the current segments array
+    const currentSegments = [...(item.segments || [])];
+
+    // Remove the segment at the specified index
+    currentSegments.splice(index, 1);
+
+    updateItemSegments(
+      formik,
+      item,
+      currentSegments,
+      collectionName,
+      getUpdatedItem
+    );
+  };
+
+  const handleSegmentReplace = (index: number, segment: FilterableSegment) => {
+    // Get the current segments array
+    const currentSegments = [...(item.segments || [])];
+
+    // Replace the segment at the specified index with the new segment key
+    currentSegments[index] = segment.key;
+
+    updateItemSegments(
+      formik,
+      item,
+      currentSegments,
+      collectionName,
+      getUpdatedItem
+    );
+  };
+
+  return {
+    handleSegmentAdd,
+    handleSegmentRemove,
+    handleSegmentReplace
+  };
+}


### PR DESCRIPTION
fixes: #4143

This PR fixes a bug in the Flipt UI where adding segments to rules caused errors. The issue primarily manifested as "[object Object] not found in segments" when adding a new segment to an existing rule/rollout.

## Key Fixes

### 1. Created a shared utility library (`formik-helpers.ts`)
- Centralize segment management logic
- Handle proper object representation in forms
- Prevent duplicate rules/rollouts during updates
- Ensure proper array initialization

### 2. Updated `QuickEditRuleForm.tsx`
- Always initialize distributions as an array (never null)
- Use `rule.id` to find and update the correct rule in Formik state
- Optimize with `useMemo` and `useCallback` hooks
- Update entire rules collection to prevent duplicates

### 3. Updated `QuickEditRolloutForm.tsx`
- Follow the same pattern as QuickEditRuleForm
- Fix type safety issues with segment value property
- Optimize performance with React hooks
- Ensure boolean values are always properly set

### 4. Updated `RolloutForm.tsx`
- Use optimized segment handlers
- Add null checking for segment collections
- Properly handle segment objects vs. string keys

## Technical Details

- Added proper TypeScript typing to prevent "object representation" errors
- Used `findIndex` with item IDs to correctly locate and update items
- Reduced performance issues by eliminating unnecessary re-renders
- Fixed the "NaN" rank bug by updating collections consistently

This approach not only fixes the immediate bugs but also improves code quality by reducing duplication and centralizing the logic for handling segments in Formik forms.
