### PR TITLE
feat(prometheus): Add minimum range interval based on scrape interval

### DIFF
--- a/internal/config/analytics.go
+++ b/internal/config/analytics.go
@@ -60,9 +60,10 @@ func (c *ClickhouseConfig) Options() (*clickhouse.Options, error) {
 
 // PrometheusConfig defines the connection details for connecting Flipt to Prometheus.
 type PrometheusConfig struct {
-	Enabled bool              `json:"enabled,omitempty" mapstructure:"enabled" yaml:"enabled,omitempty"`
-	URL     string            `json:"-" mapstructure:"url" yaml:"-"`
-	Headers map[string]string `json:"-" mapstructure:"headers" yaml:"-"`
+	Enabled               bool              `json:"enabled,omitempty" mapstructure:"enabled" yaml:"enabled,omitempty"`
+	ScrapeIntervalSeconds int               `json:"scrapeIntervalSeconds,omitempty" mapstructure:"scrapeIntervalSeconds" yaml:"scrapeIntervalSeconds,omitempty"`
+	URL                   string            `json:"-" mapstructure:"url" yaml:"-"`
+	Headers               map[string]string `json:"-" mapstructure:"headers" yaml:"-"`
 }
 
 //nolint:unparam
@@ -74,8 +75,9 @@ func (a *AnalyticsConfig) setDefaults(v *viper.Viper) error {
 				"url":     "",
 			},
 			"prometheus": map[string]any{
-				"enabled": "false",
-				"url":     "",
+				"enabled":               "false",
+				"scrapeIntervalSeconds": "15",
+				"url":                   "",
 			},
 		},
 		"buffer": map[string]any{


### PR DESCRIPTION
Inspired by how Grafana does `$__rate_interval`, this adds the feature that the minimum range passed to Prometheus will be 4x the configured scrape interval. This allows users of 1 minutes scrape intervals to see metrics on the 30 minute and 1 hour time range, which is currently impossible.

For details of Grafana's implementation:
https://grafana.com/blog/2020/09/28/new-in-grafana-7.2-__rate_interval-for-prometheus-rate-queries-that-just-work/