### PR TITLE
chore: format branch name to rm spaces

### DIFF
--- a/ui/src/components/environments/branches/BranchActionsDropdown.tsx
+++ b/ui/src/components/environments/branches/BranchActionsDropdown.tsx
@@ -21,13 +21,13 @@ import {
 } from '~/components/ui/dropdown-menu';
 
 import { IEnvironment, ProposalState, SCM } from '~/types/Environment';
+import { Product } from '~/types/Meta';
 
 import { useAppSelector } from '~/data/hooks/store';
 import { getRepoUrlFromConfig } from '~/utils/helpers';
 
 import { CreateMergeProposalModal } from './CreateMergeProposalModal';
 import DeleteBranchModal from './DeleteBranchModal';
-import { Product } from '~/types/Meta';
 
 export default function BranchActionsDropdown({
   environment

--- a/ui/src/components/environments/branches/CreateBranchPopover.tsx
+++ b/ui/src/components/environments/branches/CreateBranchPopover.tsx
@@ -28,6 +28,7 @@ import { useError } from '~/data/hooks/error';
 import { useAppDispatch } from '~/data/hooks/store';
 import { useSuccess } from '~/data/hooks/success';
 import { keyValidation } from '~/data/validations';
+import { stringAsKey } from '~/utils/helpers';
 
 export function CreateBranchPopover({
   open,
@@ -120,7 +121,7 @@ export function CreateBranchPopover({
           type="text"
           placeholder="New branch name"
           value={branchInput}
-          onChange={(e) => setBranchInput(e.target.value)}
+          onChange={(e) => setBranchInput(stringAsKey(e.target.value))}
           onKeyDown={(e) => {
             if (e.key === 'Enter') handleCreateBranch();
             if (e.key === 'Escape') handleOpenChange(false);

--- a/ui/src/utils/helpers.ts
+++ b/ui/src/utils/helpers.ts
@@ -28,14 +28,17 @@ export function copyTextToClipboard(text: string) {
 }
 
 export function upperFirst(word: string) {
+  if (!word) return '';
   return word.charAt(0).toUpperCase() + word.slice(1);
 }
 
 export function titleCase(str: string) {
+  if (!str) return '';
   return str.toLowerCase().split(' ').map(upperFirst).join(' ');
 }
 
 export function stringAsKey(str: string) {
+  if (!str) return '';
   return str.toLowerCase().split(/\s+/).join('-');
 }
 

--- a/ui/tests/branches.spec.ts
+++ b/ui/tests/branches.spec.ts
@@ -48,7 +48,9 @@ test.describe('Branches', () => {
       .click();
     await page.getByTestId('create-branch-button').click();
     await page.getByRole('textbox', { name: 'New branch name' }).click();
-    await page.getByRole('textbox', { name: 'New branch name' }).fill('foo');
+    await page
+      .getByRole('textbox', { name: 'New branch name' })
+      .fill('foo bar');
     await page.getByRole('button', { name: 'Create' }).click();
     await expect(page.getByText('Branch created successfully')).toBeVisible();
     await page
@@ -57,7 +59,7 @@ test.describe('Branches', () => {
       .click();
     await page
       .getByTestId('environment-listbox')
-      .getByRole('button', { name: 'foo' })
+      .getByRole('button', { name: 'foo-bar' })
       .click();
     await page
       .getByTestId('namespace-listbox')
@@ -72,7 +74,7 @@ test.describe('Branches', () => {
       .click();
     await page
       .getByTestId('environment-listbox')
-      .getByRole('button', { name: 'foo' })
+      .getByRole('button', { name: 'foo-bar' })
       .click();
     await page
       .getByTestId('namespace-listbox')
@@ -80,7 +82,7 @@ test.describe('Branches', () => {
       .click();
     await page.getByText('Branched from: default').click();
     await page.getByRole('menuitem', { name: 'Delete branch' }).click();
-    await page.getByRole('textbox', { name: 'foo' }).fill('bar');
+    await page.getByRole('textbox', { name: 'foo-bar' }).fill('bar');
     await expect(
       page.getByRole('button', { name: 'Delete branch' })
     ).toBeDisabled();
@@ -93,7 +95,7 @@ test.describe('Branches', () => {
       .click();
     await page
       .getByTestId('environment-listbox')
-      .getByRole('button', { name: 'foo' })
+      .getByRole('button', { name: 'foo-bar' })
       .click();
     await page
       .getByTestId('namespace-listbox')
@@ -101,7 +103,7 @@ test.describe('Branches', () => {
       .click();
     await page.getByText('Branched from: default').click();
     await page.getByRole('menuitem', { name: 'Delete branch' }).click();
-    await page.getByRole('textbox', { name: 'foo' }).fill('foo');
+    await page.getByRole('textbox', { name: 'foo-bar' }).fill('foo-bar');
     await page.getByRole('button', { name: 'Delete branch' }).click();
     await expect(page.getByText('Branch deleted successfully')).toBeVisible();
   });


### PR DESCRIPTION
This pull request introduces improvements to branch name handling and validation, along with updates to corresponding tests and utility functions. The changes ensure that branch names are consistently formatted as keys, improve error handling for empty inputs, and update tests to reflect the new behavior.

### Enhancements to branch name handling:

* [`ui/src/components/environments/branches/CreateBranchPopover.tsx`](diffhunk://#diff-cfe31214a977fbbadf2d352265dd85060efe5b38c08e29e04cd1e12ebb6d271aL123-R124): Updated the `onChange` handler for the branch name input field to use the new `stringAsKey` utility function for consistent key formatting.
* [`ui/src/utils/helpers.ts`](diffhunk://#diff-715f42a425a5545e2a2276f926e9a2c7f0ee17bfde3ccd8259aa481095dd7e22R31-R41): Added input validation to utility functions like `stringAsKey`, `titleCase`, and `upperFirst` to handle empty strings gracefully.

### Updates to tests for branch name validation:

* [`ui/tests/branches.spec.ts`](diffhunk://#diff-fe90f5fbc92fca4b9f04cd73fb5523eb8a03fe7b90be44e9063902302ade15b4L51-R53): Modified test cases to reflect the new branch name formatting as keys (e.g., "foo-bar" instead of "foo"). This includes updates to branch creation, deletion, and environment list interactions. [[1]](diffhunk://#diff-fe90f5fbc92fca4b9f04cd73fb5523eb8a03fe7b90be44e9063902302ade15b4L51-R53) [[2]](diffhunk://#diff-fe90f5fbc92fca4b9f04cd73fb5523eb8a03fe7b90be44e9063902302ade15b4L60-R62) [[3]](diffhunk://#diff-fe90f5fbc92fca4b9f04cd73fb5523eb8a03fe7b90be44e9063902302ade15b4L75-R85) [[4]](diffhunk://#diff-fe90f5fbc92fca4b9f04cd73fb5523eb8a03fe7b90be44e9063902302ade15b4L96-R106)