### PR TITLE
fix: read CHANGELOG.md from tagged commit during release

### DIFF
--- a/.github/prompts/release.md
+++ b/.github/prompts/release.md
@@ -2,7 +2,9 @@ Extract and format the release notes for this specific release.
 
 ## Instructions
 
-1. Read the CHANGELOG.md file from the project root
+1. IMPORTANT: Read the CHANGELOG.md file from the Git tag being released ({{.Tag}}), NOT from the current branch
+   - Use the command: `git show {{.Tag}}:CHANGELOG.md` to get the CHANGELOG.md content from the tagged commit
+   - This ensures we get the exact changelog content that was part of the release, not any subsequent changes
 2. Find the section that corresponds to version {{.Tag}} (without the 'v' prefix if present)
 3. Extract ONLY the content for that specific version:
    - Start after the version heading line


### PR DESCRIPTION
## Summary

Fixes the issue where release announcements were reading the CHANGELOG.md from the wrong commit, resulting in incorrect or missing release notes.

## Changes

- **Modified `.github/prompts/release.md`**: Updated the AI prompt to explicitly read CHANGELOG.md from the tagged commit using `git show {{.Tag}}:CHANGELOG.md` instead of reading from the current working directory

## Problem

The previous implementation (from PR #4757) was reading the CHANGELOG.md from the current branch state during the release process. This caused issues when:
1. The CHANGELOG.md was updated after creating the release tag
2. The release workflow ran from a different branch state than the tagged commit

## Solution

The AI prompt now explicitly instructs to read the CHANGELOG.md content from the specific Git tag being released, ensuring the release notes always match the actual release content.

## Additional Notes

This ensures consistency between the tagged release and its announcement, preventing confusion when the changelog is updated post-tagging.