### PR TITLE
fix(ci): use context.payload instead of github.event

### DIFF
--- a/.github/workflows/contributing.yml
+++ b/.github/workflows/contributing.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           script: |
             // Get pull requests associated with this workflow run
-            const pullRequests = github.event.workflow_run.pull_requests;
+            const pullRequests = context.payload.workflow_run.pull_requests;
 
             if (!pullRequests || pullRequests.length === 0) {
               console.log('No pull requests associated with this workflow run');


### PR DESCRIPTION
## Summary

Fixes the TypeError in the Contributing workflow caused by accessing event data incorrectly.

## Changes

- **Fixed **: Changed  to 

## Root Cause

In the  action context, event data must be accessed via , not . The latter is undefined in this context, causing the  error.

## Testing

This fix ensures the workflow can properly access the workflow_run event data and extract PR information for DCO check comments.