### PR TITLE
fix: allow rollout and percentage zero values in YAML serialization

### DIFF
--- a/core/validation/testdata/valid_zero_values.yaml
+++ b/core/validation/testdata/valid_zero_values.yaml
@@ -1,0 +1,51 @@
+version: "1.5"
+flags:
+  - key: test_variant_flag
+    name: Test Variant Flag
+    type: VARIANT_FLAG_TYPE
+    enabled: true
+    variants:
+      - key: variant1
+        name: Variant 1
+        description: First variant
+      - key: variant2
+        name: Variant 2
+        description: Second variant
+    rules:
+      - segment: test_segment
+        distributions:
+          - variant: variant1
+            rollout: 0
+          - variant: variant2
+            rollout: 100
+  - key: test_boolean_flag
+    name: Test Boolean Flag
+    type: BOOLEAN_FLAG_TYPE
+    enabled: true
+    rollouts:
+      - description: "enabled for 0% threshold"
+        threshold:
+          percentage: 0
+          value: true
+      - description: "enabled for 0.0% threshold"
+        threshold:
+          percentage: 0.0
+          value: true
+      - description: "enabled for 50% threshold"
+        threshold:
+          percentage: 50
+          value: true
+      - description: "enabled for test segment with false value"
+        segment:
+          key: test_segment
+          value: false
+
+segments:
+  - key: test_segment
+    name: Test Segment
+    match_type: ANY_MATCH_TYPE
+    constraints:
+      - type: STRING_COMPARISON_TYPE
+        property: user_id
+        operator: eq
+        value: test_user

