### PR TITLE
feat: return error from GetFromContext when environment not found

### DIFF
--- a/internal/coss/storage/environments/git/bitbucket/bitbucket_mock.go
+++ b/internal/coss/storage/environments/git/bitbucket/bitbucket_mock.go
@@ -37,23 +37,23 @@ func (_m *MockPullRequestsService) EXPECT() *MockPullRequestsService_Expecter {
 }
 
 // Create provides a mock function for the type MockPullRequestsService
-func (_mock *MockPullRequestsService) Create(po *bitbucket.PullRequestsOptions) (interface{}, error) {
+func (_mock *MockPullRequestsService) Create(po *bitbucket.PullRequestsOptions) (any, error) {
 	ret := _mock.Called(po)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Create")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*bitbucket.PullRequestsOptions) (interface{}, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(*bitbucket.PullRequestsOptions) (any, error)); ok {
 		return returnFunc(po)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*bitbucket.PullRequestsOptions) interface{}); ok {
+	if returnFunc, ok := ret.Get(0).(func(*bitbucket.PullRequestsOptions) any); ok {
 		r0 = returnFunc(po)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(*bitbucket.PullRequestsOptions) error); ok {
@@ -82,34 +82,34 @@ func (_c *MockPullRequestsService_Create_Call) Run(run func(po *bitbucket.PullRe
 	return _c
 }
 
-func (_c *MockPullRequestsService_Create_Call) Return(ifaceVal interface{}, err error) *MockPullRequestsService_Create_Call {
-	_c.Call.Return(ifaceVal, err)
+func (_c *MockPullRequestsService_Create_Call) Return(v any, err error) *MockPullRequestsService_Create_Call {
+	_c.Call.Return(v, err)
 	return _c
 }
 
-func (_c *MockPullRequestsService_Create_Call) RunAndReturn(run func(po *bitbucket.PullRequestsOptions) (interface{}, error)) *MockPullRequestsService_Create_Call {
+func (_c *MockPullRequestsService_Create_Call) RunAndReturn(run func(po *bitbucket.PullRequestsOptions) (any, error)) *MockPullRequestsService_Create_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Gets provides a mock function for the type MockPullRequestsService
-func (_mock *MockPullRequestsService) Gets(po *bitbucket.PullRequestsOptions) (interface{}, error) {
+func (_mock *MockPullRequestsService) Gets(po *bitbucket.PullRequestsOptions) (any, error) {
 	ret := _mock.Called(po)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Gets")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*bitbucket.PullRequestsOptions) (interface{}, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(*bitbucket.PullRequestsOptions) (any, error)); ok {
 		return returnFunc(po)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*bitbucket.PullRequestsOptions) interface{}); ok {
+	if returnFunc, ok := ret.Get(0).(func(*bitbucket.PullRequestsOptions) any); ok {
 		r0 = returnFunc(po)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(*bitbucket.PullRequestsOptions) error); ok {
@@ -138,12 +138,12 @@ func (_c *MockPullRequestsService_Gets_Call) Run(run func(po *bitbucket.PullRequ
 	return _c
 }
 
-func (_c *MockPullRequestsService_Gets_Call) Return(ifaceVal interface{}, err error) *MockPullRequestsService_Gets_Call {
-	_c.Call.Return(ifaceVal, err)
+func (_c *MockPullRequestsService_Gets_Call) Return(v any, err error) *MockPullRequestsService_Gets_Call {
+	_c.Call.Return(v, err)
 	return _c
 }
 
-func (_c *MockPullRequestsService_Gets_Call) RunAndReturn(run func(po *bitbucket.PullRequestsOptions) (interface{}, error)) *MockPullRequestsService_Gets_Call {
+func (_c *MockPullRequestsService_Gets_Call) RunAndReturn(run func(po *bitbucket.PullRequestsOptions) (any, error)) *MockPullRequestsService_Gets_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -176,23 +176,23 @@ func (_m *MockCommitsService) EXPECT() *MockCommitsService_Expecter {
 }
 
 // GetCommits provides a mock function for the type MockCommitsService
-func (_mock *MockCommitsService) GetCommits(cmo *bitbucket.CommitsOptions) (interface{}, error) {
+func (_mock *MockCommitsService) GetCommits(cmo *bitbucket.CommitsOptions) (any, error) {
 	ret := _mock.Called(cmo)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCommits")
 	}
 
-	var r0 interface{}
+	var r0 any
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(*bitbucket.CommitsOptions) (interface{}, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(*bitbucket.CommitsOptions) (any, error)); ok {
 		return returnFunc(cmo)
 	}
-	if returnFunc, ok := ret.Get(0).(func(*bitbucket.CommitsOptions) interface{}); ok {
+	if returnFunc, ok := ret.Get(0).(func(*bitbucket.CommitsOptions) any); ok {
 		r0 = returnFunc(cmo)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(interface{})
+			r0 = ret.Get(0).(any)
 		}
 	}
 	if returnFunc, ok := ret.Get(1).(func(*bitbucket.CommitsOptions) error); ok {
@@ -221,12 +221,12 @@ func (_c *MockCommitsService_GetCommits_Call) Run(run func(cmo *bitbucket.Commit
 	return _c
 }
 
-func (_c *MockCommitsService_GetCommits_Call) Return(ifaceVal interface{}, err error) *MockCommitsService_GetCommits_Call {
-	_c.Call.Return(ifaceVal, err)
+func (_c *MockCommitsService_GetCommits_Call) Return(v any, err error) *MockCommitsService_GetCommits_Call {
+	_c.Call.Return(v, err)
 	return _c
 }
 
-func (_c *MockCommitsService_GetCommits_Call) RunAndReturn(run func(cmo *bitbucket.CommitsOptions) (interface{}, error)) *MockCommitsService_GetCommits_Call {
+func (_c *MockCommitsService_GetCommits_Call) RunAndReturn(run func(cmo *bitbucket.CommitsOptions) (any, error)) *MockCommitsService_GetCommits_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/environments/storage.go
+++ b/internal/server/environments/storage.go
@@ -220,16 +220,15 @@ func (e *EnvironmentStore) Get(ctx context.Context, key string) (Environment, er
 }
 
 // GetFromContext returns the environment identified by name from the context or the default environment if no name is provided.
-func (e *EnvironmentStore) GetFromContext(ctx context.Context) Environment {
+func (e *EnvironmentStore) GetFromContext(ctx context.Context) (Environment, error) {
 	env, ok := common.FliptEnvironmentFromContext(ctx)
 	if ok {
 		ee, err := e.Get(ctx, env)
 		if err != nil {
-			e.logger.Error("failed to get environment from context", zap.String("environment", env), zap.Error(err))
-			return e.defaultEnv
+			return nil, fmt.Errorf("failed to get environment %q from context: %w", env, err)
 		}
-		return ee
+		return ee, nil
 	}
 
-	return e.defaultEnv
+	return e.defaultEnv, nil
 }

--- a/internal/server/evaluation/client/server.go
+++ b/internal/server/evaluation/client/server.go
@@ -43,7 +43,10 @@ func (s *Server) EvaluationSnapshotNamespace(ctx context.Context, r *rpcevaluati
 	if err != nil {
 		// try to get the environment from the context
 		// this is for backwards compatibility with v1
-		env = s.envs.GetFromContext(ctx)
+		env, err = s.envs.GetFromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var (

--- a/internal/server/evaluation/client/server_test.go
+++ b/internal/server/evaluation/client/server_test.go
@@ -79,7 +79,7 @@ func TestServer_EvaluationSnapshotNamespace_EnvNotFound(t *testing.T) {
 
 	mockEnv.On("Key").Return("env-key")
 	envStore.On("Get", mock.Anything, "env-key").Return(nil, errors.New("not found"))
-	envStore.On("GetFromContext", mock.Anything).Return(mockEnv)
+	envStore.On("GetFromContext", mock.Anything).Return(mockEnv, nil)
 
 	expectedSnap := &rpcevaluation.EvaluationNamespaceSnapshot{
 		Digest:    "digest",

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -32,7 +32,10 @@ func (s *Server) Variant(ctx context.Context, r *rpcevaluation.EvaluationRequest
 	if err != nil {
 		// try to get the environment from the context
 		// this is for backwards compatibility with v1
-		env = s.store.GetFromContext(ctx)
+		env, err = s.store.GetFromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	store, err := env.EvaluationStore()
@@ -272,7 +275,10 @@ func (s *Server) Boolean(ctx context.Context, r *rpcevaluation.EvaluationRequest
 	if err != nil {
 		// try to get the environment from the context
 		// this is for backwards compatibility with v1
-		env = s.store.GetFromContext(ctx)
+		env, err = s.store.GetFromContext(ctx)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	store, err := env.EvaluationStore()
@@ -454,7 +460,10 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 		if err != nil {
 			// try to get the environment from the context
 			// this is for backwards compatibility with v1
-			env = s.store.GetFromContext(ctx)
+			env, err = s.store.GetFromContext(ctx)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		store, err := env.EvaluationStore()

--- a/internal/server/evaluation/evaluation_mock.go
+++ b/internal/server/evaluation/evaluation_mock.go
@@ -96,7 +96,7 @@ func (_c *MockEnvironmentStore_Get_Call) RunAndReturn(run func(context1 context.
 }
 
 // GetFromContext provides a mock function for the type MockEnvironmentStore
-func (_mock *MockEnvironmentStore) GetFromContext(context1 context.Context) environments.Environment {
+func (_mock *MockEnvironmentStore) GetFromContext(context1 context.Context) (environments.Environment, error) {
 	ret := _mock.Called(context1)
 
 	if len(ret) == 0 {
@@ -104,6 +104,10 @@ func (_mock *MockEnvironmentStore) GetFromContext(context1 context.Context) envi
 	}
 
 	var r0 environments.Environment
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (environments.Environment, error)); ok {
+		return returnFunc(context1)
+	}
 	if returnFunc, ok := ret.Get(0).(func(context.Context) environments.Environment); ok {
 		r0 = returnFunc(context1)
 	} else {
@@ -111,7 +115,12 @@ func (_mock *MockEnvironmentStore) GetFromContext(context1 context.Context) envi
 			r0 = ret.Get(0).(environments.Environment)
 		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = returnFunc(context1)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
 // MockEnvironmentStore_GetFromContext_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFromContext'
@@ -132,12 +141,12 @@ func (_c *MockEnvironmentStore_GetFromContext_Call) Run(run func(context1 contex
 	return _c
 }
 
-func (_c *MockEnvironmentStore_GetFromContext_Call) Return(environment environments.Environment) *MockEnvironmentStore_GetFromContext_Call {
-	_c.Call.Return(environment)
+func (_c *MockEnvironmentStore_GetFromContext_Call) Return(environment environments.Environment, err error) *MockEnvironmentStore_GetFromContext_Call {
+	_c.Call.Return(environment, err)
 	return _c
 }
 
-func (_c *MockEnvironmentStore_GetFromContext_Call) RunAndReturn(run func(context1 context.Context) environments.Environment) *MockEnvironmentStore_GetFromContext_Call {
+func (_c *MockEnvironmentStore_GetFromContext_Call) RunAndReturn(run func(context1 context.Context) (environments.Environment, error)) *MockEnvironmentStore_GetFromContext_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/server/evaluation/ofrep_bridge.go
+++ b/internal/server/evaluation/ofrep_bridge.go
@@ -29,7 +29,10 @@ const (
 )
 
 func (s *Server) OFREPFlagEvaluation(ctx context.Context, r *ofrep.EvaluateFlagRequest) (*ofrep.EvaluationResponse, error) {
-	env := s.store.GetFromContext(ctx)
+	env, err := s.store.GetFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	store, err := env.EvaluationStore()
 	if err != nil {
@@ -134,7 +137,10 @@ func (s *Server) OFREPFlagEvaluation(ctx context.Context, r *ofrep.EvaluateFlagR
 }
 
 func (s *Server) OFREPFlagEvaluationBulk(ctx context.Context, r *ofrep.EvaluateBulkRequest) (*ofrep.BulkEvaluationResponse, error) {
-	env := s.store.GetFromContext(ctx)
+	env, err := s.store.GetFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	store, err := env.EvaluationStore()
 	if err != nil {

--- a/internal/server/evaluation/ofrep_bridge_test.go
+++ b/internal/server/evaluation/ofrep_bridge_test.go
@@ -34,7 +34,7 @@ func TestOFREPFlagEvaluation_Variant(t *testing.T) {
 
 	environment.On("Key").Return(environmentKey)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(flag, nil)
@@ -107,7 +107,7 @@ func TestOFREPFlagEvaluation_Boolean(t *testing.T) {
 
 	environment.On("Key").Return(environmentKey)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(flag, nil)

--- a/internal/server/evaluation/server.go
+++ b/internal/server/evaluation/server.go
@@ -11,7 +11,7 @@ import (
 
 // EnvironmentStore is the minimal abstraction for interacting with the storage layer for evaluation.
 type EnvironmentStore interface {
-	GetFromContext(context.Context) environments.Environment
+	GetFromContext(context.Context) (environments.Environment, error)
 	Get(context.Context, string) (environments.Environment, error)
 }
 

--- a/internal/server/flag_test.go
+++ b/internal/server/flag_test.go
@@ -31,7 +31,7 @@ func TestListFlags_PaginationOffset(t *testing.T) {
 
 	defer store.AssertExpectations(t)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("ListFlags", mock.Anything, storage.ListWithOptions(storage.NewNamespace(""),
@@ -75,7 +75,7 @@ func TestListFlags_PaginationPageToken(t *testing.T) {
 
 	defer store.AssertExpectations(t)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	store.On("ListFlags", mock.Anything, storage.ListWithOptions(storage.NewNamespace(""),
@@ -129,7 +129,7 @@ func TestListFlags_WithXEnvironmentHeader(t *testing.T) {
 	// Set up context with X-Environment header
 	ctx := common.WithFliptEnvironment(context.Background(), headerEnvironment)
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	// The key assertion: verify that the context passed to ListFlags contains the header environment
@@ -193,7 +193,7 @@ func TestListFlags_WithoutXEnvironmentHeader(t *testing.T) {
 	// Context without X-Environment header
 	ctx := context.Background()
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	// Verify that the context passed to ListFlags contains the request environment
@@ -256,7 +256,7 @@ func TestListFlags_WithTypes(t *testing.T) {
 	// Context without X-Environment header
 	ctx := context.Background()
 
-	envStore.On("GetFromContext", mock.Anything).Return(environment)
+	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
 
 	// Verify that the context passed to ListFlags contains the request environment

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,7 +14,7 @@ var _ flipt.FliptServer = &Server{}
 
 // EnvironmentStore is the minimal abstraction for interacting with the storage layer for evaluation.
 type EnvironmentStore interface {
-	GetFromContext(context.Context) environments.Environment
+	GetFromContext(context.Context) (environments.Environment, error)
 }
 
 // Server serves the Flipt backend
@@ -38,5 +38,9 @@ func (s *Server) RegisterGRPC(server *grpc.Server) {
 }
 
 func (s *Server) getStore(ctx context.Context) (storage.ReadOnlyStore, error) {
-	return s.store.GetFromContext(ctx).EvaluationStore()
+	env, err := s.store.GetFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return env.EvaluationStore()
 }


### PR DESCRIPTION
## Summary

This PR implements the suggestion from #4732 to make `GetFromContext` return an error when a specific environment is requested but not found, instead of silently defaulting to the default environment.

## Changes

- **Modified `internal/server/environments/storage.go`**: Updated `GetFromContext` to return `(Environment, error)` instead of just `Environment`
- **Updated interface definitions**: Modified `EnvironmentStore` interface in `internal/server/server.go` and `internal/server/evaluation/server.go`
- **Updated all call sites**: Modified error handling in:
  - `internal/server/server.go` - getStore method
  - `internal/server/evaluation/evaluation.go` - Variant, Boolean, and Batch methods
  - `internal/server/evaluation/ofrep_bridge.go` - OFREPFlagEvaluation and OFREPFlagEvaluationBulk
  - `internal/server/evaluation/client/server.go` - EvaluationSnapshotNamespace
- **Regenerated mocks**: Updated mock implementations with new signature
- **Updated tests**: Modified all test cases to expect the new error return value

## Behavior

The error is **only** returned when:
- An environment is explicitly specified in the context (e.g., via X-Environment header)
- AND that specific environment cannot be found

When no environment is specified in the context, it still returns the default environment without error, maintaining backward compatibility.

## Testing

- All existing tests pass
- Tests have been updated to handle the new error return
- Linting and formatting checks pass

Implements suggestion from https://github.com/flipt-io/flipt/pull/4732#issuecomment-2460766423

Closes #4732