### PR TITLE
fix: ensure initial snapshot is built when environment is created from existing repository

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,10 +130,11 @@ mage bootstrap
 
 ### Testing Commands
 
-- `mage go:test` - Run Go unit tests
+- `mage go:test` - Run allGo unit tests
 - `mage go:bench` - Run Go benchmarking tests
 - `mage go:cover` - Run tests and generate coverage report
 - `cd ui && npm run test` - Run UI unit tests (Jest)
+- `go test -v ./internal/storage/environments/git/ -run TestNewEnvironmentFromRepository` - Run a specific test
 
 ### Code Quality Commands
 


### PR DESCRIPTION
## Summary

Fixes an issue where Flipt v2 would not populate evaluation snapshots with existing data on restart, causing internal evaluation endpoints to return "not found" errors even when data existed in storage.

## Root Cause

When Flipt restarted with local storage containing existing data, the `NewEnvironmentFromRepo` function created environments with empty snapshots and never called `updateSnapshot()` during initialization. Snapshot building was deferred until the first `RefreshEnvironment` call triggered by a repository change.

## Changes

- **Modified `NewEnvironmentFromRepo`** to call `updateSnapshot()` immediately after environment creation
- **Added graceful error handling** to maintain backward compatibility with empty repositories  
- **Added comprehensive test** to verify the fix works correctly
- **Preserved existing behavior** while fixing the initialization issue

## Test Plan

- [x] Added unit test that verifies snapshot is initialized during environment creation
- [x] All existing tests pass - no regression introduced
- [x] Code formatting and linting checks pass
- [x] Manual testing scenario from issue description should now work

## Backward Compatibility

The fix maintains full backward compatibility:
- Empty repositories continue to work as before
- Error handling is graceful and doesn't break environment creation
- All existing functionality is preserved

## Expected Behavior After Fix

- When Flipt restarts with existing data in local storage, the snapshot is immediately populated
- The `/internal/v1/evaluation/snapshot/namespace/{namespace}` endpoint returns data without requiring a change first
- No regression in existing functionality

Fixes #4426