### PR TITLE
feat: redo the env/namespace switcher component to handle branches

### DIFF
--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -11,7 +11,7 @@ import {
 } from '~/components/ui/tooltip';
 
 import { Badge } from './Badge';
-import { EnvironmentBranchSelector } from './environments/EnvironmentBranchSelector';
+import { CreateBranchButton } from './environments/CreateBranchButton';
 import { EnvironmentRemoteInfo } from './environments/EnvironmentRemoteInfo';
 
 export function Header({
@@ -36,8 +36,8 @@ export function Header({
       style={topbarStyle}
     >
       <div className="flex w-full items-center justify-between px-4 lg:gap-2 lg:px-6">
+        <SidebarTrigger className="-ml-2" />
         <div className="flex items-center gap-2">
-          <SidebarTrigger className="-ml-2" />
           {!sidebarOpen && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -54,9 +54,9 @@ export function Header({
               </TooltipContent>
             </Tooltip>
           )}
-        </div>
-        <div className="flex items-center gap-2">
-          <EnvironmentBranchSelector environment={currentEnvironment} />
+          {currentEnvironment && !currentEnvironment?.configuration?.base && (
+            <CreateBranchButton baseEnvironment={currentEnvironment} />
+          )}
           {currentEnvironment?.configuration?.remote && (
             <EnvironmentRemoteInfo environment={currentEnvironment} />
           )}

--- a/ui/src/components/environments/CreateBranchButton.tsx
+++ b/ui/src/components/environments/CreateBranchButton.tsx
@@ -1,0 +1,162 @@
+import { GitBranchPlusIcon } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import * as Yup from 'yup';
+
+import {
+  currentEnvironmentChanged,
+  useCreateBranchEnvironmentMutation
+} from '~/app/environments/environmentsApi';
+
+import MoreInfo from '~/components/MoreInfo';
+import { Popover, PopoverContent, PopoverTrigger } from '~/components/Popover';
+import { Button } from '~/components/ui/button';
+import { Input } from '~/components/ui/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from '~/components/ui/tooltip';
+
+import { useError } from '~/data/hooks/error';
+import { useAppDispatch } from '~/data/hooks/store';
+import { useSuccess } from '~/data/hooks/success';
+import { keyValidation } from '~/data/validations';
+
+export function CreateBranchButton({
+  baseEnvironment
+}: {
+  baseEnvironment: any;
+}) {
+  const [showBranchPopover, setShowBranchPopover] = useState(false);
+  const [tooltipOpen, setTooltipOpen] = useState(false);
+
+  const [branchInput, setBranchInput] = useState('');
+
+  const [createBranch, { isLoading: isCreatingBranch }] =
+    useCreateBranchEnvironmentMutation();
+  const branchInputRef = useRef<HTMLInputElement>(null);
+
+  const { setSuccess } = useSuccess();
+  const { setError, clearError } = useError();
+  const dispatch = useAppDispatch();
+
+  const branchValidationSchema = Yup.object({
+    branchName: keyValidation.test(
+      'is-valid-branch-name',
+      'Invalid branch name',
+      (value) => {
+        if (!value) return false;
+        return !/^flipt\/[\w-]+$/.test(value);
+      }
+    )
+  });
+
+  useEffect(() => {
+    if (showBranchPopover && branchInputRef.current) {
+      branchInputRef.current.focus();
+    }
+  }, [showBranchPopover]);
+
+  if (!baseEnvironment) return null;
+
+  const handleCreateBranch = async () => {
+    const branchName = branchInput.trim();
+    if (!branchName) return;
+    try {
+      await branchValidationSchema.validate({ branchName });
+      await createBranch({
+        baseEnvironmentKey: baseEnvironment.key,
+        environmentKey: branchName
+      }).unwrap();
+      setBranchInput('');
+      setShowBranchPopover(false);
+      clearError();
+      setSuccess('Branch created successfully');
+      dispatch(currentEnvironmentChanged({ key: branchName }));
+    } catch (e) {
+      setError(e);
+    }
+  };
+
+  return (
+    <Popover open={showBranchPopover} onOpenChange={setShowBranchPopover}>
+      <Tooltip
+        open={!showBranchPopover && tooltipOpen}
+        onOpenChange={setTooltipOpen}
+      >
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="ml-1 p-1 rounded focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              tabIndex={-1}
+              type="button"
+              onMouseEnter={() => setTooltipOpen(true)}
+              onMouseLeave={() => setTooltipOpen(false)}
+              onFocus={() => setTooltipOpen(true)}
+              onBlur={() => setTooltipOpen(false)}
+              onClick={() => setTooltipOpen(false)}
+            >
+              <GitBranchPlusIcon className="w-4 h-4" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          Create a new branch from this environment
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        className="rounded-xl shadow-2xl border border-gray-200 bg-white dark:bg-gray-900 p-4 w-96"
+        align="start"
+        sideOffset={4}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="space-y-1 mb-1">
+          <div className="text-lg font-medium text-gray-900 dark:text-gray-100">
+            Create Branch
+          </div>
+          <MoreInfo href="https://www.flipt.io/docs/v2/concepts#branches">
+            Learn more about branches
+          </MoreInfo>
+        </div>
+        <div className="mt-6">
+          <Input
+            ref={branchInputRef}
+            type="text"
+            placeholder="New branch name"
+            value={branchInput}
+            onChange={(e) => setBranchInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleCreateBranch();
+              if (e.key === 'Escape') setShowBranchPopover(false);
+            }}
+            disabled={isCreatingBranch}
+            className="mb-4 px-4 py-2 border-2 border-gray-200 rounded-lg focus:border-primary focus:ring-2 focus:ring-primary/20 text-base"
+          />
+          <div className="flex gap-2 justify-end">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setShowBranchPopover(false)}
+              type="button"
+              className="font-semibold"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              onClick={handleCreateBranch}
+              disabled={isCreatingBranch || !branchInput.trim()}
+              type="button"
+              className="font-semibold"
+            >
+              Create
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
Fixes: #4235 

This redoes the EnvironmentNamespaceSwitcher to handle branched enviornments as well
It also moves the BranchCreation component to the header only when we are on a base branch

![Screen Shot 2025-05-23 at 11 51 31](https://github.com/user-attachments/assets/b583d8bf-5b51-4f27-9a2f-bee1575846d0)

![Screen Shot 2025-05-23 at 11 51 24](https://github.com/user-attachments/assets/71aa855a-118a-45b3-9144-6dcdba9447dc)


This feels better to me as now branches show up like 'real' environments, since they are

Note: There are still issues that occur if you are on a flag page in one env/namespace and then switch to another env/namespace that does not contain that item, this shows an error. We'll need to fix this seperately