### PR TITLE
feat: make playground flag aware

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -86,6 +86,13 @@ const namespacedRoutes = [
     }
   },
   {
+    path: 'playground/:flagKey',
+    element: <Console />,
+    handle: {
+      namespaced: true
+    }
+  },
+  {
     path: 'analytics',
     element: <Analytics />,
     handle: {

--- a/ui/src/app/flags/Flag.tsx
+++ b/ui/src/app/flags/Flag.tsx
@@ -1,6 +1,7 @@
 import {
   FilesIcon,
   LineChartIcon,
+  SquareTerminalIcon,
   ToggleLeftIcon,
   Trash2Icon,
   VariableIcon
@@ -172,6 +173,15 @@ export default function Flag() {
                 <LineChartIcon className="h-5 w-5 text-muted-foreground" />
               </button>
             )}
+            <button
+              className="ml-2 p-1 rounded hover:bg-accent"
+              title="View in Playground"
+              onClick={() =>
+                navigate(`/namespaces/${namespace.key}/playground/${flag.key}`)
+              }
+            >
+              <SquareTerminalIcon className="h-5 w-5 text-muted-foreground" />
+            </button>
           </div>
         }
       >
@@ -188,6 +198,15 @@ export default function Flag() {
                         `/namespaces/${namespace.key}/analytics/${flag.key}`
                       ),
                     icon: LineChartIcon
+                  },
+                  {
+                    id: 'flag-playground',
+                    label: 'View in Playground',
+                    onClick: () =>
+                      navigate(
+                        `/namespaces/${namespace.key}/playground/${flag.key}`
+                      ),
+                    icon: SquareTerminalIcon
                   }
                 ]
               : []),


### PR DESCRIPTION
Makes playground page work like new Analytics page where you can link to it directly from the Flag page and the flag is selected in the dropdown

![CleanShot 2025-05-14 at 09 40 58@2x](https://github.com/user-attachments/assets/e0a97d7b-8662-4738-9f2e-f26750ccecf0)
![CleanShot 2025-05-14 at 09 41 01@2x](https://github.com/user-attachments/assets/382f855f-144b-477e-a12f-9e1af397c66a)
![CleanShot 2025-05-14 at 09 41 09@2x](https://github.com/user-attachments/assets/1301479e-fc3a-4a44-a746-ef5860198200)
