### PR TITLE
fix: evaluation console and evaluation with envs

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1164,6 +1164,7 @@ github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+Ei
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.6/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -442,18 +442,26 @@ func (s *Server) boolean(ctx context.Context, store storage.ReadOnlyStore, env e
 
 // Batch takes in a list of *evaluation.EvaluationRequest and returns their respective responses.
 func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequest) (*rpcevaluation.BatchEvaluationResponse, error) {
-	env := s.store.GetFromContext(ctx)
-
-	store, err := env.EvaluationStore()
-	if err != nil {
-		return nil, err
-	}
-
 	resp := &rpcevaluation.BatchEvaluationResponse{
 		Responses: make([]*rpcevaluation.EvaluationResponse, 0, len(b.Requests)),
 	}
 
 	for _, req := range b.GetRequests() {
+		// this is not ideal as it could lead to a lot of swapping the environment store if requests are coming in for different environments
+		// we will need to document that while you CAN use different environments in the same request, it is not recommended and could have a performance impact
+		// but since we are using an in-memory map it's probably not that bad
+		env, err := s.store.Get(ctx, req.EnvironmentKey)
+		if err != nil {
+			// try to get the environment from the context
+			// this is for backwards compatibility with v1
+			env = s.store.GetFromContext(ctx)
+		}
+
+		store, err := env.EvaluationStore()
+		if err != nil {
+			return nil, err
+		}
+
 		f, err := store.GetFlag(ctx, storage.NewResource(req.NamespaceKey, req.FlagKey, storage.WithReference(b.Reference)))
 		if err != nil {
 			var errnf errs.ErrNotFound

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -28,7 +28,12 @@ import (
 
 // Variant evaluates a request for a multi-variate flag and entity.
 func (s *Server) Variant(ctx context.Context, r *rpcevaluation.EvaluationRequest) (*rpcevaluation.VariantEvaluationResponse, error) {
-	env := s.store.GetFromContext(ctx)
+	env, err := s.store.Get(ctx, r.EnvironmentKey)
+	if err != nil {
+		// try to get the environment from the context
+		// this is for backwards compatibility with v1
+		env = s.store.GetFromContext(ctx)
+	}
 
 	store, err := env.EvaluationStore()
 	if err != nil {
@@ -263,7 +268,12 @@ func (s *Server) variant(ctx context.Context, store storage.ReadOnlyStore, env e
 
 // Boolean evaluates a request for a boolean flag and entity.
 func (s *Server) Boolean(ctx context.Context, r *rpcevaluation.EvaluationRequest) (*rpcevaluation.BooleanEvaluationResponse, error) {
-	env := s.store.GetFromContext(ctx)
+	env, err := s.store.Get(ctx, r.EnvironmentKey)
+	if err != nil {
+		// try to get the environment from the context
+		// this is for backwards compatibility with v1
+		env = s.store.GetFromContext(ctx)
+	}
 
 	store, err := env.EvaluationStore()
 	if err != nil {

--- a/internal/server/evaluation/evaluation_test.go
+++ b/internal/server/evaluation/evaluation_test.go
@@ -28,7 +28,7 @@ func TestVariant_FlagNotFound(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{}, errs.ErrNotFound("test-flag"))
@@ -58,7 +58,7 @@ func TestVariant_NonVariantFlag(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -93,7 +93,7 @@ func TestVariant_FlagDisabled(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -134,7 +134,7 @@ func TestVariant_EvaluateFailure_OnGetEvaluationRules(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(flag, nil)
@@ -171,7 +171,7 @@ func TestVariant_Success(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(flag, nil)
@@ -233,7 +233,7 @@ func TestBoolean_FlagNotFoundError(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{}, errs.ErrNotFound("test-flag"))
@@ -262,7 +262,7 @@ func TestBoolean_NonBooleanFlagError(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -297,7 +297,7 @@ func TestBoolean_DefaultRule_NoRollouts(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -336,7 +336,7 @@ func TestBoolean_DefaultRuleFallthrough_WithPercentageRollout(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -385,7 +385,7 @@ func TestBoolean_PercentageRuleMatch(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -434,7 +434,7 @@ func TestBoolean_PercentageRuleFallthrough_SegmentMatch(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -520,7 +520,7 @@ func TestBoolean_SegmentMatch_MultipleConstraints(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -589,7 +589,7 @@ func TestBoolean_SegmentMatch_Constraint_EntityId(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -650,7 +650,7 @@ func TestBoolean_SegmentMatch_MultipleSegments_WithAnd(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -726,7 +726,7 @@ func TestBoolean_RulesOutOfOrder(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -794,7 +794,7 @@ func TestBatch_UnknownFlagType(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{
@@ -832,7 +832,7 @@ func TestBatch_InternalError_GetFlag(t *testing.T) {
 		s            = New(logger, envStore)
 	)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{}, errors.New("internal error"))
@@ -869,7 +869,7 @@ func TestBatch_Success(t *testing.T) {
 	)
 
 	environment.On("Key").Return(environmentKey)
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("Get", mock.Anything, mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{


### PR DESCRIPTION
Fixes 2 issues with evaluation:

1. on the console page, after directly linking there from a flag, while the flag was selected it would not let us submit the form because the field wasnt set in the formik context
2. much bigger issue, we werent correctly getting the environment from the request if provided, we were only looking in the header for V1 evaluation requests

one subtlty of this fix however is that users can issue batch eval requests for multiple environments. this isnt ideal as it means we'll be swapping out the env store in a loop.. but it is stored in memory so likely not tooo bad, but should be documented