### PR TITLE
fix: improve GitHub auth error message for security requirements

### DIFF
--- a/internal/server/authn/method/github/server.go
+++ b/internal/server/authn/method/github/server.go
@@ -302,6 +302,8 @@ func authnOrgsAndTeams(orgs map[string]bool, userTeamsByOrg map[string]map[strin
 		return nil
 	}
 
+	hasOrganization := false
+
 	for _, org := range config.AllowedOrganizations {
 		if !orgs[org] {
 			continue
@@ -311,6 +313,8 @@ func authnOrgsAndTeams(orgs map[string]bool, userTeamsByOrg map[string]map[strin
 		if len(config.AllowedTeams) == 0 {
 			return nil
 		}
+
+		hasOrganization = true
 
 		// Check if user is in any of the allowed teams for this org
 		var (
@@ -325,7 +329,11 @@ func authnOrgsAndTeams(orgs map[string]bool, userTeamsByOrg map[string]map[strin
 		}
 	}
 
-	return errors.ErrUnauthenticatedf("account does not satisfy the security requirements")
+	if hasOrganization {
+		return errors.ErrUnauthenticatedf("account does not satisfy the team requirements")
+	}
+
+	return errors.ErrUnauthenticatedf("account does not satisfy the organization requirements")
 }
 
 // parseOrgsForMetadata returns a JSON encoded list of organizations that the user is in.

--- a/internal/server/authn/method/github/server_test.go
+++ b/internal/server/authn/method/github/server_test.go
@@ -474,7 +474,7 @@ func Test_Server(t *testing.T) {
 			})
 
 		_, err := client.Callback(ctx, &auth.CallbackRequest{Code: "github_code"})
-		assert.ErrorContains(t, err, "account does not satisfy the security requirements")
+		assert.ErrorContains(t, err, "account does not satisfy the organization requirements")
 	})
 
 	t.Run("should authorize successfully when the user is a member of one of the allowed organizations and it's inside the allowed team", func(t *testing.T) {
@@ -573,7 +573,7 @@ func Test_Server(t *testing.T) {
 			})
 
 		_, err := client.Callback(ctx, &auth.CallbackRequest{Code: "github_code"})
-		require.ErrorIs(t, err, status.Error(codes.Unauthenticated, "account does not satisfy the security requirements"))
+		require.ErrorIs(t, err, status.Error(codes.Unauthenticated, "account does not satisfy the team requirements"))
 	})
 
 	t.Run("should return an internal error when github user route returns a code different from 200 (OK)", func(t *testing.T) {


### PR DESCRIPTION
Replace generic "request was not authenticated" error message with more
specific "account does not satisfy the security requirements" when users
fail to meet organization/team restrictions in GitHub authentication.
