### PR TITLE
fix(environments): remove deleted branches from UI when synced from Git

### DIFF
--- a/build/main.go
+++ b/build/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"dagger.io/dagger/dag"
 	"github.com/containerd/platforms"
 	"go.flipt.io/build/internal"
 	"go.flipt.io/build/internal/dagger"

--- a/build/main.go
+++ b/build/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"dagger.io/dagger/dag"
 	"github.com/containerd/platforms"
 	"go.flipt.io/build/internal"
 	"go.flipt.io/build/internal/dagger"

--- a/build/main.go
+++ b/build/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/containerd/platforms"
 	"go.flipt.io/build/internal"
+	"go.flipt.io/build/internal/dagger"
 	"go.flipt.io/build/testing"
 )
 

--- a/build/main.go
+++ b/build/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/containerd/platforms"
 	"go.flipt.io/build/internal"
-	"go.flipt.io/build/internal/dagger"
 	"go.flipt.io/build/testing"
 )
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -383,6 +383,9 @@ cloud.google.com/go/workflows v1.14.2/go.mod h1:5nqKjMD+MsJs41sJhdVrETgvD5cOK3hU
 code.gitea.io/gitea-vet v0.2.1 h1:b30by7+3SkmiftK0RjuXqFvZg2q4p68uoPGuxhzBN0s=
 code.gitea.io/gitea-vet v0.2.1/go.mod h1:zcNbT/aJEmivCAhfmkHOlT645KNOf9W2KnkLgFjGGfE=
 code.gitea.io/sdk/gitea v0.15.1/go.mod h1:klY2LVI3s3NChzIk/MzMn7G1FHrfU7qd63iSMVoHRBA=
+codeberg.org/go-fonts/liberation v0.5.0/go.mod h1:zS/2e1354/mJ4pGzIIaEtm/59VFCFnYC7YV6YdGl5GU=
+codeberg.org/go-latex/latex v0.1.0/go.mod h1:LA0q/AyWIYrqVd+A9Upkgsb+IqPcmSTKc9Dny04MHMw=
+codeberg.org/go-pdf/fpdf v0.10.0/go.mod h1:Y0DGRAdZ0OmnZPvjbMp/1bYxmIPxm0ws4tfoPOc4LjU=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20230502192102-15967c811cec h1:CSNP8nIEQt4sZEo2sGUiWSmVJ9c5QdyIQvwzZAsn+8Y=
 contrib.go.opencensus.io/exporter/aws v0.0.0-20230502192102-15967c811cec/go.mod h1:uu1P0UCM/6RbsMrgPa98ll8ZcHM858i/AD06a9aLRCA=
 contrib.go.opencensus.io/exporter/stackdriver v0.13.4/go.mod h1:aXENhDJ1Y4lIg4EUaVTwzvYETVNZk10Pu26tevFKLUc=
@@ -401,6 +404,7 @@ filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 gioui.org v0.0.0-20210308172011-57750fc8a0a6 h1:K72hopUosKG3ntOPNG4OzzbuhxGuVf06fa2la1/H/Ho=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 git.sr.ht/~sbinet/gg v0.3.1 h1:LNhjNn8DerC8f9DHLz6lS0YYul/b602DUxDgGkd/Aik=
+git.sr.ht/~sbinet/gg v0.6.0/go.mod h1:uucygbfC9wVPQIfrmwM2et0imr8L7KQWywX0xpFMm94=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
 github.com/99designs/keyring v1.2.1 h1:tYLp1ULvO7i3fI5vE21ReQuj99QFSs7lGm0xWyJo87o=
@@ -507,6 +511,7 @@ github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/bwesterb/go-ristretto v1.2.3 h1:1w53tCkGhCQ5djbat3+MH0BAQ5Kfgbt56UZQ/JMzngw=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
+github.com/campoy/embedmd v1.0.0/go.mod h1:oxyr9RCiSXg0M3VJ3ks0UGfp98BpSSGr0kpiX3MzVl8=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
@@ -627,6 +632,7 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gobuffalo/here v0.6.0 h1:hYrd0a6gDmWxBM4TnrGw8mQg24iSVoIkHEk7FodQcBI=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
+github.com/goccmack/gocc v0.0.0-20230228185258-2292f9e40198/go.mod h1:DTh/Y2+NbnOVVoypCCQrovMPDKUGp4yZpSbWg5D0XIM=
 github.com/goccy/go-json v0.9.11 h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gocql/gocql v0.0.0-20210515062232-b7ef815b4556 h1:N/MD/sr6o61X+iZBAT2qEUF023s4KbA8RWfKzl0L6MQ=
