### PR TITLE
fix: update release prompt to extract changelog from CHANGELOG.md

### DIFF
--- a/.github/prompts/release.md
+++ b/.github/prompts/release.md
@@ -1,15 +1,20 @@
-Write the release notes for this release.
+Extract and format the release notes for this specific release.
 
 ## Instructions
 
-- do not use emojis
-- write short summary featuring the 2 or 3 most exciting or user-impacting changes, if it makes sense to do so.
-- keep dependency updates brief unless they're security-related or major version changes
-- respond WITH ONLY THE GENERATED RELEASE NOTES, NOTHING ELSE.
-- format the response as markdown
-- do not change the original commit messages
+1. Read the CHANGELOG.md file from the project root
+2. Find the section that corresponds to version {{.Tag}} (without the 'v' prefix if present)
+3. Extract ONLY the content for that specific version:
+   - Start after the version heading line
+   - Stop before the next version heading or end of file
+   - Include all subsections (### Added, ### Fixed, ### Changed, ### Dependencies, etc.)
+4. Return ONLY the extracted content, preserving the exact formatting
+5. Do NOT include the version heading line itself (the line with ## [version])
+6. Do NOT include any content from other versions
+7. Do NOT add any additional commentary or formatting
+8. If version {{.Tag}} is not found in CHANGELOG.md, return "Release notes for version {{.Tag}} not found in CHANGELOG.md"
 
-## Some details about this release
+## Version Information
 
 Project name: {{.ProjectName}}
 Git repository URL: {{.GitURL}}
@@ -22,9 +27,3 @@ Version: {{.Tag}}
 {{ end }}
 {{ if .IsSnapshot }}This is a snapshot build.{{ end }}
 {{ if .IsNightly }}This is a nightly build.{{ end }}
-{{ with .TagSubject }}Tag subject: {{ . }}{{ end }}
-{{ with .TagContents }}Tag content: {{ . }}{{ end }}
-
-## Release notes
-
-{{ .ReleaseNotes }}


### PR DESCRIPTION
## Summary

Updates the release prompt to correctly extract release notes from the CHANGELOG.md file instead of using goreleaser's commit-based changelog generation.

## Problem

The current release prompt was designed to work with goreleaser's automatic commit-based changelog generation, but we maintain a manual CHANGELOG.md file. At release time, we want to extract just the specific version's content from CHANGELOG.md, not generate notes from git commits.

## Solution

Modified `.github/prompts/release.md` to:
- Read the CHANGELOG.md file from the project root
- Find and extract only the specific version section
- Preserve exact formatting from the CHANGELOG
- Handle version tags with or without 'v' prefix

## Changes

- **Modified `.github/prompts/release.md`**: Updated prompt to extract content from CHANGELOG.md instead of using `.ReleaseNotes` variable

## Testing

The prompt will now:
1. Look for the version section in CHANGELOG.md (e.g., `## [2.1.2]`)
2. Extract everything between that heading and the next version
3. Return only that version's content with subsections intact