### PR TITLE
V2 scm cleanup

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -211,6 +211,7 @@ github.com/jackc/pgtype v1.14.0/go.mod h1:LUMuVrfsFfdKGLw+AFFVv6KtHOFMwRgDDzBt76
 github.com/jackc/pgx/v4 v4.18.2/go.mod h1:Ey4Oru5tH5sB6tV7hDmfWFahwF15Eb7DNXlRKx2CkVw=
 github.com/jackc/pgx/v5 v5.5.4/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -261,6 +262,7 @@ github.com/urfave/cli/v2 v2.27.6/go.mod h1:3Sevf16NykTbInEnD0yKkjDAeZDS0A6bzhBH5
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/quicktemplate v1.8.0/go.mod h1:qIqW8/igXt8fdrUln5kOSb+KWMaJ4Y8QUsfd1k6L2jM=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
+github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
@@ -277,8 +279,6 @@ go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2
 golang.org/x/crypto v0.11.1-0.20230711161743-2e82bdd1719d/go.mod h1:xgJhtzW8F9jGdVFWZESrid1U1bjeNy4zgy5cRr/CIio=
 golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=
 golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
-golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/net v0.40.0/go.mod h1:y0hY0exeL2Pku80/zKK7tpntoX23cqL3Oa6njdgRtds=
@@ -302,6 +302,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=
+gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 modernc.org/b v1.0.0/go.mod h1:uZWcZfRj1BpYzfN9JTerzlNUnnPsV9O2ZA8JsRcubNg=

