### PR TITLE
chore: release v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 This format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0](https://github.com/flipt-io/flipt/releases/tag/v2.7.0) - 2026-02-17
+
+### Added
+
+- **SigV4 authentication for Prometheus analytics**: Support AWS SigV4 authentication for the analytics Prometheus storage backend, enabling integration with Amazon Managed Service for Prometheus (AMP) (#5388)
+
+### Fixed
+
+- **Default Git commit email**: Replace default Git commit email with a more appropriate value (#5383)
+
+### Changed
+
+- **Go 1.26**: Bumped Go version to 1.26.0 (#5386)
+- **go-git v6**: Updated go-git to v6.0.0 (#5381)
+
+### Dependencies
+
+- Updated various dependencies including OpenTelemetry, gRPC, AWS SDK, and UI libraries
+
 ## [2.6.0](https://github.com/flipt-io/flipt/releases/tag/v2.6.0) - 2026-02-07
 
 ### Added


### PR DESCRIPTION
## Summary

Release Flipt v2.7.0.

### Key Changes

- **SigV4 authentication for Prometheus analytics**: Support AWS SigV4 authentication for the analytics Prometheus storage backend (#5388)
- **Default Git commit email fix**: Replace default Git commit email with a more appropriate value (#5383)
- **Go 1.26**: Bumped Go version to 1.26.0 (#5386)
- **go-git v6**: Updated go-git to v6.0.0 (#5381)
- Various dependency updates