--- a/core/validation/validate_test.go
+++ b/core/validation/validate_test.go
@@ -93,6 +93,20 @@ func TestValidate_NamespaceDetails_v4(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidate_ZeroValues_Success(t *testing.T) {
+	const file = "testdata/valid_zero_values.yaml"
+	f, err := os.Open(file)
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	v, err := NewFeaturesValidator()
+	require.NoError(t, err)
+
+	err = v.Validate(file, f)
+	assert.NoError(t, err)
+}
+
 func TestValidate_YAML_Stream(t *testing.T) {
 	const file = "testdata/valid_yaml_stream.yaml"
 	f, err := os.Open(file)

--- a/internal/ext/common.go
+++ b/internal/ext/common.go
@@ -50,7 +50,7 @@ type Rule struct {
 
 type Distribution struct {
 	VariantKey string  `yaml:"variant,omitempty" json:"variant,omitempty"`
-	Rollout    float32 `yaml:"rollout,omitempty" json:"rollout,omitempty"`
+	Rollout    float32 `yaml:"rollout" json:"rollout"`
 }
 
 type Rollout struct {
@@ -137,7 +137,7 @@ func (s *SegmentRule) UnmarshalJSON(data []byte) error {
 }
 
 type ThresholdRule struct {
-	Percentage float32 `yaml:"percentage,omitempty" json:"percentage,omitempty"`
+	Percentage float32 `yaml:"percentage" json:"percentage"`
 	Value      bool    `yaml:"value,omitempty" json:"value,omitempty"`
 }
 

--- a/internal/ext/common_test.go
+++ b/internal/ext/common_test.go
@@ -1,0 +1,194 @@
+package ext
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDistribution_ZeroRollout_YAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		rollout  float32
+		expected string
+	}{
+		{
+			name:     "zero rollout",
+			rollout:  0,
+			expected: "variant: test\nrollout: 0\n",
+		},
+		{
+			name:     "zero float rollout",
+			rollout:  0.0,
+			expected: "variant: test\nrollout: 0\n",
+		},
+		{
+			name:     "non-zero rollout",
+			rollout:  50.0,
+			expected: "variant: test\nrollout: 50\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dist := &Distribution{
+				VariantKey: "test",
+				Rollout:    tt.rollout,
+			}
+
+			data, err := yaml.Marshal(dist)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+
+			// Test unmarshaling back
+			var unmarshaled Distribution
+			err = yaml.Unmarshal(data, &unmarshaled)
+			require.NoError(t, err)
+			assert.Equal(t, dist.VariantKey, unmarshaled.VariantKey)
+			assert.InDelta(t, dist.Rollout, unmarshaled.Rollout, 0.001)
+		})
+	}
+}
+
+func TestDistribution_ZeroRollout_JSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		rollout  float32
+		expected string
+	}{
+		{
+			name:     "zero rollout",
+			rollout:  0,
+			expected: `{"variant":"test","rollout":0}`,
+		},
+		{
+			name:     "zero float rollout",
+			rollout:  0.0,
+			expected: `{"variant":"test","rollout":0}`,
+		},
+		{
+			name:     "non-zero rollout",
+			rollout:  50.0,
+			expected: `{"variant":"test","rollout":50}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dist := &Distribution{
+				VariantKey: "test",
+				Rollout:    tt.rollout,
+			}
+
+			data, err := json.Marshal(dist)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+
+			// Test unmarshaling back
+			var unmarshaled Distribution
+			err = json.Unmarshal(data, &unmarshaled)
+			require.NoError(t, err)
+			assert.Equal(t, dist.VariantKey, unmarshaled.VariantKey)
+			assert.InDelta(t, dist.Rollout, unmarshaled.Rollout, 0.001)
+		})
+	}
+}
+
+func TestThresholdRule_ZeroPercentage_YAML(t *testing.T) {
+	tests := []struct {
+		name       string
+		percentage float32
+		value      bool
+		expected   string
+	}{
+		{
+			name:       "zero percentage with true value",
+			percentage: 0,
+			value:      true,
+			expected:   "percentage: 0\nvalue: true\n",
+		},
+		{
+			name:       "zero float percentage with false value",
+			percentage: 0.0,
+			value:      false,
+			expected:   "percentage: 0\n",
+		},
+		{
+			name:       "non-zero percentage",
+			percentage: 50.0,
+			value:      true,
+			expected:   "percentage: 50\nvalue: true\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			threshold := &ThresholdRule{
+				Percentage: tt.percentage,
+				Value:      tt.value,
+			}
+
+			data, err := yaml.Marshal(threshold)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+
+			// Test unmarshaling back
+			var unmarshaled ThresholdRule
+			err = yaml.Unmarshal(data, &unmarshaled)
+			require.NoError(t, err)
+			assert.InDelta(t, threshold.Percentage, unmarshaled.Percentage, 0.001)
+			assert.Equal(t, threshold.Value, unmarshaled.Value)
+		})
+	}
+}
+
+func TestThresholdRule_ZeroPercentage_JSON(t *testing.T) {
+	tests := []struct {
+		name       string
+		percentage float32
+		value      bool
+		expected   string
+	}{
+		{
+			name:       "zero percentage with true value",
+			percentage: 0,
+			value:      true,
+			expected:   `{"percentage":0,"value":true}`,
+		},
+		{
+			name:       "zero float percentage with false value",
+			percentage: 0.0,
+			value:      false,
+			expected:   `{"percentage":0}`,
+		},
+		{
+			name:       "non-zero percentage",
+			percentage: 50.0,
+			value:      true,
+			expected:   `{"percentage":50,"value":true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			threshold := &ThresholdRule{
+				Percentage: tt.percentage,
+				Value:      tt.value,
+			}
+
+			data, err := json.Marshal(threshold)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(data))
+
+			// Test unmarshaling back
+			var unmarshaled ThresholdRule
+			err = json.Unmarshal(data, &unmarshaled)
+			require.NoError(t, err)
+			assert.InDelta(t, threshold.Percentage, unmarshaled.Percentage, 0.001)
+			assert.Equal(t, threshold.Value, unmarshaled.Value)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes validation errors when using rollout value of 0 in variant flag distributions and percentage value of 0 in boolean flag threshold rollouts.

## Problem

When updating a variant flag with a distribution rollout value of 0, the operation fails with a CUE validation error: `incomplete value >=0 & <=100`. This occurs because the `omitempty` tag on the `Rollout` field in `Distribution` and `Percentage` field in `ThresholdRule` causes zero values to be omitted during YAML serialization, leading to validation failure.

## Changes

- **Modified `internal/ext/common.go`**: Removed `omitempty` tags from:
  - `Distribution.Rollout` field 
  - `ThresholdRule.Percentage` field
- **Added `internal/ext/common_test.go`**: Comprehensive tests for YAML and JSON serialization with zero values
- **Added `core/validation/testdata/valid_zero_values.yaml`**: Test data with rollout: 0 and percentage: 0
- **Modified `core/validation/validate_test.go`**: Added test case for zero values validation

## Testing

- All existing tests pass
- New tests verify zero values serialize correctly in both YAML and JSON
- CUE validation now passes for rollout: 0 and percentage: 0
- Linting and formatting checks pass

## Backward Compatibility

This change is backward compatible since:
- Existing YAML files with rollout/percentage values continue to work  
- The only change is that zero values are now explicitly serialized instead of omitted
- CUE validation is more consistent

Fixes #4677