### PR TITLE
fix(ui): refetch environments when window regains focus or reconnects

### DIFF
--- a/ui/src/app/Layout.tsx
+++ b/ui/src/app/Layout.tsx
@@ -45,7 +45,9 @@ function InnerLayout() {
   const location = useLocation();
   const navigate = useNavigate();
 
-  const environments = useListEnvironmentsQuery();
+  const environments = useListEnvironmentsQuery(undefined, {
+    refetchOnMountOrArgChange: true
+  });
 
   const currentEnvironment = useSelector(selectCurrentEnvironment);
   const currentNamespace = useSelector(selectCurrentNamespace);

--- a/ui/src/app/environments/environmentsApi.ts
+++ b/ui/src/app/environments/environmentsApi.ts
@@ -112,6 +112,8 @@ export const environmentsApi = createApi({
   reducerPath: 'environments-api',
   baseQuery,
   tagTypes: ['Environment', 'BranchEnvironment'],
+  refetchOnFocus: true,
+  refetchOnReconnect: true,
   endpoints: (builder) => ({
     listEnvironments: builder.query<{ environments: IEnvironment[] }, void>({
       query: () => '',

--- a/ui/src/components/environments/branches/BranchActionsDropdown.tsx
+++ b/ui/src/components/environments/branches/BranchActionsDropdown.tsx
@@ -42,9 +42,12 @@ export default function BranchActionsDropdown({
   const [mergeModalOpen, setMergeModalOpen] = useState(false);
 
   const { info } = useAppSelector((state) => state.meta);
-  const { data: baseBranches } = useListBranchEnvironmentsQuery({
-    environmentKey: environment.configuration?.base ?? ''
-  });
+  const { data: baseBranches } = useListBranchEnvironmentsQuery(
+    {
+      environmentKey: environment.configuration?.base ?? ''
+    },
+    { refetchOnMountOrArgChange: true }
+  );
   const branch = baseBranches?.branches.find(
     (branch) => branch.key === environment.key
   );


### PR DESCRIPTION
## Summary

Fixes the issue where deleted/merged branches and closed pull requests were not being removed from the environment picker until the user performed a hard refresh.

The root cause was that RTK Query's default caching behavior doesn't automatically refetch data when the browser tab regains focus or when network reconnects. This meant stale environment data persisted in the UI even after branches were deleted or PRs were merged/closed.

## Changes

- **Modified `ui/src/app/environments/environmentsApi.ts`**: Added `refetchOnFocus: true` and `refetchOnReconnect: true` to the environmentsApi configuration to enable automatic refetching
- **Modified `ui/src/app/Layout.tsx`**: Added `refetchOnMountOrArgChange: true` to useListEnvironmentsQuery to ensure fresh data on mount
- **Modified `ui/src/components/environments/branches/BranchActionsDropdown.tsx`**: Added `refetchOnMountOrArgChange: true` to useListBranchEnvironmentsQuery to keep branch data fresh

## Behavior

Now the environment list automatically refetches when:
- The user switches back to the Flipt browser tab (focus)
- The network connection is restored (reconnect)
- The component mounts or remounts

This ensures deleted branches and closed/merged PRs are removed from the environment picker without requiring a manual page refresh.

## Related

Fixes https://github.com/flipt-io/flipt/pull/4770#issuecomment-3353609205