### PR TITLE
refactor: reduce memory usage with otel and clickhouse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	gopkg.in/segmentio/analytics-go.v3 v3.1.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979
 )
 
 require (
@@ -526,7 +527,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250811160224-6b04f9b4fc78 // indirect
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 // indirect
 	honnef.co/go/tools v0.6.1 // indirect
-	k8s.io/utils v0.0.0-20250502105355-0f33e8f1c979 // indirect
 	mvdan.cc/gofumpt v0.8.0 // indirect
 	mvdan.cc/unparam v0.0.0-20250301125049-0df0534333a4 // indirect
 	pluginrpc.com/pluginrpc v0.5.0 // indirect

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -243,7 +243,7 @@ func NewGRPCServer(
 	var (
 		// legacy services
 		metasrv    = metadata.New(cfg, info)
-		evalsrv    = evaluation.New(logger, environmentStore)
+		evalsrv    = evaluation.New(logger, environmentStore, evaluation.WithTracing(cfg.Tracing.Enabled || cfg.Analytics.Storage.Clickhouse.Enabled))
 		fliptv1srv = serverfliptv1.New(logger, environmentStore)
 		ofrepsrv   = ofrep.New(logger, evalsrv, environmentStore)
 
@@ -335,7 +335,7 @@ func NewGRPCServer(
 	unaryInterceptors = append(unaryInterceptors,
 		append(authUnaryInterceptors,
 			middlewaregrpc.FliptHeadersUnaryInterceptor(logger),
-			middlewaregrpc.EvaluationUnaryInterceptor(cfg.Analytics.Enabled()),
+			middlewaregrpc.EvaluationUnaryInterceptor(),
 		)...,
 	)
 

--- a/internal/server/analytics/sink_test.go
+++ b/internal/server/analytics/sink_test.go
@@ -2,12 +2,12 @@ package analytics
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/server/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -49,16 +49,13 @@ func TestSinkSpanExporter(t *testing.T) {
 		},
 	}
 
-	evaluationResponsesBytes, err := json.Marshal(evaluationResponses)
-	require.NoError(t, err)
-
 	attrs := []attribute.KeyValue{
-		{
-			Key:   "flipt.evaluation.response",
-			Value: attribute.StringValue(string(evaluationResponsesBytes)),
-		},
+		{Key: "flipt_flag", Value: attribute.StringValue("hello")},
+		{Key: "flipt_namespace", Value: attribute.StringValue("default")},
+		{Key: "flipt_reason", Value: attribute.StringValue("MATCH_EVALUATION_REASON")},
+		{Key: "flipt_match", Value: attribute.BoolValue(b)},
 	}
-	span.AddEvent("evaluation_response", trace.WithAttributes(attrs...))
+	span.AddEvent(tracing.Event, trace.WithAttributes(attrs...), trace.WithTimestamp(evaluationResponses[0].Timestamp))
 	span.End()
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -57,24 +57,27 @@ func (s *Server) Variant(ctx context.Context, r *rpcevaluation.EvaluationRequest
 		return nil, err
 	}
 
-	spanAttrs := []attribute.KeyValue{
-		tracing.AttributeEnvironment.String(env.Key()),
-		tracing.AttributeNamespace.String(r.NamespaceKey),
-		tracing.AttributeFlag.String(r.FlagKey),
-		tracing.AttributeEntityID.String(r.EntityId),
-		tracing.AttributeRequestID.String(r.RequestId),
-		tracing.AttributeMatch.Bool(resp.Match),
-		tracing.AttributeValue.String(resp.VariantKey),
-		tracing.AttributeReason.String(resp.Reason.String()),
-		tracing.AttributeSegments.StringSlice(resp.SegmentKeys),
-		tracing.AttributeFlagKey(resp.FlagKey),
-		tracing.AttributeProviderName,
-		tracing.AttributeFlagVariant(resp.VariantKey),
+	if s.tracingEnabled {
+		// add otel attributes to span
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(
+			tracing.AttributeProviderName,
+			tracing.AttributeFlagKey(r.FlagKey),
+			tracing.AttributeFlagVariant(resp.VariantKey),
+		)
+		span.AddEvent(tracing.Event, trace.WithAttributes(
+			tracing.AttributeEnvironment.String(env.Key()),
+			tracing.AttributeNamespace.String(r.NamespaceKey),
+			tracing.AttributeFlag.String(r.FlagKey),
+			tracing.AttributeEntityID.String(r.EntityId),
+			tracing.AttributeRequestID.String(r.RequestId),
+			tracing.AttributeMatch.Bool(resp.Match),
+			tracing.AttributeValue.String(resp.VariantKey),
+			tracing.AttributeReason.String(resp.Reason.String()),
+			tracing.AttributeSegments.StringSlice(resp.SegmentKeys),
+			tracing.AttributeFlagTypeVariant,
+		))
 	}
-
-	// add otel attributes to span
-	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(spanAttrs...)
 
 	return resp, nil
 }
@@ -300,22 +303,25 @@ func (s *Server) Boolean(ctx context.Context, r *rpcevaluation.EvaluationRequest
 		return nil, err
 	}
 
-	spanAttrs := []attribute.KeyValue{
-		tracing.AttributeEnvironment.String(env.Key()),
-		tracing.AttributeNamespace.String(r.NamespaceKey),
-		tracing.AttributeFlag.String(r.FlagKey),
-		tracing.AttributeEntityID.String(r.EntityId),
-		tracing.AttributeRequestID.String(r.RequestId),
-		tracing.AttributeValue.Bool(resp.Enabled),
-		tracing.AttributeReason.String(resp.Reason.String()),
-		tracing.AttributeFlagKey(r.FlagKey),
-		tracing.AttributeProviderName,
-		tracing.AttributeFlagVariant(strconv.FormatBool(resp.Enabled)),
+	if s.tracingEnabled {
+		// add otel attributes to span
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(
+			tracing.AttributeProviderName,
+			tracing.AttributeFlagKey(r.FlagKey),
+			tracing.AttributeFlagVariant(strconv.FormatBool(resp.Enabled)),
+		)
+		span.AddEvent(tracing.Event, trace.WithAttributes(
+			tracing.AttributeEnvironment.String(env.Key()),
+			tracing.AttributeNamespace.String(r.NamespaceKey),
+			tracing.AttributeFlag.String(r.FlagKey),
+			tracing.AttributeEntityID.String(r.EntityId),
+			tracing.AttributeRequestID.String(r.RequestId),
+			tracing.AttributeValue.Bool(resp.Enabled),
+			tracing.AttributeReason.String(resp.Reason.String()),
+			tracing.AttributeFlagTypeBoolean,
+		))
 	}
-
-	// add otel attributes to span
-	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(spanAttrs...)
 
 	return resp, nil
 }

--- a/internal/server/evaluation/server.go
+++ b/internal/server/evaluation/server.go
@@ -17,17 +17,34 @@ type EnvironmentStore interface {
 
 // Server serves the Flipt evaluate v2 gRPC Server.
 type Server struct {
-	logger *zap.Logger
-	store  EnvironmentStore
+	logger         *zap.Logger
+	store          EnvironmentStore
+	tracingEnabled bool
 	evaluation.UnimplementedEvaluationServiceServer
 }
 
+// Option is a functional option for configuring the Server.
+type Option func(*Server)
+
+// WithTracing enables telemetry for the evaluation server.
+func WithTracing(enabled bool) Option {
+	return func(s *Server) {
+		s.tracingEnabled = enabled
+	}
+}
+
 // New is constructs a new Server.
-func New(logger *zap.Logger, store EnvironmentStore) *Server {
-	return &Server{
+func New(logger *zap.Logger, store EnvironmentStore, ops ...Option) *Server {
+	s := &Server{
 		logger: logger,
 		store:  store,
 	}
+
+	for _, o := range ops {
+		o(s)
+	}
+
+	return s
 }
 
 // RegisterGRPC registers the EvaluateServer onto the provided gRPC Server.

--- a/internal/server/middleware/grpc/middleware_test.go
+++ b/internal/server/middleware/grpc/middleware_test.go
@@ -462,7 +462,7 @@ func TestEvaluationUnaryInterceptor_Noop(t *testing.T) {
 		}
 	)
 
-	got, err := EvaluationUnaryInterceptor(false)(context.Background(), req, info, handler)
+	got, err := EvaluationUnaryInterceptor()(context.Background(), req, info, handler)
 	require.NoError(t, err)
 
 	assert.NotNil(t, got)
@@ -553,7 +553,7 @@ func TestEvaluationUnaryInterceptor_EnvironmentAndNamespace(t *testing.T) {
 		)
 
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := EvaluationUnaryInterceptor(false)(ctx, tt.req, info, handler)
+			_, err := EvaluationUnaryInterceptor()(ctx, tt.req, info, handler)
 			require.NoError(t, err)
 		})
 	}
@@ -625,7 +625,7 @@ func TestEvaluationUnaryInterceptor_RequestID(t *testing.T) {
 				}
 			)
 
-			got, err := EvaluationUnaryInterceptor(true)(context.Background(), test.req, info, handler)
+			got, err := EvaluationUnaryInterceptor()(context.Background(), test.req, info, handler)
 			require.NoError(t, err)
 
 			assert.NotNil(t, got)

--- a/internal/server/tracing/attributes.go
+++ b/internal/server/tracing/attributes.go
@@ -1,14 +1,18 @@
 package tracing
 
 import (
+	"go.flipt.io/flipt/rpc/v2/evaluation"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 )
+
+const Event = "flipt_flag_evaluated"
 
 // TODO: merge with metrics?
 var (
 	AttributeMatch       = attribute.Key("flipt_match")
 	AttributeFlag        = attribute.Key("flipt_flag")
+	AttributeFlagType    = attribute.Key("flipt_flag_type")
 	AttributeEnvironment = attribute.Key("flipt_environment")
 	AttributeNamespace   = attribute.Key("flipt_namespace")
 	AttributeFlagEnabled = attribute.Key("flipt_flag_enabled")
@@ -22,7 +26,9 @@ var (
 // Specific attributes for Semantic Conventions for Feature Flags in Spans
 // https://opentelemetry.io/docs/specs/semconv/feature-flags/feature-flags-spans/
 var (
-	AttributeFlagKey      = semconv.FeatureFlagKey
-	AttributeProviderName = semconv.FeatureFlagProviderName("Flipt")
-	AttributeFlagVariant  = semconv.FeatureFlagResultVariant
+	AttributeFlagKey         = semconv.FeatureFlagKey
+	AttributeProviderName    = semconv.FeatureFlagProviderName("Flipt")
+	AttributeFlagVariant     = semconv.FeatureFlagResultVariant
+	AttributeFlagTypeVariant = AttributeFlagType.String(evaluation.EvaluationFlagType_VARIANT_FLAG_TYPE.String())
+	AttributeFlagTypeBoolean = AttributeFlagType.String(evaluation.EvaluationFlagType_BOOLEAN_FLAG_TYPE.String())
 )


### PR DESCRIPTION
This pull request refactors how evaluation telemetry is handled, simplifying the tracing and analytics integration throughout the evaluation server and middleware. The main changes are the removal of legacy analytics event marshaling, the introduction of use of OpenTelemetry attributes and events for evaluation responses. This streamlines span event creation and makes tracing configuration more explicit and flexible.
