### PR TITLE
chore(deps): group OpenTelemetry dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      opentelemetry:
+        patterns:
+          - "go.opentelemetry.io/*"
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
## Summary

Configure Dependabot to group all OpenTelemetry dependency updates into a single PR.

## Changes

- **Modified `.github/dependabot.yml`**: Added `groups` configuration for the `gomod` ecosystem to group all `go.opentelemetry.io/*` dependencies together

## Backward Compatibility

No impact on backward compatibility. This only affects how Dependabot creates PRs - it will now create a single PR for all OpenTelemetry updates instead of multiple separate PRs.