### PR TITLE
refactor(otel): align event and attribute names with OTEL spec

### DIFF
--- a/internal/server/analytics/sink.go
+++ b/internal/server/analytics/sink.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.flipt.io/flipt/internal/server/tracing"
+	"go.flipt.io/flipt/rpc/v2/evaluation"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/zap"
@@ -63,7 +64,12 @@ func transformSpanEventToEvaluationResponses(event sdktrace.Event) ([]*Evaluatio
 		case tracing.AttributeFlag:
 			r.FlagKey = v.Value.AsString()
 		case tracing.AttributeFlagType:
-			r.FlagType = v.Value.AsString()
+			switch v {
+			case tracing.AttributeFlagTypeVariant:
+				r.FlagType = evaluation.EvaluationFlagType_VARIANT_FLAG_TYPE.String()
+			case tracing.AttributeFlagTypeBoolean:
+				r.FlagType = evaluation.EvaluationFlagType_BOOLEAN_FLAG_TYPE.String()
+			}
 		case tracing.AttributeEntityID:
 			r.EntityId = v.Value.AsString()
 		case tracing.AttributeMatch:
@@ -71,8 +77,8 @@ func transformSpanEventToEvaluationResponses(event sdktrace.Event) ([]*Evaluatio
 				r.Match = ptr.To(v.Value.AsBool())
 			}
 		case tracing.AttributeReason:
-			r.Reason = v.Value.AsString()
-		case tracing.AttributeValue:
+			r.Reason = tracing.ReasonFromValue(v.Value.AsString()).String()
+		case tracing.AttributeVariant:
 			r.EvaluationValue = ptr.To(v.Value.AsString())
 		}
 	}

--- a/internal/server/analytics/sink_test.go
+++ b/internal/server/analytics/sink_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/flipt/internal/server/tracing"
+	"go.flipt.io/flipt/rpc/v2/evaluation"
 	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -50,10 +51,11 @@ func TestSinkSpanExporter(t *testing.T) {
 	}
 
 	attrs := []attribute.KeyValue{
-		{Key: "flipt_flag", Value: attribute.StringValue("hello")},
-		{Key: "flipt_namespace", Value: attribute.StringValue("default")},
-		{Key: "flipt_reason", Value: attribute.StringValue("MATCH_EVALUATION_REASON")},
-		{Key: "flipt_match", Value: attribute.BoolValue(b)},
+		{Key: "flipt.key", Value: attribute.StringValue("hello")},
+		{Key: "flipt.type", Value: attribute.StringValue("variant")},
+		{Key: "flipt.namespace", Value: attribute.StringValue("default")},
+		{Key: "flipt.result.reason", Value: attribute.StringValue("match")},
+		{Key: "flipt.result.match", Value: attribute.BoolValue(b)},
 	}
 	span.AddEvent(tracing.Event, trace.WithAttributes(attrs...), trace.WithTimestamp(evaluationResponses[0].Timestamp))
 	span.End()
