### PR TITLE
fix: rm hanging test; add x-flipt-accept-server-version to default cors headers

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -172,6 +172,7 @@ JsonPath: string
 			"Authorization",
 			"Content-Type",
 			"X-CSRF-Token",
+			"X-Flipt-Accept-Server-Version",
 			"X-Flipt-Environment",
 			"X-Flipt-Namespace",
 		]

--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -122,11 +122,11 @@ JsonPath: string
 					audiences?: [...string]
 				}
 				claims_mapping?: {
-				    email?: JsonPath
-				    name?: JsonPath
-				    sub?: JsonPath
-				    picture?: JsonPath
-				    role?: JsonPath
+					email?:   JsonPath
+					name?:    JsonPath
+					sub?:     JsonPath
+					picture?: JsonPath
+					role?:    JsonPath
 				}
 				jwks_url?:        string
 				public_key_file?: string
@@ -172,8 +172,8 @@ JsonPath: string
 			"Authorization",
 			"Content-Type",
 			"X-CSRF-Token",
+			"X-Flipt-Environment",
 			"X-Flipt-Namespace",
-			"X-Flipt-Accept-Server-Version",
 		]
 	}
 

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -681,8 +681,8 @@
             "Authorization",
             "Content-Type",
             "X-CSRF-Token",
-            "X-Flipt-Namespace",
-            "X-Flipt-Accept-Server-Version"
+            "X-Flipt-Environment",
+            "X-Flipt-Namespace"
           ]
         }
       }

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -681,6 +681,7 @@
             "Authorization",
             "Content-Type",
             "X-CSRF-Token",
+            "X-Flipt-Accept-Server-Version",
             "X-Flipt-Environment",
             "X-Flipt-Namespace"
           ]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -590,6 +590,7 @@ func Default() *Config {
 				"Authorization",
 				"Content-Type",
 				"X-CSRF-Token",
+				"X-Flipt-Accept-Server-Version",
 				"X-Flipt-Environment",
 				"X-Flipt-Namespace",
 			},

--- a/internal/config/cors.go
+++ b/internal/config/cors.go
@@ -23,6 +23,7 @@ func (c *CorsConfig) setDefaults(v *viper.Viper) error {
 		"Authorization",
 		"Content-Type",
 		"X-CSRF-Token",
+		"X-Flipt-Accept-Server-Version",
 		common.HeaderFliptEnvironment,
 		common.HeaderFliptNamespace,
 	})

--- a/internal/storage/environments/environments_test.go
+++ b/internal/storage/environments/environments_test.go
@@ -16,12 +16,14 @@ import (
 )
 
 func Test_NewRepositoryManager(t *testing.T) {
-	logger := zaptest.NewLogger(t)
-	cfg := &config.Config{}
-	secretsManager := &secrets.MockManager{}
-	licenseManager := &license.MockManager{}
+	var (
+		logger         = zaptest.NewLogger(t)
+		cfg            = &config.Config{}
+		secretsManager = &secrets.MockManager{}
+		licenseManager = &license.MockManager{}
 
-	rm := NewRepositoryManager(logger, cfg, secretsManager, licenseManager)
+		rm = NewRepositoryManager(logger, cfg, secretsManager, licenseManager)
+	)
 
 	assert.NotNil(t, rm)
 	assert.Equal(t, logger, rm.logger)
@@ -36,6 +38,7 @@ func Test_RepositoryManager_GetOrCreate(t *testing.T) {
 		name          string
 		envConf       *config.EnvironmentConfig
 		storageConfig *config.StorageConfig
+		expectCached  bool
 		expectedError bool
 		setupMocks    func(*license.MockManager, *secrets.MockManager)
 	}{
@@ -69,21 +72,6 @@ func Test_RepositoryManager_GetOrCreate(t *testing.T) {
 			setupMocks: func(lm *license.MockManager, sm *secrets.MockManager) {},
 		},
 		{
-			name: "creates repository with remote",
-			envConf: &config.EnvironmentConfig{
-				Name:    "test-env",
-				Storage: "test-storage",
-			},
-			storageConfig: &config.StorageConfig{
-				Backend: config.StorageBackendConfig{
-					Type: config.MemoryStorageBackendType,
-				},
-				Branch: "main",
-				Remote: "https://github.com/flipt-io/flipt.git",
-			},
-			setupMocks: func(lm *license.MockManager, sm *secrets.MockManager) {},
-		},
-		{
 			name: "creates repository with CA cert bytes",
 			envConf: &config.EnvironmentConfig{
 				Name:    "test-env",
@@ -110,7 +98,8 @@ func Test_RepositoryManager_GetOrCreate(t *testing.T) {
 				},
 				Branch: "main",
 			},
-			setupMocks: func(lm *license.MockManager, sm *secrets.MockManager) {},
+			setupMocks:   func(lm *license.MockManager, sm *secrets.MockManager) {},
+			expectCached: true,
 		},
 		{
 			name: "repository with commit signing enabled - OSS license",
@@ -222,7 +211,7 @@ test_key_data
 				assert.NotNil(t, repo)
 
 				// Verify repository is cached
-				if tt.name == "reuses existing repository" {
+				if tt.expectCached {
 					// Pre-populate the cache
 					rm.repos[tt.envConf.Storage] = repo
 					repo2, err := rm.GetOrCreate(ctx, tt.envConf, tt.storageConfig, credentials)


### PR DESCRIPTION
Test fixes from #4563
Add `X-Flipt-Accept-Server-Version` to default allowed cors headers because its sent by client sdks still

