### PR TITLE
fix(config): use snake_case for fetch policy in json schema

### DIFF
--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -790,7 +790,7 @@
             "remote": {
               "type": "string"
             },
-            "fetchPolicy": {
+            "fetch_policy": {
               "type": "string",
               "enum": ["strict", "lenient"],
               "default": "strict"


### PR DESCRIPTION
The existing Test_JSONSchema only validates against the default config,
which has empty remote="" so fetch_policy is never included in the output.
This meant the schema bug (fetchPolicy vs fetch_policy) went undetected.
