### PR TITLE
feat(credentials): normalize SSH remote URLs

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -132,3 +132,12 @@ func (c *Credential) APIAuthentication() *APIAuth {
 func (c *Credential) Type() config.CredentialType {
 	return c.config.Type
 }
+
+// SSHUser returns the SSH user configured in the credential.
+// Returns empty string if the credential is not SSH type.
+func (c *Credential) SSHUser() string {
+	if c.config.Type != config.CredentialTypeSSH || c.config.SSH == nil {
+		return ""
+	}
+	return c.config.SSH.User
+}

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -217,6 +217,82 @@ func TestCredential_Type(t *testing.T) {
 	}
 }
 
+func TestCredential_SSHUser(t *testing.T) {
+	logger := zap.NewNop()
+
+	tests := []struct {
+		name     string
+		config   *config.CredentialConfig
+		expected string
+	}{
+		{
+			name: "ssh credential with user",
+			config: &config.CredentialConfig{
+				Type: config.CredentialTypeSSH,
+				SSH: &config.SSHAuthConfig{
+					User:           "git",
+					Password:       "pass",
+					PrivateKeyPath: "/path/to/key",
+				},
+			},
+			expected: "git",
+		},
+		{
+			name: "ssh credential with custom user",
+			config: &config.CredentialConfig{
+				Type: config.CredentialTypeSSH,
+				SSH: &config.SSHAuthConfig{
+					User:           "deploy",
+					Password:       "pass",
+					PrivateKeyPath: "/path/to/key",
+				},
+			},
+			expected: "deploy",
+		},
+		{
+			name: "basic auth credential returns empty",
+			config: &config.CredentialConfig{
+				Type: config.CredentialTypeBasic,
+				Basic: &config.BasicAuthConfig{
+					Username: "user",
+					Password: "pass",
+				},
+			},
+			expected: "",
+		},
+		{
+			name: "access token credential returns empty",
+			config: &config.CredentialConfig{
+				Type: config.CredentialTypeAccessToken,
+				AccessToken: func() *string {
+					s := "token123"
+					return &s
+				}(),
+			},
+			expected: "",
+		},
+		{
+			name: "ssh credential with nil SSH config returns empty",
+			config: &config.CredentialConfig{
+				Type: config.CredentialTypeSSH,
+				SSH:  nil,
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Credential{
+				logger: logger,
+				config: tt.config,
+			}
+
+			assert.Equal(t, tt.expected, c.SSHUser())
+		})
+	}
+}
+
 func TestCredential_APIAuthentication(t *testing.T) {
 	logger := zap.NewNop()
 

--- a/internal/credentials/sshurl.go
+++ b/internal/credentials/sshurl.go
@@ -1,0 +1,124 @@
+package credentials
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// sshURLRegex matches SCP-style SSH URLs like git@github.com:owner/repo.git
+// or user@host:path format. Note: This does NOT match ssh:// protocol URLs.
+var sshURLRegex = regexp.MustCompile(`^([^@]+)@([^:]+):(.+)$`)
+
+// NormalizeSSHRemoteURL transforms a remote URL for use with SSH credentials.
+// It handles the following cases:
+//  1. Strips https:// or http:// protocol if present (SSH doesn't use HTTP(S) URLs)
+//  2. Converts ssh:// protocol URLs to SCP-style format
+//  3. Prepends the SSH user to the URL if not already present
+//  4. Returns an error if the URL contains a user that differs from sshUser
+//
+// The sshUser parameter is the user from SSH credentials configuration.
+// If empty, it defaults to "git".
+//
+// Examples:
+//   - https://github.com/org/repo.git + user="git" -> git@github.com:org/repo.git
+//   - github.com/org/repo.git + user="git" -> git@github.com:org/repo.git
+//   - git@github.com:org/repo.git + user="git" -> git@github.com:org/repo.git (unchanged)
+//   - git@github.com:org/repo.git + user="other" -> error (conflicting users)
+//   - ssh://git@github.com/org/repo.git + user="git" -> git@github.com:org/repo.git
+func NormalizeSSHRemoteURL(remoteURL, sshUser string) (string, error) {
+	if sshUser == "" {
+		sshUser = "git"
+	}
+
+	url := strings.TrimSpace(remoteURL)
+
+	// Handle ssh:// protocol URL format FIRST (before regex check)
+	// because ssh://git@host:port/path would incorrectly match the SCP regex
+	if strings.HasPrefix(url, "ssh://") {
+		return convertSSHProtocolURL(url, sshUser)
+	}
+
+	// Check if it's already a valid SCP-style SSH URL (user@host:path)
+	if matches := sshURLRegex.FindStringSubmatch(url); matches != nil {
+		existingUser := matches[1]
+		if existingUser != sshUser {
+			return "", fmt.Errorf("conflicting SSH users: URL contains %q but credentials specify %q", existingUser, sshUser)
+		}
+		// URL is already in correct format
+		return url, nil
+	}
+
+	// Strip https:// or http:// protocol (including any port like :443 or :80)
+	url = strings.TrimPrefix(url, "https://")
+	url = strings.TrimPrefix(url, "http://")
+
+	// Handle URLs with user@ prefix (e.g., from stripping protocol off git@host/path)
+	// The condition checks: is there an @ before the first / (if any)?
+	// If slashIndex is -1 (no slash), we skip this block and fall through to error handling.
+	atIndex := strings.Index(url, "@")
+	slashIndex := strings.Index(url, "/")
+	if atIndex != -1 && (slashIndex == -1 || atIndex < slashIndex) {
+		existingUser := url[:atIndex]
+		if existingUser != sshUser {
+			return "", fmt.Errorf("conflicting SSH users: URL contains %q but credentials specify %q", existingUser, sshUser)
+		}
+		// Strip user@ and continue processing
+		url = url[atIndex+1:]
+		slashIndex = strings.Index(url, "/")
+	}
+
+	// At this point, url should be: host/path or host:port/path
+	if slashIndex == -1 {
+		return "", fmt.Errorf("invalid remote URL format: %q (expected host/path)", remoteURL)
+	}
+
+	host := url[:slashIndex]
+	path := url[slashIndex+1:]
+
+	// Strip port from host if present (e.g., github.com:443 -> github.com)
+	if colonIndex := strings.LastIndex(host, ":"); colonIndex != -1 {
+		host = host[:colonIndex]
+	}
+
+	return sshUser + "@" + host + ":" + path, nil
+}
+
+// convertSSHProtocolURL converts ssh:// protocol URLs to SCP-style format.
+// ssh://[user@]host[:port]/path -> user@host:path
+func convertSSHProtocolURL(url, sshUser string) (string, error) {
+	url = strings.TrimPrefix(url, "ssh://")
+
+	// Extract user if present (user@host:port/path or user@host/path)
+	// The @ must come before the first / to be a user
+	var hostPortAndPath string
+	atIndex := strings.Index(url, "@")
+	slashIndex := strings.Index(url, "/")
+
+	if atIndex != -1 && (slashIndex == -1 || atIndex < slashIndex) {
+		existingUser := url[:atIndex]
+		if existingUser != sshUser {
+			return "", fmt.Errorf("conflicting SSH users: URL contains %q but credentials specify %q", existingUser, sshUser)
+		}
+		hostPortAndPath = url[atIndex+1:]
+	} else {
+		hostPortAndPath = url
+	}
+
+	// Find the path separator
+	slashIndex = strings.Index(hostPortAndPath, "/")
+	if slashIndex == -1 {
+		return "", fmt.Errorf("invalid ssh:// URL format: %q (expected ssh://host/path)", "ssh://"+url)
+	}
+
+	hostPort := hostPortAndPath[:slashIndex]
+	path := hostPortAndPath[slashIndex+1:]
+
+	// Strip port from host if present (e.g., github.com:22 -> github.com)
+	host := hostPort
+	if colonIndex := strings.LastIndex(hostPort, ":"); colonIndex != -1 {
+		host = hostPort[:colonIndex]
+	}
+
+	return sshUser + "@" + host + ":" + path, nil
+}

--- a/internal/credentials/sshurl_test.go
+++ b/internal/credentials/sshurl_test.go
@@ -1,0 +1,203 @@
+package credentials
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeSSHRemoteURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		remoteURL string
+		sshUser   string
+		want      string
+		wantErr   string
+	}{
+		// Basic HTTPS to SSH conversion
+		{
+			name:      "https URL with git user",
+			remoteURL: "https://github.com/org-name/some-test-repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org-name/some-test-repo.git",
+		},
+		{
+			name:      "https URL without .git suffix",
+			remoteURL: "https://github.com/org-name/some-test-repo",
+			sshUser:   "git",
+			want:      "git@github.com:org-name/some-test-repo",
+		},
+		{
+			name:      "https URL with custom user",
+			remoteURL: "https://github.com/org-name/some-test-repo.git",
+			sshUser:   "myuser",
+			want:      "myuser@github.com:org-name/some-test-repo.git",
+		},
+
+		// Plain host/path format
+		{
+			name:      "host/path format with git user",
+			remoteURL: "github.com/org-name/some-test-repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org-name/some-test-repo.git",
+		},
+		{
+			name:      "host/path format with empty user defaults to git",
+			remoteURL: "github.com/org-name/some-test-repo.git",
+			sshUser:   "",
+			want:      "git@github.com:org-name/some-test-repo.git",
+		},
+
+		// Already valid SSH URLs
+		{
+			name:      "already valid SSH URL with matching user",
+			remoteURL: "git@github.com:org-name/some-test-repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org-name/some-test-repo.git",
+		},
+		{
+			name:      "already valid SSH URL with custom matching user",
+			remoteURL: "deploy@gitlab.com:org/repo.git",
+			sshUser:   "deploy",
+			want:      "deploy@gitlab.com:org/repo.git",
+		},
+
+		// SSH protocol URLs
+		{
+			name:      "ssh:// protocol URL",
+			remoteURL: "ssh://git@github.com/org-name/some-test-repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org-name/some-test-repo.git",
+		},
+		{
+			name:      "ssh:// protocol URL without user",
+			remoteURL: "ssh://github.com/org-name/some-test-repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org-name/some-test-repo.git",
+		},
+
+		// HTTP (non-HTTPS) URL
+		{
+			name:      "http URL converts to SSH",
+			remoteURL: "http://github.com/org-name/some-test-repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org-name/some-test-repo.git",
+		},
+
+		// Whitespace handling
+		{
+			name:      "URL with leading/trailing whitespace",
+			remoteURL: "  https://github.com/org/repo.git  ",
+			sshUser:   "git",
+			want:      "git@github.com:org/repo.git",
+		},
+
+		// Different Git providers
+		{
+			name:      "GitLab URL",
+			remoteURL: "https://gitlab.com/group/project.git",
+			sshUser:   "git",
+			want:      "git@gitlab.com:group/project.git",
+		},
+		{
+			name:      "Bitbucket URL",
+			remoteURL: "https://bitbucket.org/team/repo.git",
+			sshUser:   "git",
+			want:      "git@bitbucket.org:team/repo.git",
+		},
+		{
+			name:      "Self-hosted GitLab",
+			remoteURL: "https://git.example.com/team/project.git",
+			sshUser:   "git",
+			want:      "git@git.example.com:team/project.git",
+		},
+
+		// URLs with explicit ports
+		{
+			name:      "https URL with port 443",
+			remoteURL: "https://github.com:443/org/repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org/repo.git",
+		},
+		{
+			name:      "ssh:// URL with port 22",
+			remoteURL: "ssh://git@github.com:22/org/repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org/repo.git",
+		},
+		{
+			name:      "ssh:// URL without user but with port",
+			remoteURL: "ssh://github.com:22/org/repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org/repo.git",
+		},
+		{
+			name:      "host:port/path format",
+			remoteURL: "github.com:443/org/repo.git",
+			sshUser:   "git",
+			want:      "git@github.com:org/repo.git",
+		},
+
+		// Nested paths (GitLab subgroups, etc.)
+		{
+			name:      "GitLab nested subgroups",
+			remoteURL: "https://gitlab.com/group/subgroup/project.git",
+			sshUser:   "git",
+			want:      "git@gitlab.com:group/subgroup/project.git",
+		},
+		{
+			name:      "deeply nested path",
+			remoteURL: "https://gitlab.com/org/team/product/service.git",
+			sshUser:   "git",
+			want:      "git@gitlab.com:org/team/product/service.git",
+		},
+		{
+			name:      "ssh:// with nested path",
+			remoteURL: "ssh://git@gitlab.com/group/subgroup/project.git",
+			sshUser:   "git",
+			want:      "git@gitlab.com:group/subgroup/project.git",
+		},
+
+		// Error cases
+		{
+			name:      "conflicting users in SSH URL",
+			remoteURL: "git@github.com:org-name/some-test-repo.git",
+			sshUser:   "other",
+			wantErr:   `conflicting SSH users: URL contains "git" but credentials specify "other"`,
+		},
+		{
+			name:      "conflicting users in ssh:// URL",
+			remoteURL: "ssh://git@github.com/org/repo.git",
+			sshUser:   "deploy",
+			wantErr:   `conflicting SSH users: URL contains "git" but credentials specify "deploy"`,
+		},
+		{
+			name:      "invalid URL without path",
+			remoteURL: "github.com",
+			sshUser:   "git",
+			wantErr:   `invalid remote URL format: "github.com" (expected host/path)`,
+		},
+		{
+			name:      "invalid ssh:// URL without path",
+			remoteURL: "ssh://github.com",
+			sshUser:   "git",
+			wantErr:   `invalid ssh:// URL format`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeSSHRemoteURL(tt.remoteURL, tt.sshUser)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add SSH remote URL normalization to handle cases where users configure an HTTPS URL but provide SSH credentials. This ensures Git operations work correctly by converting URLs to SCP-style format.

## Changes

- **credentials.go**: Add `SSHUser()` method to extract SSH user from credential config
- **sshurl.go** (new): Add `NormalizeSSHRemoteURL()` function to parse and normalize various URL formats (HTTPS, HTTP, ssh://, host/path, etc.) to SCP-style
- **environments.go**: Move credential handling before remote URL setup to enable SSH URL normalization
- **credentials_test.go**: Add comprehensive test coverage for `SSHUser()`
- **sshurl_test.go** (new): Add 20 test cases covering HTTPS/HTTP/ssh:// conversions, custom users, nested paths, port handling, and error cases

Fixes: #5126 