### PR TITLE
chore: reduce how often contributor workflow runs

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,7 +2,7 @@ name: Contributor Assistant
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened]
   check_run:
     types: [completed]
 
@@ -14,12 +14,13 @@ permissions:
 jobs:
   post-dco-comment:
     runs-on: ubuntu-latest
-    # Only run if triggered by PR events or if a check_run named "DCO" failed
+    # Only run for PR opened events or when DCO check specifically fails
     if: |
       github.event_name == 'pull_request_target' || 
       (github.event_name == 'check_run' && 
        github.event.check_run.name == 'DCO' && 
-       github.event.check_run.conclusion == 'failure')
+       github.event.check_run.conclusion == 'failure' &&
+       github.event.check_run.pull_requests[0] != null)
     steps:
       - name: Get Pull Request and Check DCO Status
         id: check_dco


### PR DESCRIPTION
This pull request updates the workflow in `.github/workflows/contributors.yml` to refine when the Contributor Assistant runs, making the automation more targeted and reliable.

Workflow trigger improvements:

* The workflow will now only run on pull request events when a PR is opened, instead of also running on synchronize or reopened events.

Reliability and correctness fixes:

* The conditional for running the job on DCO check failures now ensures that the failed check is actually associated with a pull request, preventing unnecessary or erroneous workflow runs.