### PR TITLE
fix: add startup delay to prevent Keygen API rate limits during pod restarts

### DIFF
--- a/internal/coss/license/license.go
+++ b/internal/coss/license/license.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"sync"
 	"time"
@@ -250,6 +251,12 @@ func (lm *ManagerImpl) validateAndSet(ctx context.Context) {
 		lm.logger.Warn("no license key provided; additional features are disabled.")
 		return
 	}
+
+	// Add random startup delay (0-30s) to prevent thundering herd during mass pod restarts
+	// Only delay when we have a license key that will make API calls
+	delay := time.Duration(rand.Intn(30)) * time.Second
+	lm.logger.Debug("adding startup delay to prevent rate limits", zap.Duration("delay", delay))
+	time.Sleep(delay)
 
 	var (
 		license *keygen.License


### PR DESCRIPTION
## Summary

Adds a random startup delay (0-30 seconds) to license validation to prevent Keygen API rate limit issues during mass pod restarts.

## Changes

- **Modified `internal/coss/license/license.go`**: Added random startup delay before license validation
- **Added `math/rand` import**: For generating random delay duration
- **Conditional delay**: Only applies when a license key is configured (no delay for OSS instances)

## Problem

When multiple pods restart simultaneously (crash loops, deployments, etc.), they all call the Keygen API at nearly the same time, quickly hitting the rate limits:
- Client tokens: 60 requests/30 seconds, 500 requests/5 minutes  
- This causes license validation failures and features being disabled

## Solution

The random 0-30 second startup delay spreads out API calls across a wider time window, preventing the thundering herd problem while:
- Only delaying pods that actually have license keys configured
- Not affecting development environments (force flag bypass)
- Maintaining reasonable startup times with debug logging

This should significantly reduce the API request spikes visible in the Keygen dashboard during pod restart scenarios.