### PR TITLE
fix: replace panic with proper error handling in EmailMatchingUnaryInterceptor

### DIFF
--- a/internal/server/authn/middleware/grpc/middleware.go
+++ b/internal/server/authn/middleware/grpc/middleware.go
@@ -441,7 +441,8 @@ func EmailMatchingUnaryInterceptor(logger *zap.Logger, rgxs []*regexp.Regexp, o 
 
 		auth := GetAuthenticationFrom(ctx)
 		if auth == nil {
-			panic("authentication not found in context, middleware installed incorrectly")
+			logger.Error("unauthenticated", zap.String("reason", "authentication required for email matching"))
+			return nil, errUnauthenticated
 		}
 
 		// this mechanism only applies to authentications created using OIDC

--- a/internal/server/authn/middleware/grpc/middleware_test.go
+++ b/internal/server/authn/middleware/grpc/middleware_test.go
@@ -815,14 +815,14 @@ func TestEmailMatchingUnaryInterceptorWithNoAuth(t *testing.T) {
 		}
 	)
 
-	require.Panics(t, func() {
-		_, _ = EmailMatchingUnaryInterceptor(logger, []*regexp.Regexp{regexp.MustCompile("^.*@flipt.io$")})(
-			ctx,
-			nil,
-			&grpc.UnaryServerInfo{Server: &mockServer{}},
-			handler,
-		)
-	})
+	_, err := EmailMatchingUnaryInterceptor(logger, []*regexp.Regexp{regexp.MustCompile("^.*@flipt.io$")})(
+		ctx,
+		nil,
+		&grpc.UnaryServerInfo{Server: &mockServer{}},
+		handler,
+	)
+
+	require.Equal(t, errUnauthenticated, err)
 }
 
 func TestEmailMatchingUnaryInterceptor(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a panic in the `EmailMatchingUnaryInterceptor` middleware that occurs when authentication is not found in context (e.g., after pod restarts with in-memory session storage).

- **Root cause**: When using OIDC with `email_matches` patterns and in-memory sessions, pod restarts cause sessions to be lost, leading to `GetAuthenticationFrom(ctx)` returning `nil`
- **Previous behavior**: Application would panic with "authentication not found in context, middleware installed incorrectly" 
- **New behavior**: Returns proper `errUnauthenticated` error like other middleware functions in the same file

## Changes

- **Modified `internal/server/authn/middleware/grpc/middleware.go`**: Replace panic with proper error handling following established patterns
- **Updated `internal/server/authn/middleware/grpc/middleware_test.go`**: Update existing test to expect error instead of panic

## Test Plan

- [x] Updated existing test `TestEmailMatchingUnaryInterceptorWithNoAuth` to verify error handling
- [x] All authentication middleware tests pass 
- [x] Go linting and formatting checks pass
- [x] Verified consistent logging level with other authentication scenarios

## Backward Compatibility

**Maintained** - API behavior unchanged, clients still receive 401 Unauthorized responses. Only difference is proper error handling instead of application crash.

Fixes #4743