### PR TITLE
fix: use static v2-nightly version for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,10 +60,6 @@ jobs:
       - name: Prep Build
         run: mage prep
 
-      # - name: Git Tag
-      #   run: |
-      #     echo "GORELEASER_CURRENT_TAG=$(git describe --tags --match='v[0-9]*' `git rev-list --tags --max-count=1`)" >> $GITHUB_ENV
-
       - name: GoReleaser (Nightly) Build
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -44,8 +44,8 @@ release:
   target_commitish: "{{ .Commit }}"
 
 nightly:
-  # Default is `{{ incpatch .Version }}-{{ .ShortCommit }}-nightly`.
-  version_template: "v{{ incpatch .Version }}-nightly"
+  # Static v2-nightly version for all nightly builds from v2 branch
+  version_template: "v2-nightly"
 
 changelog:
   disable: true

--- a/README.md
+++ b/README.md
@@ -137,6 +137,19 @@ docker run --rm -p 8080:8080 -p 9000:9000 -t docker.flipt.io/flipt/flipt:v2
 
 Flipt UI will be available at [http://127.0.0.1:8080/](http://127.0.0.1:8080).
 
+#### Nightly Builds
+
+> [!WARNING]  
+> Nightly builds are automatically generated from the latest v2 branch and should not be considered stable for production use.
+
+To run the latest nightly build:
+
+```bash
+docker run --rm -p 8080:8080 -p 9000:9000 -t docker.flipt.io/flipt/flipt:v2-nightly
+```
+
+Nightly builds include the latest features and bug fixes but may contain untested changes. Use them for testing new features or verifying bug fixes before the next stable release.
+
 ### Configuration Example
 
 ```yaml


### PR DESCRIPTION
## Summary

Simplifies the nightly build versioning to avoid confusion when determining the latest v2 tag.

## Problem

The nightly GitHub Action was incorrectly detecting `v2.1.0` as the latest tag instead of `v2.1.2`. This happened because:
- The `v2.1.1` and `v2.1.2` tags were created on the `release/2.1` branch
- The nightly workflow checks out the `v2` branch
- GoReleaser's `git describe` only finds tags that are ancestors of the current HEAD

This caused nightly builds to create confusing versions like `v2.1.1-nightly` when we already had `v2.1.2` released.

## Solution

Use a static `v2-nightly` version for all nightly builds from the v2 branch. This:
- Removes the need to determine the "latest" tag
- Avoids confusion when tags are created on different branches
- Provides a consistent, predictable version for nightly builds

## Changes

- **Modified `.goreleaser.nightly.yml`**: Changed `version_template` to use static `"v2-nightly"` instead of incrementing from the latest version
- **Modified `.github/workflows/nightly.yml`**: Removed unnecessary tag fetching logic that was commented out

## Testing

The nightly builds will now consistently produce artifacts versioned as `v2-nightly` regardless of the tag structure in the repository.