### PR TITLE
chore: Add renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,50 @@
+{
+  extends: ["config:base"],
+  baseBranches: ["main", "v2"],
+  timezone: "America/New_York",
+
+  // Run once a week at 2am Monday (cron)
+  schedule: ["0 2 * * 1"],
+
+  prConcurrentLimit: 5,
+  prHourlyLimit: 2,
+
+  labels: ["dependencies"],
+
+  packageRules: [
+    {
+      matchManagers: ["gomod"],
+      matchBaseBranches: ["main", "v2"],
+      labels: ["dependencies", "go", "automerge"],
+      updateTypes: ["minor", "patch"],
+      automerge: false,
+    },
+    {
+      matchManagers: ["npm"],
+      matchBaseBranches: ["main", "v2"],
+      matchPaths: ["/ui/**"],
+      labels: ["dependencies", "javascript", "automerge"],
+      updateTypes: ["minor", "patch"],
+      automerge: false,
+    },
+    {
+      matchManagers: ["github-actions"],
+      matchBaseBranches: ["main", "v2"],
+      labels: ["dependencies", "github_actions", "automerge"],
+      updateTypes: ["minor", "patch"],
+      automerge: false,
+    },
+    {
+      matchManagers: ["dockerfile"],
+      matchBaseBranches: ["main", "v2"],
+      matchPaths: ["/build/**"],
+      labels: ["dependencies", "docker", "automerge"],
+      updateTypes: ["minor", "patch"],
+      automerge: false,
+    },
+    {
+      updateTypes: ["major"],
+      enabled: false,
+    },
+  ],
+}


### PR DESCRIPTION
explore switching to renovate to support both main and v2 branches for dep updates https://github.com/renovatebot/renovate