### PR TITLE
feat(oidc): optionally merge userinfo claims into auth session

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -145,6 +145,7 @@ JsonPath: string
 			scopes?: [...string]
 			use_pkce?: bool
 			algorithms?: [...("RS256" | "RS384" | "RS512" | "ES256" | "ES384" | "ES512" | "PS256" | "PS384" | "PS512")] | *["RS256"]
+			fetch_extra_user_info?: bool
 		}
 
 	}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -434,6 +434,10 @@
                           "default": [
                             "RS256"
                           ]
+                        },
+                        "fetch_extra_user_info": {
+                          "type": "boolean",
+                          "default": false
                         }
                       }
                     }

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -526,14 +526,15 @@ func (a AuthenticationMethodOIDCConfig) validate() error {
 
 // AuthenticationOIDCProvider configures provider credentials
 type AuthenticationMethodOIDCProvider struct {
-	IssuerURL       string   `json:"issuerURL,omitempty" mapstructure:"issuer_url" yaml:"issuer_url,omitempty"`
-	ClientID        string   `json:"-" mapstructure:"client_id" yaml:"-"`
-	ClientSecret    string   `json:"-" mapstructure:"client_secret" yaml:"-"`
-	RedirectAddress string   `json:"redirectAddress,omitempty" mapstructure:"redirect_address" yaml:"redirect_address,omitempty"`
-	Nonce           string   `json:"nonce,omitempty" mapstructure:"nonce" yaml:"nonce,omitempty"`
-	Scopes          []string `json:"scopes,omitempty" mapstructure:"scopes" yaml:"scopes,omitempty"`
-	UsePKCE         bool     `json:"usePKCE,omitempty" mapstructure:"use_pkce" yaml:"use_pkce,omitempty"`
-	Algorithms      []string `json:"algorithms,omitempty" mapstructure:"algorithms" yaml:"algorithms,omitempty"`
+	IssuerURL          string   `json:"issuerURL,omitempty" mapstructure:"issuer_url" yaml:"issuer_url,omitempty"`
+	ClientID           string   `json:"-" mapstructure:"client_id" yaml:"-"`
+	ClientSecret       string   `json:"-" mapstructure:"client_secret" yaml:"-"`
+	RedirectAddress    string   `json:"redirectAddress,omitempty" mapstructure:"redirect_address" yaml:"redirect_address,omitempty"`
+	Nonce              string   `json:"nonce,omitempty" mapstructure:"nonce" yaml:"nonce,omitempty"`
+	Scopes             []string `json:"scopes,omitempty" mapstructure:"scopes" yaml:"scopes,omitempty"`
+	UsePKCE            bool     `json:"usePKCE,omitempty" mapstructure:"use_pkce" yaml:"use_pkce,omitempty"`
+	Algorithms         []string `json:"algorithms,omitempty" mapstructure:"algorithms" yaml:"algorithms,omitempty"`
+	FetchExtraUserInfo bool     `json:"fetchExtraUserInfo,omitempty" mapstructure:"fetch_extra_user_info" yaml:"fetch_extra_user_info,omitempty"`
 }
 
 func (a AuthenticationMethodOIDCProvider) setDefaults(defaults map[string]any) {


### PR DESCRIPTION
## Summary
Some OIDC providers keep ID token claims minimal and require calling the UserInfo endpoint to obtain additional attributes (for example: email, display name, or group membership). This adds an opt-in `include_user_info` provider option to fetch UserInfo during the callback flow and merge returned claims into the session claim set.

closes #5363.

## Changes
- Update configuration schema to allow `authentication.methods.oidc.providers.<provider>.include_user_info`
- Add `IncludeUserInfo` to OIDC provider config struct
- When enabled, call UserInfo endpoint and merge returned claims into existing claims

## Backward compatibility
- Default remains `false`

## Test plan
- Unit tests (added a new one besides existing OIDC callback/login tests)