### PR TITLE
Add `Metadata` field to `ListFlags` API response

### DIFF
--- a/internal/server/flag.go
+++ b/internal/server/flag.go
@@ -73,6 +73,7 @@ func (s *Server) ListFlags(ctx context.Context, r *flipt.ListFlagRequest) (*flip
 			DefaultVariant: defaultVariant,
 			Type:           toListFlagType(flag.Type),
 			Enabled:        flag.Enabled,
+			Metadata:       flag.Metadata,
 		})
 	}
 


### PR DESCRIPTION
This PR updates the `ListFlags` API to include the `Metadata` field in the returned `Flag` objects.

Previously, the `ListFlags` API did not include metadata for flags, which made it inconsistent with other endpoints and limited clients’ ability to fully understand flag context in bulk retrievals.

This change allows clients to access metadata for each flag without needing to fetch flags individually.

### Details:
- Updated the `ListFlags` server implementation (`server/flag.go`) to populate the `Metadata` field in each `flipt.Flag` returned.
- The metadata is pulled directly from the `flag.Metadata` field retrieved from storage.

Example response:
```json
{
  "flags": [
    {
      "key": "example-flag",
      "name": "Example Flag",
      "description": "A test flag",
      "enabled": true,
      "metadata": {
        "team": "growth",
        "owner": "alice"
      }
    }
  ],
  "totalCount": 1
}
```

Alternative (gRPC):
```bash
grpcurl -d '{"environment_key": "default", "namespace_key": "default", "type_url": "flipt.core.Flag"}' \
  localhost:9000 environments.EnvironmentsService/ListResources
```
