### PR TITLE
feat(oidc): support configurable token signing algorithms

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -144,6 +144,7 @@ JsonPath: string
 			nonce?:            string
 			scopes?: [...string]
 			use_pkce?: bool
+			algorithms?: [...("RS256" | "RS384" | "RS512" | "ES256" | "ES384" | "ES512" | "PS256" | "PS384" | "PS512")] | *["RS256"]
 		}
 
 	}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -411,6 +411,29 @@
                         "use_pkce": {
                           "type": "boolean",
                           "default": false
+                        },
+                        "algorithms": {
+                          "type": [
+                            "array",
+                            "null"
+                          ],
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "RS256",
+                              "RS384",
+                              "RS512",
+                              "ES256",
+                              "ES384",
+                              "ES512",
+                              "PS256",
+                              "PS384",
+                              "PS512"
+                            ]
+                          },
+                          "default": [
+                            "RS256"
+                          ]
                         }
                       }
                     }

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -533,10 +533,12 @@ type AuthenticationMethodOIDCProvider struct {
 	Nonce           string   `json:"nonce,omitempty" mapstructure:"nonce" yaml:"nonce,omitempty"`
 	Scopes          []string `json:"scopes,omitempty" mapstructure:"scopes" yaml:"scopes,omitempty"`
 	UsePKCE         bool     `json:"usePKCE,omitempty" mapstructure:"use_pkce" yaml:"use_pkce,omitempty"`
+	Algorithms      []string `json:"algorithms,omitempty" mapstructure:"algorithms" yaml:"algorithms,omitempty"`
 }
 
 func (a AuthenticationMethodOIDCProvider) setDefaults(defaults map[string]any) {
 	defaults["nonce"] = "static"
+	defaults["algorithms"] = []string{"RS256"}
 }
 
 func (a AuthenticationMethodOIDCProvider) validate() error {

--- a/internal/server/authn/method/oidc/server.go
+++ b/internal/server/authn/method/oidc/server.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/go-oidc/v3/oidc"
 	capoidc "github.com/hashicorp/cap/oidc"
 	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/config"
@@ -206,13 +205,21 @@ func (s *Server) providerFor(provider string, state string) (*capoidc.Provider, 
 		return nil, nil, err
 	}
 
+	algorithms := make([]capoidc.Alg, len(providerCfg.Algorithms))
+	for i, algorithm := range providerCfg.Algorithms {
+		algorithms[i] = capoidc.Alg(algorithm)
+	}
+	if len(algorithms) == 0 {
+		algorithms = []capoidc.Alg{capoidc.RS256}
+	}
+
 	callback = callbackURL(providerCfg.RedirectAddress, provider)
 
 	config, err = capoidc.NewConfig(
 		providerCfg.IssuerURL,
 		providerCfg.ClientID,
 		capoidc.ClientSecret(providerCfg.ClientSecret),
-		[]capoidc.Alg{oidc.RS256},
+		algorithms,
 		[]string{callback},
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary
Add an `algorithms` field to the OIDC provider configuration so Flipt can verify ID tokens signed with algorithms other than RS256.

closes #5361.

## Changes
- Update config schema to allow `authentication.methods.oidc.providers.<provider>.algorithms` (default `["RS256"]`)
- Plumb configured algorithms into OIDC provider setup
- Update OIDC server tests to include algorithms config

## Test plan
- Run existing unit tests for OIDC auth method (updated tests included)