### PR TITLE
chore: V2 prep release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,3 +162,25 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
+
+  update-helm-chart:
+    name: Update Helm Chart
+    runs-on: ubuntu-latest
+    needs: release
+    if: success()
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.FLIPT_RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
+          owner: ${{ github.repository_owner }}
+          repositories: helm-charts
+
+      - name: Trigger Helm Chart Update
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          echo "Triggering helm-chart update workflow for release ${{ github.ref_name }}"
+          gh workflow run update.yml -R flipt-io/helm-charts -f tag="${{ github.ref_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2025-08-12
+## [2.0.0](https://github.com/flipt-io/flipt/releases/tag/v2.0.0) - 2025-08-12
 
 Flipt v2 is a complete re-architecture of Flipt, focused on Git-native operations and multi-environment support. This major release represents a fundamental shift in how Flipt manages feature flags, bringing enterprise-grade GitOps workflows to feature management.
 
@@ -39,4 +39,3 @@ Flipt v2 is a complete re-architecture of Flipt, focused on Git-native operation
 - **Configuration Format**: New configuration structure to support environments and Git storage options
 - **API Versioning**: New v2 APIs for environments, analytics, and evaluation while maintaining v1 compatibility
 - **License Model**: Introduction of Pro tier with enterprise features while maintaining OSS core
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2025-08-12
+
+Flipt v2 is a complete re-architecture of Flipt, focused on Git-native operations and multi-environment support. This major release represents a fundamental shift in how Flipt manages feature flags, bringing enterprise-grade GitOps workflows to feature management.
+
+### Added
+
+#### Core Features
+
+- **Git-Native Architecture**: Feature flags are now stored directly in Git repositories with full read/write capabilities through the API and UI
+- **Multi-Environment Support**: Manage feature flags across multiple environments using:
+  - Different Git repositories per environment
+  - Different directories within the same repository
+  - Different branches within the same repository
+- **Environment Branching**: Create isolated branches of any environment for testing changes without affecting production
+- **Git SCM Integration** (Pro): Native integration with GitHub, GitLab, BitBucket, Azure DevOps, and Gitea for merge proposals and GPG-signed commits
+- **Offline Mode**: Continue serving flags even when the source Git repository is temporarily unavailable
+
+#### Security & Secrets Management
+
+- **Secret References in Configuration**: Support for referencing secrets from environment variables and files using `{{ secret "key" }}` syntax
+- **Integrated Secrets Management**: Built-in secure storage for GPG keys with HashiCorp Vault integration (Pro) and file system support (OSS)
+- **GPG Commit Signing** (Pro): Sign all Git commits for maximum security and auditability
+- **JWT Claims Mapping**: Configurable mapping of JWT claims to well-known authentication metadata
+
+#### UI & Developer Experience
+
+- **Redesigned UI**: Complete UI overhaul for improved user experience and intuitive navigation
+- **Environment Switcher**: Seamless switching between environments in the UI
+- **Merge Proposals**: Create pull/merge requests directly from the UI (Pro)
+
+### Changed
+
+- **Storage Backend**: Default storage is now Git-based (memory or disk) rather than database-backed
+- **Configuration Format**: New configuration structure to support environments and Git storage options
+- **API Versioning**: New v2 APIs for environments, analytics, and evaluation while maintaining v1 compatibility
+- **License Model**: Introduction of Pro tier with enterprise features while maintaining OSS core
+


### PR DESCRIPTION
Prep for releasing v2 tomorrow

* Added a detailed `CHANGELOG.md` for v2.0.0
* Added a new `update-helm-chart` job to `.github/workflows/release.yml` that triggers an update to the Helm chart repository after a successful release. See: <https://github.com/flipt-io/helm-charts/pull/232>