### PR TITLE
fix(license): resolve timeout issues during license deactivation on shutdown

### DIFF
--- a/cmd/flipt/main.go
+++ b/cmd/flipt/main.go
@@ -391,7 +391,10 @@ func run(ctx context.Context, logger *zap.Logger, cfg *config.Config) error {
 	licenseManager, licenseManagerShutdown := license.NewManager(ctx, logger, keygenAccountID, keygenProductID, cfg.License.Key, licenseManagerOpts...)
 
 	defer func() {
-		_ = licenseManagerShutdown(shutdownCtx)
+		// Use a dedicated timeout context for deactivation to avoid competing with other shutdown operations
+		deactivateCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		_ = licenseManagerShutdown(deactivateCtx)
+		cancel()
 	}()
 
 	info := info.New(

--- a/internal/coss/license/license.go
+++ b/internal/coss/license/license.go
@@ -148,8 +148,9 @@ func NewManager(ctx context.Context, logger *zap.Logger, accountID, productID, l
 		}
 
 		c := retryablehttp.NewClient()
+		c.HTTPClient.Timeout = 10 * time.Second
 		c.Backoff = retryablehttp.LinearJitterBackoff
-		c.RetryMax = 5
+		c.RetryMax = 3
 		c.Logger = log.New(io.Discard, "", log.LstdFlags)
 
 		keygen.HTTPClient = c.StandardClient()
@@ -195,7 +196,10 @@ func (lm *ManagerImpl) Shutdown(ctx context.Context) error {
 			return err
 		}
 		// deactivate the license for this machine so it can be used on another machine
-		if err := lm.license.Deactivate(ctx, fingerprint); err != nil {
+		// Use a dedicated timeout context for deactivation to avoid competing with other shutdown operations
+		deactivateCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if err := lm.license.Deactivate(deactivateCtx, fingerprint); err != nil {
 			lm.logger.Warn("failed to deactivate license", zap.Error(err))
 		}
 	}

--- a/internal/coss/license/license.go
+++ b/internal/coss/license/license.go
@@ -196,10 +196,7 @@ func (lm *ManagerImpl) Shutdown(ctx context.Context) error {
 			return err
 		}
 		// deactivate the license for this machine so it can be used on another machine
-		// Use a dedicated timeout context for deactivation to avoid competing with other shutdown operations
-		deactivateCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-		if err := lm.license.Deactivate(deactivateCtx, fingerprint); err != nil {
+		if err := lm.license.Deactivate(ctx, fingerprint); err != nil {
 			lm.logger.Warn("failed to deactivate license", zap.Error(err))
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes timeout issues during license deactivation on shutdown that were causing "context deadline exceeded" errors when attempting to deactivate Keygen licenses.

## Original Error

```
^C2025-07-23T00:16:57Z  INFO    shutting down...
2025-07-23T00:16:57Z    INFO    shutting down HTTP server...    {"server": "http"}
2025-07-23T00:16:57Z    INFO    shutting down GRPC server...    {"server": "grpc"}
2025-07-23T00:16:57Z    WARN    failed to deactivate license    {"error": "Delete \"https://api.keygen.sh/v1/accounts/****/machines/****\": DELETE https://api.keygen.sh/v1/accounts/****/machines/**** giving up after 1 attempt(s): context deadline exceeded"}
```

## Changes

- **Modified `internal/coss/license/license.go`**: 
  - Added 10-second timeout to retryable HTTP client for Keygen API calls
  - Reduced retry attempts from 5 to 3 for faster failure detection  
  - Use dedicated 15-second timeout context for license deactivation during shutdown
  - Prevent deactivation from being cancelled by other shutdown operations

## Root Cause

The issue occurred due to two problems:

1. **No explicit HTTP client timeout**: The retryable HTTP client lacked a timeout, causing requests to hang indefinitely when the Keygen API was slow or unreachable
2. **Context competition**: License deactivation was competing with other shutdown operations for the shared 30-second shutdown context, leading to premature cancellation

## Additional Notes

This fix ensures licenses are properly released during shutdown so they can be used on other machines, following Keygen best practices for machine deactivation.