@@ -70,6 +72,7 @@ func TestSinkSpanExporter(t *testing.T) {
 		assert.Equal(t, evaluationResponses[0].Reason, evaluationResponseActual.Reason)
 		assert.Equal(t, *evaluationResponses[0].Match, *evaluationResponseActual.Match)
 		assert.Equal(t, evaluationResponses[0].Timestamp, evaluationResponseActual.Timestamp)
+		assert.Equal(t, evaluation.EvaluationFlagType_VARIANT_FLAG_TYPE.String(), evaluationResponseActual.FlagType)
 	case <-timeoutCtx.Done():
 		require.Fail(t, "message should have been sent on the channel")
 	}

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -60,11 +60,6 @@ func (s *Server) Variant(ctx context.Context, r *rpcevaluation.EvaluationRequest
 	if s.tracingEnabled {
 		// add otel attributes to span
 		span := trace.SpanFromContext(ctx)
-		span.SetAttributes(
-			tracing.AttributeProviderName,
-			tracing.AttributeFlagKey(r.FlagKey),
-			tracing.AttributeFlagVariant(resp.VariantKey),
-		)
 		span.AddEvent(tracing.Event, trace.WithAttributes(
 			tracing.AttributeEnvironment.String(env.Key()),
 			tracing.AttributeNamespace.String(r.NamespaceKey),
@@ -72,8 +67,8 @@ func (s *Server) Variant(ctx context.Context, r *rpcevaluation.EvaluationRequest
 			tracing.AttributeEntityID.String(r.EntityId),
 			tracing.AttributeRequestID.String(r.RequestId),
 			tracing.AttributeMatch.Bool(resp.Match),
-			tracing.AttributeValue.String(resp.VariantKey),
-			tracing.AttributeReason.String(resp.Reason.String()),
+			tracing.AttributeVariant.String(resp.VariantKey),
+			tracing.AttributeReason.String(tracing.ReasonToValue(resp.Reason)),
 			tracing.AttributeSegments.StringSlice(resp.SegmentKeys),
 			tracing.AttributeFlagTypeVariant,
 		))
@@ -306,19 +301,14 @@ func (s *Server) Boolean(ctx context.Context, r *rpcevaluation.EvaluationRequest
 	if s.tracingEnabled {
 		// add otel attributes to span
 		span := trace.SpanFromContext(ctx)
-		span.SetAttributes(
-			tracing.AttributeProviderName,
-			tracing.AttributeFlagKey(r.FlagKey),
-			tracing.AttributeFlagVariant(strconv.FormatBool(resp.Enabled)),
-		)
 		span.AddEvent(tracing.Event, trace.WithAttributes(
 			tracing.AttributeEnvironment.String(env.Key()),
 			tracing.AttributeNamespace.String(r.NamespaceKey),
 			tracing.AttributeFlag.String(r.FlagKey),
 			tracing.AttributeEntityID.String(r.EntityId),
 			tracing.AttributeRequestID.String(r.RequestId),
-			tracing.AttributeValue.Bool(resp.Enabled),
-			tracing.AttributeReason.String(resp.Reason.String()),
+			tracing.AttributeVariant.Bool(resp.Enabled),
+			tracing.AttributeReason.String(tracing.ReasonToValue(resp.Reason)),
 			tracing.AttributeSegments.StringSlice(resp.SegmentKeys),
 			tracing.AttributeFlagTypeBoolean,
 		))

--- a/internal/server/evaluation/ofrep_bridge.go
+++ b/internal/server/evaluation/ofrep_bridge.go
@@ -70,18 +70,13 @@ func (s *Server) OFREPFlagEvaluation(ctx context.Context, r *ofrep.EvaluateFlagR
 
 		if s.tracingEnabled {
 			span := trace.SpanFromContext(ctx)
-			span.SetAttributes(
-				tracing.AttributeProviderName,
-				tracing.AttributeFlagKey(r.Key),
-				tracing.AttributeFlagVariant(resp.VariantKey),
-			)
 			span.AddEvent(tracing.Event, trace.WithAttributes(
 				tracing.AttributeEnvironment.String(env.Key()),
 				tracing.AttributeNamespace.String(namespaceKey),
 				tracing.AttributeFlag.String(r.Key),
 				tracing.AttributeMatch.Bool(resp.Match),
-				tracing.AttributeValue.String(resp.VariantKey),
-				tracing.AttributeReason.String(resp.Reason.String()),
+				tracing.AttributeVariant.String(resp.VariantKey),
+				tracing.AttributeReason.String(tracing.ReasonToValue(resp.Reason)),
 				tracing.AttributeSegments.StringSlice(resp.SegmentKeys),
 				tracing.AttributeFlagTypeVariant,
 			))
@@ -118,17 +113,12 @@ func (s *Server) OFREPFlagEvaluation(ctx context.Context, r *ofrep.EvaluateFlagR
 
 		if s.tracingEnabled {
 			span := trace.SpanFromContext(ctx)
-			span.SetAttributes(
-				tracing.AttributeProviderName,
-				tracing.AttributeFlagKey(r.Key),
-				tracing.AttributeFlagVariant(strconv.FormatBool(resp.Enabled)),
-			)
 			span.AddEvent(tracing.Event, trace.WithAttributes(
 				tracing.AttributeEnvironment.String(env.Key()),
 				tracing.AttributeNamespace.String(namespaceKey),
 				tracing.AttributeFlag.String(r.Key),
-				tracing.AttributeValue.Bool(resp.Enabled),
-				tracing.AttributeReason.String(resp.Reason.String()),
+				tracing.AttributeVariant.Bool(resp.Enabled),
+				tracing.AttributeReason.String(tracing.ReasonToValue(resp.Reason)),
 				tracing.AttributeSegments.StringSlice(resp.SegmentKeys),
 				tracing.AttributeFlagTypeBoolean,
 			))

--- a/internal/server/tracing/attributes.go
+++ b/internal/server/tracing/attributes.go
@@ -1,34 +1,46 @@
 package tracing
 
 import (
-	"go.flipt.io/flipt/rpc/v2/evaluation"
+	"go.flipt.io/flipt/rpc/flipt/evaluation"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 )
 
-const Event = "flipt_flag_evaluated"
+const Event = "flipt.flag_evaluation"
 
-// TODO: merge with metrics?
 var (
-	AttributeMatch       = attribute.Key("flipt_match")
-	AttributeFlag        = attribute.Key("flipt_flag")
-	AttributeFlagType    = attribute.Key("flipt_flag_type")
-	AttributeEnvironment = attribute.Key("flipt_environment")
-	AttributeNamespace   = attribute.Key("flipt_namespace")
-	AttributeFlagEnabled = attribute.Key("flipt_flag_enabled")
-	AttributeSegments    = attribute.Key("flipt_segments")
-	AttributeReason      = attribute.Key("flipt_reason")
-	AttributeValue       = attribute.Key("flipt_value")
-	AttributeEntityID    = attribute.Key("flipt_entity_id")
-	AttributeRequestID   = attribute.Key("flipt_request_id")
+	AttributeFlag            = attribute.Key("flipt.key")
+	AttributeFlagType        = attribute.Key("flipt.type")
+	AttributeEnvironment     = attribute.Key("flipt.environment")
+	AttributeNamespace       = attribute.Key("flipt.namespace")
+	AttributeSegments        = attribute.Key("flipt.result.segments")
+	AttributeReason          = attribute.Key("flipt.result.reason")
+	AttributeVariant         = attribute.Key("flipt.result.variant")
+	AttributeMatch           = attribute.Key("flipt.result.match")
+	AttributeEntityID        = attribute.Key("flipt.context.entity_id")
+	AttributeRequestID       = attribute.Key("flipt.context.request_id")
+	AttributeFlagTypeVariant = AttributeFlagType.String("variant")
+	AttributeFlagTypeBoolean = AttributeFlagType.String("boolean")
 )
 
-// Specific attributes for Semantic Conventions for Feature Flags in Spans
-// https://opentelemetry.io/docs/specs/semconv/feature-flags/feature-flags-spans/
 var (
-	AttributeFlagKey         = semconv.FeatureFlagKey
-	AttributeProviderName    = semconv.FeatureFlagProviderName("Flipt")
-	AttributeFlagVariant     = semconv.FeatureFlagResultVariant
-	AttributeFlagTypeVariant = AttributeFlagType.String(evaluation.EvaluationFlagType_VARIANT_FLAG_TYPE.String())
-	AttributeFlagTypeBoolean = AttributeFlagType.String(evaluation.EvaluationFlagType_BOOLEAN_FLAG_TYPE.String())
+	evaluationReasonToValues = map[evaluation.EvaluationReason]string{
+		evaluation.EvaluationReason_UNKNOWN_EVALUATION_REASON:       "unknown",
+		evaluation.EvaluationReason_FLAG_DISABLED_EVALUATION_REASON: "disabled",
+		evaluation.EvaluationReason_MATCH_EVALUATION_REASON:         "match",
+		evaluation.EvaluationReason_DEFAULT_EVALUATION_REASON:       "default",
+	}
+	evaluationReasonToNames = map[string]evaluation.EvaluationReason{
+		"unknown":  evaluation.EvaluationReason_UNKNOWN_EVALUATION_REASON,
+		"disabled": evaluation.EvaluationReason_FLAG_DISABLED_EVALUATION_REASON,
+		"match":    evaluation.EvaluationReason_MATCH_EVALUATION_REASON,
+		"default":  evaluation.EvaluationReason_DEFAULT_EVALUATION_REASON,
+	}
 )
+
+func ReasonToValue(reason evaluation.EvaluationReason) string {
+	return evaluationReasonToValues[reason]
+}
+
+func ReasonFromValue(vallue string) evaluation.EvaluationReason {
+	return evaluationReasonToNames[vallue]
+}

--- a/internal/server/tracing/attributes.go
+++ b/internal/server/tracing/attributes.go
@@ -42,5 +42,5 @@ func ReasonToValue(reason evaluation.EvaluationReason) string {
 }
 
 func ReasonFromValue(value string) evaluation.EvaluationReason {
-	return evaluationReasonToNames[vallue]
+	return evaluationReasonToNames[value]
 }

--- a/internal/server/tracing/attributes.go
+++ b/internal/server/tracing/attributes.go
@@ -41,6 +41,6 @@ func ReasonToValue(reason evaluation.EvaluationReason) string {
 	return evaluationReasonToValues[reason]
 }
 
-func ReasonFromValue(vallue string) evaluation.EvaluationReason {
+func ReasonFromValue(value string) evaluation.EvaluationReason {
 	return evaluationReasonToNames[vallue]
 }

--- a/internal/server/tracing/attributes_test.go
+++ b/internal/server/tracing/attributes_test.go
@@ -1,0 +1,18 @@
+package tracing_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.flipt.io/flipt/internal/server/tracing"
+	"go.flipt.io/flipt/rpc/flipt/evaluation"
+)
+
+func TestReasonTransformation(t *testing.T) {
+	for _, r := range evaluation.EvaluationReason_value {
+		reason := evaluation.EvaluationReason(r)
+		value := tracing.ReasonToValue(reason)
+		got := tracing.ReasonFromValue(value)
+		assert.Equal(t, reason, got)
+	}
+}


### PR DESCRIPTION
This pull request refactors how OpenTelemetry tracing attributes are named and handled for flag evaluation events, aligning them with a more consistent and descriptive naming convention. It also introduces explicit transformation functions for evaluation reasons, ensures correct flag type handling, and updates related tests accordingly.

The event name isn't well-defined and is subject to change at the moment. I followed the same style that OpenFeature uses. I also created a discussion about this issue in the `opentelemetry-demo` repo, since the project currently uses different styles across its services. I hope to get some guidance on this topic.

I've removed the code that added extra `feature_flag.*` attributes to the span in favor of using a span event. If there are multiple evaluations during a call (such as in a `batch` or `ofrep.bulk` operation) those attributes only store data about the last evaluation. I think the `feature_flag.*` attributes are better used on the client side, or in the app that’s using the Flipt or OpenFeature SDKs.
