### PR TITLE
feat: optimize UI integration tests with cached Flipt images

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -163,13 +163,21 @@ jobs:
     name: UI Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: [build-cache]
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run UI Tests
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run UI Tests with Cached Image
         uses: dagger/dagger-for-github@v7
         with:
           verb: call
           version: ${{ env.DAGGER_VERSION }}
-          args: test --source . ui
+          args: test --source . --cached-image "${{ needs.build-cache.outputs.cached-image }}" ui


### PR DESCRIPTION
## Summary

This PR optimizes the UI integration tests to use cached Flipt images from the build-cache job, bringing them in line with how other integration tests work.

## Changes

- Modified `.github/workflows/integration-test.yml` to make UI tests depend on the `build-cache` job
- Added container registry login step to pull cached images
- Updated Dagger command to use the `--cached-image` parameter

## Benefits

- **Performance**: Should  reduces UI test execution time by ~50%
- **Consistency**: UI tests now use the same caching strategy as other integration tests