### PR TITLE
fix(ci): correct YAML indentation in comment body

### DIFF
--- a/.github/workflows/contributing.yml
+++ b/.github/workflows/contributing.yml
@@ -118,11 +118,11 @@ jobs:
 
             const commentBody = `## Thank you for your contribution! 🎉
 
-👋 Hi @${prInfo.author}!
+            👋 Hi @${prInfo.author}!
 
-The DCO check has failed for this pull request. This means one or more of your commits are missing the required "Signed-off-by" line.
+            The DCO check has failed for this pull request. This means one or more of your commits are missing the required "Signed-off-by" line.
 
-Please see the [failed DCO check](${checkInfo.url}) for detailed instructions on how to sign your commits.`;
+            Please see the [failed DCO check](${checkInfo.url}) for detailed instructions on how to sign your commits.`;
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Fixes YAML syntax error on line 121 in the Contributing workflow.

## Changes

- **Fixed **: Corrected indentation of the multi-line string in the comment body to ensure proper YAML syntax

## Context

The previous commit simplified the DCO comment but introduced a YAML syntax error due to incorrect indentation of the template literal content. This PR fixes that indentation issue.