### PR TITLE
fix(build): move ARG declaration after FROM in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,8 @@
 # https://goreleaser.com/docker/
 
-ARG BINARY=flipt
-
 FROM alpine:3.22.1
+
+ARG BINARY=flipt
 
 LABEL maintainer="dev@flipt.io"
 LABEL org.opencontainers.image.name="flipt"


### PR DESCRIPTION
## Summary

Fixes Docker build warning about undefined variable `$BINARY` by moving the ARG declaration to after the FROM instruction.

## Changes

- **Modified `build/Dockerfile`**: Moved `ARG BINARY=flipt` from before `FROM alpine:3.22.1` to after it

## Technical Details

ARG declarations before FROM are in global scope and cannot be used after FROM unless redeclared. This was causing the warning:
```
1 warning found (use docker --debug to expand):
- UndefinedVar: Usage of undefined variable '$BINARY' (line 14)
```

By moving the ARG declaration after FROM, it's properly scoped within the build stage and available for use in the COPY instruction.

Fixes #4584