### PR TITLE
chore: add back dependabot for v2 branch; renovate for main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: github.com/golangci/golangci-lint
+        versions:
+          - "> 1.26.0"
+    labels:
+      - "dependencies"
+      - "go"
+      # kodiak `merge.automerge_label`
+      - "automerge"
+
+  - package-ecosystem: npm
+    directory: "/ui"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+    labels:
+      - "dependencies"
+      - "javascript"
+      # kodiak `merge.automerge_label`
+      - "automerge"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github_actions"
+      # kodiak `merge.automerge_label`
+      - "automerge"
+
+  - package-ecosystem: "docker"
+    directory: "/build"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+      # kodiak `merge.automerge_label`
+      - "automerge"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["config:recommended"],
   dependencyDashboardApproval: false,
-  baseBranchPatterns: ["main", "v2"],
+  baseBranchPatterns: ["main"],
   timezone: "America/New_York",
   schedule: [
     "after 10pm every weekday",
@@ -27,14 +27,14 @@
     },
     {
       matchManagers: ["gomod"],
-      matchBaseBranches: ["main", "v2"],
+      matchBaseBranches: ["main"],
       labels: ["dependencies", "go", "automerge"],
       matchUpdateTypes: ["minor", "patch"],
       automerge: false,
     },
     {
       matchManagers: ["npm"],
-      matchBaseBranches: ["main", "v2"],
+      matchBaseBranches: ["main"],
       matchFileNames: ["/ui/**"],
       labels: ["dependencies", "javascript", "automerge"],
       matchUpdateTypes: ["minor", "patch"],
@@ -42,14 +42,14 @@
     },
     {
       matchManagers: ["github-actions"],
-      matchBaseBranches: ["main", "v2"],
+      matchBaseBranches: ["main"],
       labels: ["dependencies", "github_actions", "automerge"],
       matchUpdateTypes: ["minor", "patch"],
       automerge: false,
     },
     {
       matchManagers: ["dockerfile"],
-      matchBaseBranches: ["main", "v2"],
+      matchBaseBranches: ["main"],
       matchFileNames: ["/build/**"],
       labels: ["dependencies", "docker", "automerge"],
       matchUpdateTypes: ["minor", "patch"],


### PR DESCRIPTION
for whatever reason I cant get renovate to consistenly update both `main` and `v2` dependencies

So I'm moving back to dependabot for `v2` branch and keeping renovate only for `main` because it seems like dependabot only works on the default branch (v2)