### PR TITLE
V2 fix analytics

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -202,10 +202,10 @@ func NewHTTPServer(
 
 		r.Mount("/api/v1", api)
 		r.Mount("/evaluate/v1", evaluateAPI)
-		r.Mount("/internal/v1/analytics", analyticsAPI)
 		r.Mount("/internal/v1", evaluateDataAPI)
 		r.Mount("/ofrep", ofrepAPI)
 
+		r.Mount("/internal/v2/analytics", analyticsAPI)
 		r.Mount("/api/v2/environments", v2Environments)
 
 		// mount all authentication related HTTP components

--- a/internal/server/analytics/clickhouse/mutation.go
+++ b/internal/server/analytics/clickhouse/mutation.go
@@ -19,7 +19,7 @@ func (c *Client) IncrementFlagEvaluationCounts(ctx context.Context, responses []
 	valueArgs := make([]interface{}, 0, len(responses)*10)
 
 	for _, response := range responses {
-		valuePlaceHolders = append(valuePlaceHolders, "(toDateTime(?, 'UTC'),?,?,?,?,?,?,?,?,?)")
+		valuePlaceHolders = append(valuePlaceHolders, "(toDateTime(?, 'UTC'),?,?,?,?,?,?,?,?,?,?)")
 		valueArgs = append(valueArgs, response.Timestamp.Format(time.DateTime))
 		valueArgs = append(valueArgs, counterAnalyticsName)
 		valueArgs = append(valueArgs, response.EnvironmentKey)

--- a/internal/server/metrics/metrics.go
+++ b/internal/server/metrics/metrics.go
@@ -55,12 +55,12 @@ var (
 
 	// Attributes used in evaluation metrics
 	//nolint
-	AttributeMatch       = attribute.Key("flipt.match")
-	AttributeFlag        = attribute.Key("flipt.flag")
-	AttributeFlagType    = attribute.Key("flipt.flag_type")
-	AttributeSegments    = attribute.Key("flipt.segments")
-	AttributeReason      = attribute.Key("flipt.reason")
-	AttributeValue       = attribute.Key("flipt.value")
-	AttributeNamespace   = attribute.Key("flipt.namespace")
-	AttributeEnvironment = attribute.Key("flipt.environment")
+	AttributeMatch       = attribute.Key("flipt_match")
+	AttributeFlag        = attribute.Key("flipt_flag")
+	AttributeFlagType    = attribute.Key("flipt_flag_type")
+	AttributeSegments    = attribute.Key("flipt_segments")
+	AttributeReason      = attribute.Key("flipt_reason")
+	AttributeValue       = attribute.Key("flipt_value")
+	AttributeNamespace   = attribute.Key("flipt_namespace")
+	AttributeEnvironment = attribute.Key("flipt_environment")
 )

--- a/internal/server/tracing/attributes.go
+++ b/internal/server/tracing/attributes.go
@@ -7,16 +7,16 @@ import (
 
 // TODO: merge with metrics?
 var (
-	AttributeMatch       = attribute.Key("flipt.match")
-	AttributeFlag        = attribute.Key("flipt.flag")
-	AttributeEnvironment = attribute.Key("flipt.environment")
-	AttributeNamespace   = attribute.Key("flipt.namespace")
-	AttributeFlagEnabled = attribute.Key("flipt.flag_enabled")
-	AttributeSegments    = attribute.Key("flipt.segments")
-	AttributeReason      = attribute.Key("flipt.reason")
-	AttributeValue       = attribute.Key("flipt.value")
-	AttributeEntityID    = attribute.Key("flipt.entity_id")
-	AttributeRequestID   = attribute.Key("flipt.request_id")
+	AttributeMatch       = attribute.Key("flipt_match")
+	AttributeFlag        = attribute.Key("flipt_flag")
+	AttributeEnvironment = attribute.Key("flipt_environment")
+	AttributeNamespace   = attribute.Key("flipt_namespace")
+	AttributeFlagEnabled = attribute.Key("flipt_flag_enabled")
+	AttributeSegments    = attribute.Key("flipt_segments")
+	AttributeReason      = attribute.Key("flipt_reason")
+	AttributeValue       = attribute.Key("flipt_value")
+	AttributeEntityID    = attribute.Key("flipt_entity_id")
+	AttributeRequestID   = attribute.Key("flipt_request_id")
 )
 
 // Specific attributes for Semantic Conventions for Feature Flags in Spans

--- a/rpc/flipt/analytics/analytics.pb.go
+++ b/rpc/flipt/analytics/analytics.pb.go
@@ -7,6 +7,8 @@
 package analytics
 
 import (
+	_ "github.com/google/gnostic/openapiv3"
+	_ "google.golang.org/genproto/googleapis/api/annotations"
 	_ "google.golang.org/genproto/googleapis/api/visibility"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -24,11 +26,11 @@ const (
 
 type GetFlagEvaluationsCountRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
-	NamespaceKey   string                 `protobuf:"bytes,1,opt,name=namespace_key,json=namespaceKey,proto3" json:"namespace_key,omitempty"`
-	FlagKey        string                 `protobuf:"bytes,2,opt,name=flag_key,json=flagKey,proto3" json:"flag_key,omitempty"`
-	From           string                 `protobuf:"bytes,3,opt,name=from,proto3" json:"from,omitempty"`
-	To             string                 `protobuf:"bytes,4,opt,name=to,proto3" json:"to,omitempty"`
-	EnvironmentKey string                 `protobuf:"bytes,5,opt,name=environment_key,json=environmentKey,proto3" json:"environment_key,omitempty"`
+	EnvironmentKey string                 `protobuf:"bytes,1,opt,name=environment_key,json=environmentKey,proto3" json:"environment_key,omitempty"`
+	NamespaceKey   string                 `protobuf:"bytes,2,opt,name=namespace_key,json=namespaceKey,proto3" json:"namespace_key,omitempty"`
+	FlagKey        string                 `protobuf:"bytes,3,opt,name=flag_key,json=flagKey,proto3" json:"flag_key,omitempty"`
+	From           string                 `protobuf:"bytes,4,opt,name=from,proto3" json:"from,omitempty"`
+	To             string                 `protobuf:"bytes,5,opt,name=to,proto3" json:"to,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -63,6 +65,13 @@ func (*GetFlagEvaluationsCountRequest) Descriptor() ([]byte, []int) {
 	return file_analytics_analytics_proto_rawDescGZIP(), []int{0}
 }
 
+func (x *GetFlagEvaluationsCountRequest) GetEnvironmentKey() string {
+	if x != nil {
+		return x.EnvironmentKey
+	}
+	return ""
+}
+
 func (x *GetFlagEvaluationsCountRequest) GetNamespaceKey() string {
 	if x != nil {
 		return x.NamespaceKey
@@ -87,13 +96,6 @@ func (x *GetFlagEvaluationsCountRequest) GetFrom() string {
 func (x *GetFlagEvaluationsCountRequest) GetTo() string {
 	if x != nil {
 		return x.To
-	}
-	return ""
-}
-
-func (x *GetFlagEvaluationsCountRequest) GetEnvironmentKey() string {
-	if x != nil {
-		return x.EnvironmentKey
 	}
 	return ""
 }
@@ -154,20 +156,20 @@ var File_analytics_analytics_proto protoreflect.FileDescriptor
 
 const file_analytics_analytics_proto_rawDesc = "" +
 	"\n" +
-	"\x19analytics/analytics.proto\x12\x0fflipt.analytics\x1a\x1bgoogle/api/visibility.proto\"\xad\x01\n" +
-	"\x1eGetFlagEvaluationsCountRequest\x12#\n" +
-	"\rnamespace_key\x18\x01 \x01(\tR\fnamespaceKey\x12\x19\n" +
-	"\bflag_key\x18\x02 \x01(\tR\aflagKey\x12\x12\n" +
-	"\x04from\x18\x03 \x01(\tR\x04from\x12\x0e\n" +
-	"\x02to\x18\x04 \x01(\tR\x02to\x12'\n" +
-	"\x0fenvironment_key\x18\x05 \x01(\tR\x0eenvironmentKey\"Y\n" +
+	"\x19analytics/analytics.proto\x12\x0fflipt.analytics\x1a$gnostic/openapi/v3/annotations.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1bgoogle/api/visibility.proto\"\xad\x01\n" +
+	"\x1eGetFlagEvaluationsCountRequest\x12'\n" +
+	"\x0fenvironment_key\x18\x01 \x01(\tR\x0eenvironmentKey\x12#\n" +
+	"\rnamespace_key\x18\x02 \x01(\tR\fnamespaceKey\x12\x19\n" +
+	"\bflag_key\x18\x03 \x01(\tR\aflagKey\x12\x12\n" +
+	"\x04from\x18\x04 \x01(\tR\x04from\x12\x0e\n" +
+	"\x02to\x18\x05 \x01(\tR\x02to\"Y\n" +
 	"\x1fGetFlagEvaluationsCountResponse\x12\x1e\n" +
 	"\n" +
 	"timestamps\x18\x01 \x03(\tR\n" +
 	"timestamps\x12\x16\n" +
-	"\x06values\x18\x02 \x03(\x02R\x06values2\xac\x01\n" +
-	"\x10AnalyticsService\x12~\n" +
-	"\x17GetFlagEvaluationsCount\x12/.flipt.analytics.GetFlagEvaluationsCountRequest\x1a0.flipt.analytics.GetFlagEvaluationsCountResponse\"\x00\x1a\x18\xfa\xd2\xe4\x93\x02\x12\x12\x10flipt:sdk:ignoreB'Z%go.flipt.io/flipt/rpc/flipt/analyticsb\x06proto3"
+	"\x06values\x18\x02 \x03(\x02R\x06values2\xb3\x02\n" +
+	"\x10AnalyticsService\x12\x84\x02\n" +
+	"\x17GetFlagEvaluationsCount\x12/.flipt.analytics.GetFlagEvaluationsCountRequest\x1a0.flipt.analytics.GetFlagEvaluationsCountResponse\"\x85\x01\xbaG\x19*\x17getFlagEvaluationsCount\x82\xd3\xe4\x93\x02c\x12a/internal/v2/analytics/environments/{environment_key}/namespaces/{namespace_key}/flags/{flag_key}\x1a\x18\xfa\xd2\xe4\x93\x02\x12\x12\x10flipt:sdk:ignoreB'Z%go.flipt.io/flipt/rpc/flipt/analyticsb\x06proto3"
 
 var (
 	file_analytics_analytics_proto_rawDescOnce sync.Once

--- a/rpc/flipt/analytics/analytics.pb.gw.go
+++ b/rpc/flipt/analytics/analytics.pb.gw.go
@@ -35,7 +35,7 @@ var (
 	_ = metadata.Join
 )
 
-var filter_AnalyticsService_GetFlagEvaluationsCount_0 = &utilities.DoubleArray{Encoding: map[string]int{"namespace_key": 0, "flag_key": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+var filter_AnalyticsService_GetFlagEvaluationsCount_0 = &utilities.DoubleArray{Encoding: map[string]int{"environment_key": 0, "namespace_key": 1, "flag_key": 2}, Base: []int{1, 1, 2, 3, 0, 0, 0}, Check: []int{0, 1, 1, 1, 2, 3, 4}}
 
 func request_AnalyticsService_GetFlagEvaluationsCount_0(ctx context.Context, marshaler runtime.Marshaler, client AnalyticsServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
@@ -44,7 +44,15 @@ func request_AnalyticsService_GetFlagEvaluationsCount_0(ctx context.Context, mar
 		err      error
 	)
 	io.Copy(io.Discard, req.Body)
-	val, ok := pathParams["namespace_key"]
+	val, ok := pathParams["environment_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "environment_key")
+	}
+	protoReq.EnvironmentKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "environment_key", err)
+	}
+	val, ok = pathParams["namespace_key"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace_key")
 	}
@@ -76,7 +84,15 @@ func local_request_AnalyticsService_GetFlagEvaluationsCount_0(ctx context.Contex
 		metadata runtime.ServerMetadata
 		err      error
 	)
-	val, ok := pathParams["namespace_key"]
+	val, ok := pathParams["environment_key"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "environment_key")
+	}
+	protoReq.EnvironmentKey, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "environment_key", err)
+	}
+	val, ok = pathParams["namespace_key"]
 	if !ok {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace_key")
 	}
@@ -114,7 +130,7 @@ func RegisterAnalyticsServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.analytics.AnalyticsService/GetFlagEvaluationsCount", runtime.WithHTTPPathPattern("/internal/v1/analytics/namespaces/{namespace_key}/flags/{flag_key}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/flipt.analytics.AnalyticsService/GetFlagEvaluationsCount", runtime.WithHTTPPathPattern("/internal/v2/analytics/environments/{environment_key}/namespaces/{namespace_key}/flags/{flag_key}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -172,7 +188,7 @@ func RegisterAnalyticsServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/flipt.analytics.AnalyticsService/GetFlagEvaluationsCount", runtime.WithHTTPPathPattern("/internal/v1/analytics/namespaces/{namespace_key}/flags/{flag_key}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/flipt.analytics.AnalyticsService/GetFlagEvaluationsCount", runtime.WithHTTPPathPattern("/internal/v2/analytics/environments/{environment_key}/namespaces/{namespace_key}/flags/{flag_key}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -189,7 +205,7 @@ func RegisterAnalyticsServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 }
 
 var (
-	pattern_AnalyticsService_GetFlagEvaluationsCount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5, 1, 0, 4, 1, 5, 6}, []string{"internal", "v1", "analytics", "namespaces", "namespace_key", "flags", "flag_key"}, ""))
+	pattern_AnalyticsService_GetFlagEvaluationsCount_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4, 2, 5, 1, 0, 4, 1, 5, 6, 2, 7, 1, 0, 4, 1, 5, 8}, []string{"internal", "v2", "analytics", "environments", "environment_key", "namespaces", "namespace_key", "flags", "flag_key"}, ""))
 )
 
 var (

--- a/rpc/flipt/analytics/analytics.proto
+++ b/rpc/flipt/analytics/analytics.proto
@@ -2,16 +2,18 @@ syntax = "proto3";
 
 package flipt.analytics;
 
+import "gnostic/openapi/v3/annotations.proto";
+import "google/api/annotations.proto";
 import "google/api/visibility.proto";
 
 option go_package = "go.flipt.io/flipt/rpc/flipt/analytics";
 
 message GetFlagEvaluationsCountRequest {
-  string namespace_key = 1;
-  string flag_key = 2;
-  string from = 3;
-  string to = 4;
-  string environment_key = 5;
+  string environment_key = 1;
+  string namespace_key = 2;
+  string flag_key = 3;
+  string from = 4;
+  string to = 5;
 }
 
 message GetFlagEvaluationsCountResponse {
@@ -22,5 +24,8 @@ message GetFlagEvaluationsCountResponse {
 service AnalyticsService {
   option (google.api.api_visibility) = {restriction: "flipt:sdk:ignore"};
 
-  rpc GetFlagEvaluationsCount(GetFlagEvaluationsCountRequest) returns (GetFlagEvaluationsCountResponse) {}
+  rpc GetFlagEvaluationsCount(GetFlagEvaluationsCountRequest) returns (GetFlagEvaluationsCountResponse) {
+    option (google.api.http) = {get: "/internal/v2/analytics/environments/{environment_key}/namespaces/{namespace_key}/flags/{flag_key}"};
+    option (gnostic.openapi.v3.operation) = {operation_id: "getFlagEvaluationsCount"};
+  }
 }

--- a/rpc/flipt/flipt.yaml
+++ b/rpc/flipt/flipt.yaml
@@ -32,9 +32,3 @@ http:
   # evaluation methods
   - selector: flipt.evaluation.DataService.EvaluationSnapshotNamespace
     get: /internal/v1/evaluation/snapshot/namespace/{key}
-
-  # analytics methods
-  #
-  # method: evaluation count
-  - selector: flipt.analytics.AnalyticsService.GetFlagEvaluationsCount
-    get: /internal/v1/analytics/namespaces/{namespace_key}/flags/{flag_key}

--- a/rpc/flipt/openapi.yaml
+++ b/rpc/flipt/openapi.yaml
@@ -262,6 +262,42 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/VariantEvaluationResponse'
+    /internal/v2/analytics/environments/{environmentKey}/namespaces/{namespaceKey}/flags/{flagKey}:
+        get:
+            tags:
+                - AnalyticsService
+            operationId: getFlagEvaluationsCount
+            parameters:
+                - name: environmentKey
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: namespaceKey
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: flagKey
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: from
+                  in: query
+                  schema:
+                    type: string
+                - name: to
+                  in: query
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GetFlagEvaluationsCountResponse'
     /ofrep/v1/configuration:
         get:
             tags:
@@ -560,6 +596,18 @@ components:
                 totalCount:
                     type: integer
                     format: int32
+        GetFlagEvaluationsCountResponse:
+            type: object
+            properties:
+                timestamps:
+                    type: array
+                    items:
+                        type: string
+                values:
+                    type: array
+                    items:
+                        type: number
+                        format: float
         GetProviderConfigurationResponse:
             type: object
             properties:
@@ -706,6 +754,7 @@ components:
 security:
     - bearerAuth: []
 tags:
+    - name: AnalyticsService
     - name: AuthenticationMethodKubernetesService
     - name: AuthenticationMethodOIDCService
     - name: AuthenticationService

--- a/ui/src/app/flags/analytics/Analytics.tsx
+++ b/ui/src/app/flags/analytics/Analytics.tsx
@@ -4,8 +4,8 @@ import { addMinutes } from 'date-fns';
 import { LineChartIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { selectCurrentEnvironment } from '~/app/environments/environmentsApi';
 
+import { selectCurrentEnvironment } from '~/app/environments/environmentsApi';
 import { useGetFlagEvaluationCountQuery } from '~/app/flags/analyticsApi';
 import { selectInfo } from '~/app/meta/metaSlice';
 import { selectCurrentNamespace } from '~/app/namespaces/namespacesApi';

--- a/ui/src/app/flags/analytics/Analytics.tsx
+++ b/ui/src/app/flags/analytics/Analytics.tsx
@@ -4,6 +4,7 @@ import { addMinutes } from 'date-fns';
 import { LineChartIcon } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { selectCurrentEnvironment } from '~/app/environments/environmentsApi';
 
 import { useGetFlagEvaluationCountQuery } from '~/app/flags/analyticsApi';
 import { selectInfo } from '~/app/meta/metaSlice';
@@ -67,6 +68,7 @@ export default function Analytics(props: AnalyticsProps) {
   );
   const [pollingInterval, setPollingInterval] = useState<number>(0);
 
+  const environment = useSelector(selectCurrentEnvironment);
   const namespace = useSelector(selectCurrentNamespace);
 
   const info = useSelector(selectInfo);
@@ -77,6 +79,7 @@ export default function Analytics(props: AnalyticsProps) {
 
   const getFlagEvaluationCount = useGetFlagEvaluationCountQuery(
     {
+      environmentKey: environment.key,
       namespaceKey: namespace.key,
       flagKey: flag.key,
       from: addMinutes(

--- a/ui/src/app/flags/analyticsApi.tsx
+++ b/ui/src/app/flags/analyticsApi.tsx
@@ -2,11 +2,11 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 
 import { IFlagEvaluationCount } from '~/types/Analytics';
 
-import { internalV2Query } from '~/utils/redux-rtk';
+import { internalQuery } from '~/utils/redux-rtk';
 
 export const analyticsApi = createApi({
   reducerPath: 'analytics',
-  baseQuery: internalV2Query,
+  baseQuery: internalQuery,
   tagTypes: ['Analytics'],
   endpoints: (builder) => ({
     // get evaluation count

--- a/ui/src/app/flags/analyticsApi.tsx
+++ b/ui/src/app/flags/analyticsApi.tsx
@@ -12,7 +12,13 @@ export const analyticsApi = createApi({
     // get evaluation count
     getFlagEvaluationCount: builder.query<
       IFlagEvaluationCount,
-      { environmentKey: string; namespaceKey: string; flagKey: string; from: string; to: string }
+      {
+        environmentKey: string;
+        namespaceKey: string;
+        flagKey: string;
+        from: string;
+        to: string;
+      }
     >({
       query: ({ environmentKey, namespaceKey, flagKey, from, to }) => ({
         url: `/analytics/environments/${environmentKey}/namespaces/${namespaceKey}/flags/${flagKey}`,

--- a/ui/src/app/flags/analyticsApi.tsx
+++ b/ui/src/app/flags/analyticsApi.tsx
@@ -2,20 +2,20 @@ import { createApi } from '@reduxjs/toolkit/query/react';
 
 import { IFlagEvaluationCount } from '~/types/Analytics';
 
-import { internalQuery } from '~/utils/redux-rtk';
+import { internalV2Query } from '~/utils/redux-rtk';
 
 export const analyticsApi = createApi({
   reducerPath: 'analytics',
-  baseQuery: internalQuery,
+  baseQuery: internalV2Query,
   tagTypes: ['Analytics'],
   endpoints: (builder) => ({
     // get evaluation count
     getFlagEvaluationCount: builder.query<
       IFlagEvaluationCount,
-      { namespaceKey: string; flagKey: string; from: string; to: string }
+      { environmentKey: string; namespaceKey: string; flagKey: string; from: string; to: string }
     >({
-      query: ({ namespaceKey, flagKey, from, to }) => ({
-        url: `/analytics/namespaces/${namespaceKey}/flags/${flagKey}`,
+      query: ({ environmentKey, namespaceKey, flagKey, from, to }) => ({
+        url: `/analytics/environments/${environmentKey}/namespaces/${namespaceKey}/flags/${flagKey}`,
         params: { from, to }
       })
     })

--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -10,6 +10,7 @@ export const apiURL = 'api/v2/environments';
 export const authURL = 'auth/v1';
 export const evaluateURL = 'evaluate/v1';
 export const internalURL = 'internal/v1';
+export const internalV2URL = 'internal/v2';
 export const metaURL = 'meta/info';
 
 export const sessionKey = 'session';

--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -9,8 +9,7 @@ import { getUser } from '~/data/user';
 export const apiURL = 'api/v2/environments';
 export const authURL = 'auth/v1';
 export const evaluateURL = 'evaluate/v1';
-export const internalURL = 'internal/v1';
-export const internalV2URL = 'internal/v2';
+export const internalURL = 'internal/v2';
 export const metaURL = 'meta/info';
 
 export const sessionKey = 'session';

--- a/ui/src/utils/redux-rtk.ts
+++ b/ui/src/utils/redux-rtk.ts
@@ -5,7 +5,7 @@ import {
   fetchBaseQuery
 } from '@reduxjs/toolkit/query/react';
 
-import { apiURL, checkResponse, defaultHeaders, internalURL } from '~/data/api';
+import { apiURL, checkResponse, defaultHeaders, internalURL, internalV2URL } from '~/data/api';
 
 type CustomFetchFn = (
   url: RequestInfo,
@@ -25,6 +25,11 @@ export const customFetchFn: CustomFetchFn = async (url, options) => {
 
 export const internalQuery = fetchBaseQuery({
   baseUrl: internalURL,
+  fetchFn: customFetchFn
+});
+
+export const internalV2Query = fetchBaseQuery({
+  baseUrl: internalV2URL,
   fetchFn: customFetchFn
 });
 

--- a/ui/src/utils/redux-rtk.ts
+++ b/ui/src/utils/redux-rtk.ts
@@ -5,7 +5,13 @@ import {
   fetchBaseQuery
 } from '@reduxjs/toolkit/query/react';
 
-import { apiURL, checkResponse, defaultHeaders, internalURL, internalV2URL } from '~/data/api';
+import {
+  apiURL,
+  checkResponse,
+  defaultHeaders,
+  internalURL,
+  internalV2URL
+} from '~/data/api';
 
 type CustomFetchFn = (
   url: RequestInfo,

--- a/ui/src/utils/redux-rtk.ts
+++ b/ui/src/utils/redux-rtk.ts
@@ -5,13 +5,7 @@ import {
   fetchBaseQuery
 } from '@reduxjs/toolkit/query/react';
 
-import {
-  apiURL,
-  checkResponse,
-  defaultHeaders,
-  internalURL,
-  internalV2URL
-} from '~/data/api';
+import { apiURL, checkResponse, defaultHeaders, internalURL } from '~/data/api';
 
 type CustomFetchFn = (
   url: RequestInfo,
@@ -31,11 +25,6 @@ export const customFetchFn: CustomFetchFn = async (url, options) => {
 
 export const internalQuery = fetchBaseQuery({
   baseUrl: internalURL,
-  fetchFn: customFetchFn
-});
-
-export const internalV2Query = fetchBaseQuery({
-  baseUrl: internalV2URL,
   fetchFn: customFetchFn
 });
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       '/auth/v1': fliptAddr,
       '/evaluate/v1': fliptAddr,
       '/internal/v1': fliptAddr,
+      '/internal/v2': fliptAddr,
       '/meta': fliptAddr,
       '/api/v2': fliptAddr
     },


### PR DESCRIPTION


![CleanShot 2025-05-01 at 15 01 38@2x](https://github.com/user-attachments/assets/b2d40cc5-bb75-4055-8bc0-19d698ba84aa)

fixes analytics for v2 by:

1. creating new `/internal/v2/analytics` endpoint which includes environment in the path
2. fixes metrics to be `_` separated instead of `.` so they are consistent between prometheus and otel
3. update ui analytics component to pass in env