### PR TITLE
chore: update changelog for v1.59.1; fix changelog gen script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.59.1](https://github.com/flipt-io/flipt/releases/tag/v1.59.1) - 2025-06-27
+
+### Fixed
+
+- flag metadata parsing from snapshot (#4384)
+
 ## [v1.59.0](https://github.com/flipt-io/flipt/releases/tag/v1.59.0) - 2025-06-26
 
 ### Added

--- a/build/release/changelog.go
+++ b/build/release/changelog.go
@@ -132,7 +132,7 @@ func insertChangeLogVersion(dst io.Writer, src io.Reader, log changeLogVersion) 
 		}
 
 		// write changelog heading
-		fmt.Fprintf(dst, "\n## [%s](https://github.com/flipt-io/flipt/releases/tag/%s) - %s\n\n", log.Version, tag, log.Date.Format(time.DateOnly))
+		fmt.Fprintf(dst, "## [%s](https://github.com/flipt-io/flipt/releases/tag/%s) - %s\n\n", log.Version, tag, log.Date.Format(time.DateOnly))
 
 		// write out all changelog entries
 		log.write(dst)

--- a/build/release/release.go
+++ b/build/release/release.go
@@ -315,7 +315,7 @@ func versionTags(repo *git.Repository, prefix string, includePre bool) (v []stri
 	if err := iter.ForEach(func(ref *plumbing.Reference) error {
 		name := strings.TrimPrefix(string(ref.Name()), "refs/tags/")
 		if prefix == "" {
-			if strings.HasPrefix(name, "v") {
+			if strings.HasPrefix(name, "v1") {
 				v = append(v, fix(name))
 			}
 


### PR DESCRIPTION
This pull request includes changes to improve the handling of version tags and changelog entries in the release process. The most important changes include updating the logic for filtering version tags, fixing formatting in changelog generation, and adding a new changelog entry for version `v1.59.1`.

### Improvements to version tag filtering:

* [`build/release/release.go`](diffhunk://#diff-d0f43db3c5f00dd589567722bc587f941c555f2f286c9452520f958c4dc381f4L318-R318): Updated the `versionTags` function to filter tags starting with `v1` instead of `v`. This ensures that only version 1 tags are included in the release process.

### Fixes to changelog generation:

* [`build/release/changelog.go`](diffhunk://#diff-64f3ce0373cda689039c2ef1cf126b7e09af1d161028da442eb9a43307507fc4L135-R135): Removed the unnecessary newline before the changelog heading in the `insertChangeLogVersion` function to improve formatting consistency.

### Addition of a new changelog entry:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R11): Added the changelog entry for version `v1.59.1`, including a fix for flag metadata parsing from snapshots.