--- a/internal/coss/storage/environments/git/azure/azure.go
+++ b/internal/coss/storage/environments/git/azure/azure.go
@@ -123,7 +123,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 	s.logger.Debug("changes compared", zap.Int("commits", len(*commits)))
 
 	for _, commit := range *commits {
-		if limit > 0 && int32(len(changes)) >= limit {
+		if limit > 0 && len(changes) >= int(limit) {
 			break
 		}
 

--- a/internal/coss/storage/environments/git/azure/azure.go
+++ b/internal/coss/storage/environments/git/azure/azure.go
@@ -60,20 +60,9 @@ func WithApiAuth(apiAuth *credentials.APIAuth) ClientOption {
 	}
 }
 
-// WithLogger sets the logger for the SCM client.
-func WithLogger(logger *zap.Logger) ClientOption {
-	return func(c *azureOptions) {
-		if logger != nil {
-			c.logger = logger
-		}
-	}
-}
-
 // NewSCM creates a new SCM instance for Azure DevOps Git.
-func NewSCM(ctx context.Context, repoOwner, repoProject, repoName string, opts ...ClientOption) (*SCM, error) {
-	options := &azureOptions{
-		logger: zap.NewNop(),
-	}
+func NewSCM(ctx context.Context, logger *zap.Logger, repoOwner, repoProject, repoName string, opts ...ClientOption) (*SCM, error) {
+	options := &azureOptions{}
 	for _, opt := range opts {
 		opt(options)
 	}
@@ -85,7 +74,7 @@ func NewSCM(ctx context.Context, repoOwner, repoProject, repoName string, opts .
 	}
 
 	return &SCM{
-		logger:      options.logger.With(zap.String("repository", fmt.Sprintf("%s/%s", repoProject, repoName)), zap.String("scm", "azure git")),
+		logger:      logger.With(zap.String("repository", fmt.Sprintf("%s/%s", repoProject, repoName)), zap.String("scm", "azure")),
 		client:      client,
 		repoOwner:   repoOwner,
 		repoProject: repoProject,
@@ -147,8 +136,12 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 
 func (s *SCM) Propose(ctx context.Context, req git.ProposalRequest) (*environments.EnvironmentProposalDetails, error) {
 	s.logger.Info("proposing pull request", zap.String("base", req.Base), zap.String("head", req.Head), zap.String("title", req.Title), zap.Bool("draft", req.Draft))
-	sourceRefName := fmt.Sprintf("refs/heads/%s", req.Head)
-	targetRefName := fmt.Sprintf("refs/heads/%s", req.Base)
+
+	var (
+		sourceRefName = fmt.Sprintf("refs/heads/%s", req.Head)
+		targetRefName = fmt.Sprintf("refs/heads/%s", req.Base)
+	)
+
 	pr, err := s.client.CreatePullRequest(ctx, azuregit.CreatePullRequestArgs{
 		GitPullRequestToCreate: &azuregit.GitPullRequest{
 			Title:         &req.Title,
@@ -163,7 +156,9 @@ func (s *SCM) Propose(ctx context.Context, req git.ProposalRequest) (*environmen
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pull request: %w", err)
 	}
+
 	s.logger.Info("pull request created", zap.String("pr", *pr.Url), zap.String("state", string(*pr.Status)))
+
 	return &environments.EnvironmentProposalDetails{
 		Url:   *pr.Url,
 		State: environments.ProposalState_PROPOSAL_STATE_OPEN,
@@ -173,7 +168,7 @@ func (s *SCM) Propose(ctx context.Context, req git.ProposalRequest) (*environmen
 func (s *SCM) ListProposals(ctx context.Context, env serverenvs.Environment) (map[string]*environments.EnvironmentProposalDetails, error) {
 	var (
 		details = map[string]*environments.EnvironmentProposalDetails{}
-		prs     = &prs{ctx: ctx, client: s.client, repoProject: s.repoProject, repoName: s.repoName, base: env.Configuration().Ref}
+		prs     = s.listPRs(ctx, env.Configuration().Ref)
 	)
 
 	for pr := range prs.All() {
@@ -211,20 +206,26 @@ type prs struct {
 	err error
 }
 
+func (s *SCM) listPRs(ctx context.Context, base string) *prs {
+	return &prs{ctx: ctx, client: s.client, repoProject: s.repoProject, repoName: s.repoName, base: base, err: nil}
+}
+
 func (p *prs) Err() error {
 	return p.err
 }
 
 func (p *prs) All() iter.Seq[*azuregit.GitPullRequest] {
 	return iter.Seq[*azuregit.GitPullRequest](func(yield func(*azuregit.GitPullRequest) bool) {
-		targetRefName := fmt.Sprintf("refs/heads/%s", p.base)
-		includeLinks := true
-		top := 100
-		skip := 0
-		criteria := &azuregit.GitPullRequestSearchCriteria{
-			TargetRefName: &targetRefName,
-			IncludeLinks:  &includeLinks,
-		}
+		var (
+			targetRefName = fmt.Sprintf("refs/heads/%s", p.base)
+			includeLinks  = true
+			top           = 100
+			skip          = 0
+			criteria      = &azuregit.GitPullRequestSearchCriteria{
+				TargetRefName: &targetRefName,
+				IncludeLinks:  &includeLinks,
+			}
+		)
 
 		for {
 			prs, err := p.client.GetPullRequests(p.ctx, azuregit.GetPullRequestsArgs{

--- a/internal/coss/storage/environments/git/gitea/gitea.go
+++ b/internal/coss/storage/environments/git/gitea/gitea.go
@@ -135,7 +135,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 	)
 
 	for _, commit := range comparison.Commits {
-		if limit > 0 && int32(len(changes)) >= limit {
+		if limit > 0 && len(changes) >= int(limit) {
 			break
 		}
 

--- a/internal/coss/storage/environments/git/gitea/gitea.go
+++ b/internal/coss/storage/environments/git/gitea/gitea.go
@@ -6,12 +6,11 @@
 package gitea
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"iter"
 	"net/http"
-	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -52,7 +51,7 @@ func WithApiAuth(apiAuth *credentials.APIAuth) ClientOption {
 	}
 }
 
-func NewSCM(logger *zap.Logger, url, repoOwner, repoName string, opts ...ClientOption) (*SCM, error) {
+func NewSCM(ctx context.Context, logger *zap.Logger, url, repoOwner, repoName string, opts ...ClientOption) (*SCM, error) {
 	giteaOpts := &giteaOptions{
 		httpClient: http.DefaultClient,
 	}
@@ -128,7 +127,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 		return nil, fmt.Errorf("failed to compare branches: %w", err)
 	}
 
-	s.logger.Info("changes compared", zap.Int("commits", len(comparison.Commits)))
+	s.logger.Debug("changes compared", zap.Int("commits", len(comparison.Commits)))
 
 	var (
 		changes []*environments.Change
@@ -155,9 +154,12 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 		changes = append(changes, change)
 	}
 
-	slices.SortFunc(changes, func(i, j *environments.Change) int {
-		return cmp.Compare(i.Timestamp, j.Timestamp)
-	})
+	// sort changes by timestamp descending if not empty
+	if len(changes) > 0 {
+		sort.Slice(changes, func(i, j int) bool {
+			return changes[i].Timestamp > changes[j].Timestamp
+		})
+	}
 
 	return &environments.ListBranchedEnvironmentChangesResponse{
 		Changes: changes,

--- a/internal/coss/storage/environments/git/github/github.go
+++ b/internal/coss/storage/environments/git/github/github.go
@@ -166,7 +166,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 			continue
 		}
 
-		if limit > 0 && int32(len(changes)) >= limit {
+		if limit > 0 && len(changes) >= int(limit) {
 			break
 		}
 

--- a/internal/coss/storage/environments/git/github/github.go
+++ b/internal/coss/storage/environments/git/github/github.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v66/github"
 	"go.flipt.io/flipt/internal/config"
@@ -78,7 +79,7 @@ func WithApiAuth(apiAuth *credentials.APIAuth) ClientOption {
 }
 
 // NewSCM creates a new GitHub SCM instance.
-func NewSCM(logger *zap.Logger, repoOwner, repoName string, opts ...ClientOption) (*SCM, error) {
+func NewSCM(ctx context.Context, logger *zap.Logger, repoOwner, repoName string, opts ...ClientOption) (*SCM, error) {
 	githubOpts := &gitHubOptions{
 		httpClient: http.DefaultClient,
 	}
@@ -102,7 +103,7 @@ func NewSCM(logger *zap.Logger, repoOwner, repoName string, opts ...ClientOption
 			client = client.WithAuthToken(apiAuth.Token)
 		case config.CredentialTypeBasic:
 			// Use basic auth for API operations - convert to OAuth2 token format
-			client = github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
+			client = github.NewClient(oauth2.NewClient(ctx, oauth2.StaticTokenSource(
 				&oauth2.Token{
 					TokenType:   "Basic",
 					AccessToken: base64.StdEncoding.EncodeToString(fmt.Appendf(nil, "%s:%s", apiAuth.Username, apiAuth.Password)),
@@ -153,7 +154,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 		return nil, fmt.Errorf("failed to compare branches: %w", err)
 	}
 
-	s.logger.Info("changes compared", zap.Int("commits", len(comparison.Commits)))
+	s.logger.Debug("changes compared", zap.Int("commits", len(comparison.Commits)))
 
 	var (
 		changes []*environments.Change
@@ -178,7 +179,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 		if commit.GetCommit().GetAuthor() != nil {
 			change.AuthorName = github.String(commit.GetCommit().GetAuthor().GetName())
 			change.AuthorEmail = github.String(commit.GetCommit().GetAuthor().GetEmail())
-			change.Timestamp = commit.GetCommit().GetAuthor().GetDate().Format("2006-01-02T15:04:05Z07:00")
+			change.Timestamp = commit.GetCommit().GetAuthor().GetDate().Format(time.RFC3339)
 		}
 
 		changes = append(changes, change)

--- a/internal/coss/storage/environments/git/gitlab/gitlab.go
+++ b/internal/coss/storage/environments/git/gitlab/gitlab.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	gitlab "gitlab.com/gitlab-org/api/client-go"
 	"go.flipt.io/flipt/internal/config"
@@ -65,7 +66,7 @@ func WithApiAuth(apiAuth *credentials.APIAuth) ClientOption {
 }
 
 // NewSCM creates a new GitLab SCM instance.
-func NewSCM(logger *zap.Logger, repoOwner, repoName string, opts ...ClientOption) (*SCM, error) {
+func NewSCM(ctx context.Context, logger *zap.Logger, repoOwner, repoName string, opts ...ClientOption) (*SCM, error) {
 	gitlabOpts := &gitLabOptions{
 		httpClient: http.DefaultClient,
 	}
@@ -160,7 +161,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 		return nil, fmt.Errorf("failed to compare branches: %w", err)
 	}
 
-	s.logger.Info("changes compareddd", zap.Int("commits", len(comparison.Commits)))
+	s.logger.Debug("changes compared", zap.Int("commits", len(comparison.Commits)))
 
 	var (
 		changes []*environments.Change
@@ -185,7 +186,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 			change.AuthorEmail = &commit.AuthorEmail
 		}
 		if commit.CreatedAt != nil {
-			change.Timestamp = commit.CreatedAt.Format("2006-01-02T15:04:05Z07:00")
+			change.Timestamp = commit.CreatedAt.Format(time.RFC3339)
 		}
 
 		changes = append(changes, change)

--- a/internal/coss/storage/environments/git/gitlab/gitlab.go
+++ b/internal/coss/storage/environments/git/gitlab/gitlab.go
@@ -169,7 +169,7 @@ func (s *SCM) ListChanges(ctx context.Context, req git.ListChangesRequest) (*env
 	)
 
 	for _, commit := range comparison.Commits {
-		if limit > 0 && int32(len(changes)) >= limit {
+		if limit > 0 && len(changes) >= int(limit) {
 			break
 		}
 

--- a/internal/coss/storage/environments/git/url.go
+++ b/internal/coss/storage/environments/git/url.go
@@ -15,10 +15,6 @@ type URL interface {
 	GetHostName() string
 }
 
-type gitURL struct {
-	giturl.IGitURL
-}
-
 var _ URL = &sshURL{}
 
 type sshURL struct {

--- a/internal/coss/storage/environments/git/url.go
+++ b/internal/coss/storage/environments/git/url.go
@@ -9,53 +9,78 @@ import (
 	giturl "github.com/kubescape/go-git-url"
 )
 
-type URL struct {
-	Owner string
-	Repo  string
+type URL interface {
+	GetOwnerName() string
+	GetRepoName() string
+	GetHostName() string
 }
 
-func ParseGitURL(rawURL string) (*URL, error) {
+type gitURL struct {
+	giturl.IGitURL
+}
+
+var _ URL = &sshURL{}
+
+type sshURL struct {
+	Owner string
+	Repo  string
+	Host  string
+}
+
+func (u *sshURL) GetOwnerName() string {
+	return u.Owner
+}
+
+func (u *sshURL) GetRepoName() string {
+	return u.Repo
+}
+
+func (u *sshURL) GetHostName() string {
+	return u.Host
+}
+
+func ParseGitURL(rawURL string) (URL, error) {
 	gitURL, err := giturl.NewGitURL(rawURL)
 	if err != nil {
 		// fall back to ssh parsing
-		owner, repo, err := parseSSHRepo(rawURL)
+		sshURL, err := parseSSHRepo(rawURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse git url: %w", err)
 		}
-		return &URL{Owner: owner, Repo: repo}, nil
+		return sshURL, nil
 	}
 
-	return &URL{Owner: gitURL.GetOwnerName(), Repo: gitURL.GetRepoName()}, nil
+	return gitURL, nil
 }
 
-func parseSSHRepo(rawURL string) (owner, repo string, err error) {
+func parseSSHRepo(rawURL string) (*sshURL, error) {
 	// Handle SSH-style URL: git@gitea.example.com:owner/repo.git
 	if strings.Contains(rawURL, ":") && strings.Contains(rawURL, "@") && !strings.HasPrefix(rawURL, "http") {
 		// Example: git@gitea.example.com:owner/repo.git
 		parts := strings.SplitN(rawURL, ":", 2)
 		if len(parts) != 2 {
-			return "", "", errors.New("invalid SSH URL format")
+			return nil, errors.New("invalid SSH URL format")
 		}
 		path := strings.TrimSuffix(parts[1], ".git")
 		subParts := strings.SplitN(path, "/", 2)
 		if len(subParts) != 2 {
-			return "", "", errors.New("invalid SSH repo path")
+			return nil, errors.New("invalid SSH repo path")
 		}
-		return subParts[0], subParts[1], nil
+		return &sshURL{Owner: subParts[0], Repo: subParts[1]}, nil
 	}
 
 	// Try parsing as a regular URL
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return "", "", fmt.Errorf("invalid URL: %w", err)
+		return nil, fmt.Errorf("invalid URL: %w", err)
 	}
 
 	path := strings.TrimSuffix(u.Path, ".git")
 	path = strings.TrimPrefix(path, "/")
 	parts := strings.SplitN(path, "/", 2)
 	if len(parts) != 2 {
-		return "", "", errors.New("invalid path structure")
+		return nil, errors.New("invalid path structure")
 	}
 
-	return parts[0], parts[1], nil
+	return &sshURL{Owner: parts[0], Repo: parts[1], Host: u.Host}, nil
 }

--- a/internal/coss/storage/environments/git/url_test.go
+++ b/internal/coss/storage/environments/git/url_test.go
@@ -20,8 +20,8 @@ func TestParseGitURL(t *testing.T) {
 			t.Run(fmt.Sprint(i), func(t *testing.T) {
 				gitURL, err := ParseGitURL(ex)
 				require.NoError(t, err)
-				assert.Equal(t, "flipt-io", gitURL.Owner)
-				assert.Equal(t, "flipt", gitURL.Repo)
+				assert.Equal(t, "flipt-io", gitURL.GetOwnerName())
+				assert.Equal(t, "flipt", gitURL.GetRepoName())
 			})
 		}
 	})
@@ -37,8 +37,8 @@ func TestParseGitURL(t *testing.T) {
 			t.Run(fmt.Sprint(i), func(t *testing.T) {
 				gitURL, err := ParseGitURL(ex)
 				require.NoError(t, err)
-				assert.Equal(t, "flipt-io", gitURL.Owner)
-				assert.Equal(t, "flipt", gitURL.Repo)
+				assert.Equal(t, "flipt-io", gitURL.GetOwnerName())
+				assert.Equal(t, "flipt", gitURL.GetRepoName())
 			})
 		}
 	})
@@ -54,8 +54,8 @@ func TestParseGitURL(t *testing.T) {
 			t.Run(fmt.Sprint(i), func(t *testing.T) {
 				gitURL, err := ParseGitURL(ex)
 				require.NoError(t, err)
-				assert.Equal(t, "flipt-io", gitURL.Owner)
-				assert.Equal(t, "flipt", gitURL.Repo)
+				assert.Equal(t, "flipt-io", gitURL.GetOwnerName())
+				assert.Equal(t, "flipt", gitURL.GetRepoName())
 			})
 		}
 	})

--- a/internal/storage/environments/environments.go
+++ b/internal/storage/environments/environments.go
@@ -86,7 +86,7 @@ func (rm *RepositoryManager) GetOrCreate(ctx context.Context, envConf *config.En
 				var err error
 				path, err = os.MkdirTemp(os.TempDir(), "flipt-git-*")
 				if err != nil {
-					return nil, fmt.Errorf("making tempory directory for git storage: %w", err)
+					return nil, fmt.Errorf("making temporary directory for git storage: %w", err)
 				}
 			}
 			opts = append(opts, storagegit.WithFilesystemStorage(path))
@@ -219,119 +219,9 @@ func (f *EnvironmentFactory) Create(ctx context.Context, name string, envConf *c
 			return wrapped, nil
 		}
 
-		var scm cossgit.SCM = &cossgit.SCMNotImplemented{}
-
-		repoURL, err := cossgit.ParseGitURL(repo.GetRemote())
+		scm, err := f.createSCM(ctx, envConf.SCM, repo)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse git url: %w", err)
-		}
-
-		var (
-			repoOwner = repoURL.GetOwnerName()
-			repoName  = repoURL.GetRepoName()
-		)
-
-		//nolint
-		switch envConf.SCM.Type {
-		case config.GitHubSCMType:
-			opts := []github.ClientOption{}
-
-			// To support GitHub Enterprise
-			if envConf.SCM.ApiURL != "" {
-				apiURL, err := url.Parse(envConf.SCM.ApiURL)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse api url: %w", err)
-				}
-				opts = append(opts, github.WithApiURL(apiURL))
-			}
-
-			if envConf.SCM.Credentials != nil {
-				creds, err := f.credentials.Get(*envConf.SCM.Credentials)
-				if err != nil {
-					return nil, err
-				}
-
-				opts = append(opts, github.WithApiAuth(creds.APIAuthentication()))
-			}
-
-			scm, err = github.NewSCM(f.logger, repoOwner, repoName, opts...)
-			if err != nil {
-				return nil, fmt.Errorf("failed to setup github scm: %w", err)
-			}
-		case config.GitLabSCMType:
-			opts := []gitlab.ClientOption{}
-
-			// To support GitLab Enterprise
-			if envConf.SCM.ApiURL != "" {
-				apiURL, err := url.Parse(envConf.SCM.ApiURL)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse api url: %w", err)
-				}
-				opts = append(opts, gitlab.WithApiURL(apiURL))
-			}
-
-			if envConf.SCM.Credentials != nil {
-				creds, err := f.credentials.Get(*envConf.SCM.Credentials)
-				if err != nil {
-					return nil, err
-				}
-
-				opts = append(opts, gitlab.WithApiAuth(creds.APIAuthentication()))
-			}
-
-			scm, err = gitlab.NewSCM(f.logger, repoOwner, repoName, opts...)
-			if err != nil {
-				return nil, fmt.Errorf("failed to setup gitlab scm: %w", err)
-			}
-
-		case config.AzureSCMType:
-			azureURL, ok := repoURL.(*v1.AzureURL)
-			if !ok {
-				return nil, fmt.Errorf("failed to parse azure git url: %w", err)
-			}
-
-			opts := []azure.ClientOption{
-				azure.WithApiURL(azureURL.GetURL()),
-			}
-
-			// To support Azure Enterprise
-			if envConf.SCM.ApiURL != "" {
-				apiURL, err := url.Parse(envConf.SCM.ApiURL)
-				if err != nil {
-					return nil, fmt.Errorf("failed to parse api url: %w", err)
-				}
-				opts = append(opts, azure.WithApiURL(apiURL))
-			}
-
-			if envConf.SCM.Credentials != nil {
-				creds, err := f.credentials.Get(*envConf.SCM.Credentials)
-				if err != nil {
-					return nil, err
-				}
-
-				opts = append(opts, azure.WithApiAuth(creds.APIAuthentication()))
-			}
-
-			scm, err = azure.NewSCM(ctx, f.logger, repoOwner, azureURL.GetProjectName(), repoName, opts...)
-			if err != nil {
-				return nil, fmt.Errorf("failed to setup azure scm: %w", err)
-			}
-		case config.GiteaSCMType:
-			opts := []gitea.ClientOption{}
-
-			if envConf.SCM.Credentials != nil {
-				creds, err := f.credentials.Get(*envConf.SCM.Credentials)
-				if err != nil {
-					return nil, err
-				}
-
-				opts = append(opts, gitea.WithApiAuth(creds.APIAuthentication()))
-			}
-
-			scm, err = gitea.NewSCM(f.logger, envConf.SCM.ApiURL, repoOwner, repoName, opts...)
-			if err != nil {
-				return nil, fmt.Errorf("failed to setup gitea scm: %w", err)
-			}
+			return nil, err
 		}
 
 		wrapped := cossgit.NewEnvironment(f.logger, env, scm)
@@ -343,6 +233,171 @@ func (f *EnvironmentFactory) Create(ctx context.Context, name string, envConf *c
 		zap.String("storage", envConf.Storage))
 
 	return env, nil
+}
+
+// createSCM creates the appropriate SCM client based on configuration
+func (f *EnvironmentFactory) createSCM(ctx context.Context, scmConfig *config.SCMConfig, repo *storagegit.Repository) (cossgit.SCM, error) {
+	repoURL, err := cossgit.ParseGitURL(repo.GetRemote())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse git url: %w", err)
+	}
+
+	// Create SCM using factory pattern
+	scmCreators := map[config.SCMType]func() (cossgit.SCM, error){
+		config.GitHubSCMType: func() (cossgit.SCM, error) {
+			return f.createGitHubSCM(ctx, scmConfig, repoURL)
+		},
+		config.GitLabSCMType: func() (cossgit.SCM, error) {
+			return f.createGitLabSCM(ctx, scmConfig, repoURL)
+		},
+		config.AzureSCMType: func() (cossgit.SCM, error) {
+			return f.createAzureSCM(ctx, scmConfig, repoURL)
+		},
+		config.GiteaSCMType: func() (cossgit.SCM, error) {
+			return f.createGiteaSCM(ctx, scmConfig, repoURL)
+		},
+	}
+
+	creator, exists := scmCreators[scmConfig.Type]
+	if !exists {
+		return &cossgit.SCMNotImplemented{}, nil
+	}
+
+	return creator()
+}
+
+// createGitHubSCM creates a GitHub SCM client
+func (f *EnvironmentFactory) createGitHubSCM(ctx context.Context, scmConfig *config.SCMConfig, repoURL cossgit.URL) (cossgit.SCM, error) {
+	var (
+		repoOwner = repoURL.GetOwnerName()
+		repoName  = repoURL.GetRepoName()
+
+		opts = []github.ClientOption{}
+	)
+
+	// To support GitHub Enterprise
+	if scmConfig.ApiURL != "" {
+		apiURL, err := url.Parse(scmConfig.ApiURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse api url: %w", err)
+		}
+		opts = append(opts, github.WithApiURL(apiURL))
+	}
+
+	if scmConfig.Credentials != nil {
+		creds, err := f.credentials.Get(*scmConfig.Credentials)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, github.WithApiAuth(creds.APIAuthentication()))
+	}
+
+	scm, err := github.NewSCM(ctx, f.logger, repoOwner, repoName, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup github scm: %w", err)
+	}
+
+	return scm, nil
+}
+
+// createGitLabSCM creates a GitLab SCM client
+func (f *EnvironmentFactory) createGitLabSCM(ctx context.Context, scmConfig *config.SCMConfig, repoURL cossgit.URL) (cossgit.SCM, error) {
+	var (
+		repoOwner = repoURL.GetOwnerName()
+		repoName  = repoURL.GetRepoName()
+
+		opts = []gitlab.ClientOption{}
+	)
+
+	// To support GitLab Enterprise
+	if scmConfig.ApiURL != "" {
+		apiURL, err := url.Parse(scmConfig.ApiURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse api url: %w", err)
+		}
+		opts = append(opts, gitlab.WithApiURL(apiURL))
+	}
+
+	if scmConfig.Credentials != nil {
+		creds, err := f.credentials.Get(*scmConfig.Credentials)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, gitlab.WithApiAuth(creds.APIAuthentication()))
+	}
+
+	scm, err := gitlab.NewSCM(ctx, f.logger, repoOwner, repoName, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup gitlab scm: %w", err)
+	}
+
+	return scm, nil
+}
+
+// createAzureSCM creates an Azure SCM client
+func (f *EnvironmentFactory) createAzureSCM(ctx context.Context, scmConfig *config.SCMConfig, repoURL cossgit.URL) (cossgit.SCM, error) {
+	var (
+		repoOwner = repoURL.GetOwnerName()
+		repoName  = repoURL.GetRepoName()
+
+		opts = []azure.ClientOption{}
+	)
+
+	azureURL, ok := repoURL.(*v1.AzureURL)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse azure git url")
+	}
+
+	opts = append(opts, azure.WithApiURL(azureURL.GetURL()))
+
+	// To support Azure Enterprise
+	if scmConfig.ApiURL != "" {
+		apiURL, err := url.Parse(scmConfig.ApiURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse api url: %w", err)
+		}
+		opts = append(opts, azure.WithApiURL(apiURL))
+	}
+
+	if scmConfig.Credentials != nil {
+		creds, err := f.credentials.Get(*scmConfig.Credentials)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, azure.WithApiAuth(creds.APIAuthentication()))
+	}
+
+	scm, err := azure.NewSCM(ctx, f.logger, repoOwner, azureURL.GetProjectName(), repoName, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup azure scm: %w", err)
+	}
+
+	return scm, nil
+}
+
+// createGiteaSCM creates a Gitea SCM client
+func (f *EnvironmentFactory) createGiteaSCM(ctx context.Context, scmConfig *config.SCMConfig, repoURL cossgit.URL) (cossgit.SCM, error) {
+	var (
+		repoOwner = repoURL.GetOwnerName()
+		repoName  = repoURL.GetRepoName()
+
+		opts = []gitea.ClientOption{}
+	)
+
+	if scmConfig.Credentials != nil {
+		creds, err := f.credentials.Get(*scmConfig.Credentials)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, gitea.WithApiAuth(creds.APIAuthentication()))
+	}
+
+	scm, err := gitea.NewSCM(ctx, f.logger, scmConfig.ApiURL, repoOwner, repoName, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup gitea scm: %w", err)
+	}
+
+	return scm, nil
 }
 
 // environmentSubscriber is a subscriber for storagegit.Repository


### PR DESCRIPTION
- refactor how git urls are handled and cast to azureURL type for azure to get project
- cleanup environment factory scm creation so each scm gets its own method for clarity
- make scm implementations consistent with timestamps, logging, and sorting