@@ -1140,6 +1146,7 @@ golang.org/x/exp v0.0.0-20250531010427-b6e5de432a8b/go.mod h1:U6Lno4MTRCDY+Ba7aC
 golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476 h1:bsqhLWFR6G6xiQcb+JoGqdKdRU6WzPWmK8E0jxTjzo4=
 golang.org/x/exp v0.0.0-20250606033433-dcc06ee1d476/go.mod h1:3//PLf8L/X+8b4vuAfHzxeRUl04Adcb341+IGKfnqS8=
 golang.org/x/image v0.0.0-20220302094943-723b81ca9867 h1:TcHcE0vrmgzNH1v3ppjcMGbhG5+9fMuvOmUYwNEF4q4=
+golang.org/x/image v0.25.0/go.mod h1:tCAmOEGthTtkalusGp1g3xa2gke8J6c2N565dTyl9Rs=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 h1:4+4C/Iv2U4fMZBiMCc98MG1In4gJY5YRhtpDNeDeHWs=
@@ -1263,6 +1270,7 @@ golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/
 gonum.org/v1/gonum v0.11.0 h1:f1IJhK4Km5tBJmaiJXtk/PkL4cdVX6J+tGiM187uT5E=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/plot v0.10.1 h1:dnifSs43YJuNMDzB7v8wV64O4ABBHReuAVAoBxqBqS4=
+gonum.org/v1/plot v0.15.2/go.mod h1:DX+x+DWso3LTha+AdkJEv5Txvi+Tql3KAGkehP0/Ubg=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.1.0/go.mod h1:UGEZY7KEX120AnNLIHFMKIo4obdJhkp2tPbaPlQx13Y=

--- a/internal/server/environments/storage.go
+++ b/internal/server/environments/storage.go
@@ -153,6 +153,13 @@ func (e *EnvironmentStore) Add(env Environment) {
 	e.byKey[env.Key()] = env
 }
 
+func (e *EnvironmentStore) Remove(key string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	delete(e.byKey, key)
+}
+
 func (e *EnvironmentStore) DeleteBranch(ctx context.Context, base, branch string) error {
 	baseEnv, err := e.Get(ctx, base)
 	if err != nil {

--- a/internal/storage/environments/environments.go
+++ b/internal/storage/environments/environments.go
@@ -498,6 +498,9 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config, secre
 						envStore.Add(e)
 					}
 					for _, key := range result.DeletedBranchKeys {
+						logger.Debug("removing environment from store",
+							zap.String("key", key),
+						)
 						envStore.Remove(key)
 					}
 					return nil

--- a/internal/storage/environments/environments.go
+++ b/internal/storage/environments/environments.go
@@ -498,9 +498,6 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config, secre
 						envStore.Add(e)
 					}
 					for _, key := range result.DeletedBranchKeys {
-						logger.Debug("removing environment from store",
-							zap.String("key", key),
-						)
 						envStore.Remove(key)
 					}
 					return nil

