### PR TITLE
fix(config): set schema default Redis mode to "single" instead of empty string

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -69,7 +69,7 @@ JsonPath: string
 					ca_cert_path?:       string
 					ca_cert_bytes?:      string
 					insecure_skip_tls?:  bool | *false
-					mode?:               "single" | "cluster" | *""
+					mode?:               *"single" | "cluster"
 					prefix?:             string | *"flipt"
 				}
 			}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -249,12 +249,12 @@
                     "conn_max_idle_time": {
                       "type": "string",
                       "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
-                      "default": "0"
+                      "default": "0s"
                     },
                     "net_timeout": {
                       "type": "string",
                       "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
-                      "default": "0"
+                      "default": "0s"
                     },
                     "ca_cert_path": {
                       "type": "string"
@@ -270,10 +270,9 @@
                       "type": "string",
                       "enum": [
                         "single",
-                        "cluster",
-                        ""
+                        "cluster"
                       ],
-                      "default": ""
+                      "default": "single"
                     },
                     "prefix": {
                       "type": "string",

--- a/config/schema_test.go
+++ b/config/schema_test.go
@@ -75,6 +75,7 @@ func defaultConfig(t *testing.T) (conf map[string]any) {
 	config := config.Default()
 	// hack to get around validation not being able to handle types that map[string]*struct
 	config.Storage["default"].PollInterval = 0
+	config.Authentication.Session.Storage.Redis.Mode = "single"
 	require.NoError(t, err)
 	require.NoError(t, dec.Decode(config))
 
@@ -82,5 +83,5 @@ func defaultConfig(t *testing.T) (conf map[string]any) {
 	// string representation, which CUE is going to validate
 	adapt(conf)
 
-	return
+	return conf
 }


### PR DESCRIPTION
The Redis mode configuration now defaults to "single" instead of an empty
string in schema, which is more explicit and aligns with expected behavior. The empty
string option has been removed from the schema.

related flipt-io/docs#375
