### PR TITLE
fix(storage): map protobuf enums to ints in sql updates for rule and rollout

### DIFF
--- a/internal/storage/sql/common/rollout.go
+++ b/internal/storage/sql/common/rollout.go
@@ -585,7 +585,7 @@ func (s *Store) UpdateRollout(ctx context.Context, r *flipt.UpdateRolloutRequest
 
 		if _, err := s.builder.Update(tableRolloutSegments).
 			RunWith(tx).
-			Set("segment_operator", segmentOperator).
+			Set("segment_operator", int32(segmentOperator)).
 			Set("value", segmentRule.Value).
 			Where(sq.Eq{"rollout_id": r.Id}).ExecContext(ctx); err != nil {
 			return nil, err

--- a/internal/storage/sql/common/rule.go
+++ b/internal/storage/sql/common/rule.go
@@ -461,7 +461,7 @@ func (s *Store) UpdateRule(ctx context.Context, r *flipt.UpdateRuleRequest) (_ *
 	// Set segment operator.
 	_, err = s.builder.Update("rules").
 		RunWith(tx).
-		Set("segment_operator", segmentOperator).
+		Set("segment_operator", int32(segmentOperator)).
 		Set("updated_at", &fliptsql.Timestamp{Timestamp: flipt.Now()}).
 		Where(sq.Eq{"id": r.Id, "namespace_key": r.NamespaceKey, "flag_key": r.FlagKey}).
 		ExecContext(ctx)


### PR DESCRIPTION
The original fix was done in #3454 but updating rollout and rules were not resolved

closes #4230