--- a/internal/storage/environments/environments.go
+++ b/internal/storage/environments/environments.go
@@ -442,7 +442,7 @@ func (s *environmentSubscriber) Notify(ctx context.Context, refs map[string]stri
 
 type repoEnv interface {
 	Repository() *storagegit.Repository
-	RefreshEnvironment(context.Context, map[string]string) ([]serverconfig.Environment, []string, error)
+	RefreshEnvironment(context.Context, map[string]string) (*environmentsgit.RefreshResult, error)
 	Branches() []string
 }
 
@@ -490,14 +490,14 @@ func NewStore(ctx context.Context, logger *zap.Logger, cfg *config.Config, secre
 					return gitEnv.Branches()
 				},
 				notifyFn: func(ctx context.Context, refs map[string]string) error {
-					newEnvs, deletedKeys, err := gitEnv.RefreshEnvironment(ctx, refs)
+					result, err := gitEnv.RefreshEnvironment(ctx, refs)
 					if err != nil {
 						return err
 					}
-					for _, e := range newEnvs {
+					for _, e := range result.NewBranches {
 						envStore.Add(e)
 					}
-					for _, key := range deletedKeys {
+					for _, key := range result.DeletedBranchKeys {
 						envStore.Remove(key)
 					}
 					return nil

--- a/internal/storage/environments/git/store.go
+++ b/internal/storage/environments/git/store.go
@@ -717,9 +717,11 @@ func (e *Environment) RefreshEnvironment(ctx context.Context, refs map[string]st
 	e.mu.Lock()
 	for branchName := range e.branches {
 		if _, exists := existingBranches[branchName]; !exists {
+			env := e.branches[branchName]
 			e.logger.Debug("removing deleted branch from cache",
 				zap.String("environment", e.cfg.Name),
 				zap.String("branch", branchName),
+				zap.String("environment_key", env.Key()),
 			)
 			delete(e.branches, branchName)
 			delete(e.refs, fmt.Sprintf("flipt/%s/%s", e.cfg.Name, branchName))

--- a/internal/storage/environments/git/store.go
+++ b/internal/storage/environments/git/store.go
@@ -653,15 +653,7 @@ func (e *Environment) RefreshEnvironment(ctx context.Context, refs map[string]st
 	// Track which branches still exist in Git
 	existingBranches := make(map[string]struct{})
 
-	e.logger.Debug("scanning for branch environments in Git",
-		zap.String("base_environment", e.cfg.Name),
-	)
-
 	for cfg := range iterator.All() {
-		e.logger.Debug("found branch in Git",
-			zap.String("branch_name", cfg.Name),
-			zap.String("git_branch", cfg.branch),
-		)
 		existingBranches[cfg.Name] = struct{}{}
 
 		e.mu.RLock()
@@ -723,18 +715,11 @@ func (e *Environment) RefreshEnvironment(ctx context.Context, refs map[string]st
 
 	// Remove branches that no longer exist in Git
 	e.mu.Lock()
-	e.logger.Debug("checking for deleted branches",
-		zap.String("base_environment", e.cfg.Name),
-		zap.Int("cached_branches", len(e.branches)),
-		zap.Int("git_branches", len(existingBranches)),
-	)
 	for branchName := range e.branches {
 		if _, exists := existingBranches[branchName]; !exists {
-			env := e.branches[branchName]
 			e.logger.Debug("removing deleted branch from cache",
 				zap.String("environment", e.cfg.Name),
 				zap.String("branch", branchName),
-				zap.String("environment_key", env.Key()),
 			)
 			delete(e.branches, branchName)
 			delete(e.refs, fmt.Sprintf("flipt/%s/%s", e.cfg.Name, branchName))

--- a/internal/storage/environments/git/store.go
+++ b/internal/storage/environments/git/store.go
@@ -653,7 +653,15 @@ func (e *Environment) RefreshEnvironment(ctx context.Context, refs map[string]st
 	// Track which branches still exist in Git
 	existingBranches := make(map[string]struct{})
 
+	e.logger.Debug("scanning for branch environments in Git",
+		zap.String("base_environment", e.cfg.Name),
+	)
+
 	for cfg := range iterator.All() {
+		e.logger.Debug("found branch in Git",
+			zap.String("branch_name", cfg.Name),
+			zap.String("git_branch", cfg.branch),
+		)
 		existingBranches[cfg.Name] = struct{}{}
 
 		e.mu.RLock()
@@ -715,6 +723,11 @@ func (e *Environment) RefreshEnvironment(ctx context.Context, refs map[string]st
 
 	// Remove branches that no longer exist in Git
 	e.mu.Lock()
+	e.logger.Debug("checking for deleted branches",
+		zap.String("base_environment", e.cfg.Name),
+		zap.Int("cached_branches", len(e.branches)),
+		zap.Int("git_branches", len(existingBranches)),
+	)
 	for branchName := range e.branches {
 		if _, exists := existingBranches[branchName]; !exists {
 			env := e.branches[branchName]

--- a/internal/storage/environments/git/store.go
+++ b/internal/storage/environments/git/store.go
@@ -618,10 +618,10 @@ func (e *Environment) RefreshEnvironment(ctx context.Context, refs map[string]st
 	}
 
 	// Track which branches still exist in Git
-	existingBranches := make(map[string]bool)
+	existingBranches := make(map[string]struct{})
 
 	for cfg := range iterator.All() {
-		existingBranches[cfg.Name] = true
+		existingBranches[cfg.Name] = struct{}{}
 
 		env, ok := e.branches[cfg.Name]
 		// if we dont have an environment for this branch, create one

--- a/internal/storage/environments/git/store.go
+++ b/internal/storage/environments/git/store.go
@@ -669,7 +669,7 @@ func (e *Environment) RefreshEnvironment(ctx context.Context, refs map[string]st
 
 	// Remove branches that no longer exist in Git
 	for branchName := range e.branches {
-		if !existingBranches[branchName] {
+		if _, exists := existingBranches[branchName]; !exists {
 			e.logger.Debug("removing deleted branch from cache",
 				zap.String("environment", e.cfg.Name),
 				zap.String("branch", branchName),

--- a/internal/storage/environments/git/store_test.go
+++ b/internal/storage/environments/git/store_test.go
@@ -202,9 +202,10 @@ func Test_Environment_RefreshEnvironment(t *testing.T) {
 		return nil
 	})
 
-	newBranches, err := env.RefreshEnvironment(ctx, refs)
+	newBranches, deletedBranches, err := env.RefreshEnvironment(ctx, refs)
 	require.NoError(t, err)
 	assert.NotEmpty(t, newBranches)
+	assert.Empty(t, deletedBranches)
 	found := false
 	for _, b := range newBranches {
 		if b.Key() == "testbranch" {
@@ -212,6 +213,68 @@ func Test_Environment_RefreshEnvironment(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected to find new branch environment 'testbranch'")
+}
+
+func Test_Environment_RefreshEnvironment_DeletedBranches(t *testing.T) {
+	env := newTestEnvironment(t, "production")
+	ctx := context.Background()
+
+	// Create a branch in the repo
+	branchName := "flipt/production/testbranch"
+	err := env.repo.CreateBranchIfNotExists(ctx, branchName, storagegit.WithBase(env.currentBranch))
+	require.NoError(t, err)
+
+	// First refresh to add the branch to environment
+	references, err := env.repo.References()
+	require.NoError(t, err)
+	refs := map[string]string{}
+	_ = references.ForEach(func(r *plumbing.Reference) error {
+		if r.Name().IsRemote() {
+			refs[strings.TrimPrefix(r.Name().String(), "refs/remotes/origin/")] = r.Hash().String()
+		}
+		return nil
+	})
+
+	newBranches, deletedBranches, err := env.RefreshEnvironment(ctx, refs)
+	require.NoError(t, err)
+	assert.Len(t, newBranches, 1)
+	assert.Empty(t, deletedBranches)
+	assert.Equal(t, "testbranch", newBranches[0].Key())
+
+	// Verify the branch is in the environment's branches map
+	assert.Contains(t, env.branches, "testbranch")
+
+	// Delete the branch from Git (both local and remote tracking ref)
+	err = env.repo.DeleteBranch(ctx, branchName)
+	require.NoError(t, err)
+
+	// Also need to remove the remote tracking reference since we're using in-memory storage
+	remoteRef := plumbing.NewRemoteReferenceName("origin", branchName)
+	_ = env.repo.Storer.RemoveReference(remoteRef)
+
+	// Refresh references after deletion
+	references, err = env.repo.References()
+	require.NoError(t, err)
+	refs = map[string]string{}
+	_ = references.ForEach(func(r *plumbing.Reference) error {
+		if r.Name().IsRemote() {
+			refs[strings.TrimPrefix(r.Name().String(), "refs/remotes/origin/")] = r.Hash().String()
+		}
+		return nil
+	})
+
+	// Verify the branch is not in refs anymore
+	assert.NotContains(t, refs, branchName, "deleted branch should not be in refs")
+
+	// Second refresh should detect the deleted branch
+	newBranches, deletedBranches, err = env.RefreshEnvironment(ctx, refs)
+	require.NoError(t, err)
+	assert.Empty(t, newBranches, "should not find any new branches")
+	assert.Len(t, deletedBranches, 1, "should find one deleted branch")
+	assert.Equal(t, "testbranch", deletedBranches[0])
+
+	// Verify the branch is removed from the environment's branches map
+	assert.NotContains(t, env.branches, "testbranch")
 }
 
 func Test_Environment_GetAndListNamespaces(t *testing.T) {

--- a/internal/storage/environments/git/store_test.go
+++ b/internal/storage/environments/git/store_test.go
@@ -202,12 +202,12 @@ func Test_Environment_RefreshEnvironment(t *testing.T) {
 		return nil
 	})
 
-	newBranches, deletedBranches, err := env.RefreshEnvironment(ctx, refs)
+	result, err := env.RefreshEnvironment(ctx, refs)
 	require.NoError(t, err)
-	assert.NotEmpty(t, newBranches)
-	assert.Empty(t, deletedBranches)
+	assert.NotEmpty(t, result.NewBranches)
+	assert.Empty(t, result.DeletedBranchKeys)
 	found := false
-	for _, b := range newBranches {
+	for _, b := range result.NewBranches {
 		if b.Key() == "testbranch" {
 			found = true
 		}
@@ -235,11 +235,11 @@ func Test_Environment_RefreshEnvironment_DeletedBranches(t *testing.T) {
 		return nil
 	})
 
-	newBranches, deletedBranches, err := env.RefreshEnvironment(ctx, refs)
+	result, err := env.RefreshEnvironment(ctx, refs)
 	require.NoError(t, err)
-	assert.Len(t, newBranches, 1)
-	assert.Empty(t, deletedBranches)
-	assert.Equal(t, "testbranch", newBranches[0].Key())
+	assert.Len(t, result.NewBranches, 1)
+	assert.Empty(t, result.DeletedBranchKeys)
+	assert.Equal(t, "testbranch", result.NewBranches[0].Key())
 
 	// Verify the branch is in the environment's branches map
 	assert.Contains(t, env.branches, "testbranch")
@@ -267,11 +267,11 @@ func Test_Environment_RefreshEnvironment_DeletedBranches(t *testing.T) {
 	assert.NotContains(t, refs, branchName, "deleted branch should not be in refs")
 
 	// Second refresh should detect the deleted branch
-	newBranches, deletedBranches, err = env.RefreshEnvironment(ctx, refs)
+	result, err = env.RefreshEnvironment(ctx, refs)
 	require.NoError(t, err)
-	assert.Empty(t, newBranches, "should not find any new branches")
-	assert.Len(t, deletedBranches, 1, "should find one deleted branch")
-	assert.Equal(t, "testbranch", deletedBranches[0])
+	assert.Empty(t, result.NewBranches, "should not find any new branches")
+	assert.Len(t, result.DeletedBranchKeys, 1, "should find one deleted branch")
+	assert.Equal(t, "testbranch", result.DeletedBranchKeys[0])
 
 	// Verify the branch is removed from the environment's branches map
 	assert.NotContains(t, env.branches, "testbranch")

--- a/internal/storage/git/repository.go
+++ b/internal/storage/git/repository.go
@@ -338,6 +338,7 @@ func (r *Repository) Fetch(ctx context.Context, specific ...string) (err error) 
 		CABundle:        r.caBundle,
 		InsecureSkipTLS: r.insecureSkipTLS,
 		RefSpecs:        refSpecs,
+		Prune:           true,
 	}); err != nil && !errors.Is(err, git.NoErrAlreadyUpToDate) {
 		return err
 	}


### PR DESCRIPTION
## Summary

Fixes a customer-reported bug where deleted Git branches persist in the Flipt Pro UI after being merged and deleted from the repository.

## Root Cause

The bug had two components:

1. **Missing pruning on fetch**: When fetching from remote, Git was not configured to prune (remove) deleted remote tracking branches. This meant that when a branch was deleted upstream, the local ref `refs/remotes/origin/flipt/env/branch` would persist indefinitely.

2. **No cleanup in RefreshEnvironment**: The `RefreshEnvironment` method only added new branches and updated existing ones, but never removed branches that had been deleted from Git.

## Solution

### 1. Enable Pruning on Fetch

Added `Prune: true` to `FetchOptions` in the Repository's `Fetch` method. This ensures that deleted remote branches are removed from local tracking refs, matching the behavior of `git fetch --prune`.

### 2. Branch Cleanup in RefreshEnvironment

Updated `RefreshEnvironment` to:
- Track which branches currently exist in the Git repository during sync
- Detect branches that have been deleted from Git but still exist in the cache
- Remove deleted branches from both the environment's internal cache (`e.branches`) and the global `EnvironmentStore`
- Return a `RefreshResult` struct containing both new and deleted branches for cleaner API

### 3. Fixed Data Race Conditions

- Added proper mutex locking throughout `RefreshEnvironment` to protect concurrent access to `e.branches` and `e.refs` maps
- Fixed race condition in `Notify` method which was accessing `e.refs` without holding the mutex

## Behavior

Deleted branches will be automatically removed from the UI on the next Git sync cycle (default: 30 seconds). The fix is backwards compatible and follows existing patterns in the codebase.