### PR TITLE
fix(ci): bump Go version to 1.26 in nightly release workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 jobs:
   nightly-build:


### PR DESCRIPTION
## Summary

The nightly release workflow was failing because `go.mod` requires `go >= 1.26.0` but the workflow was pinned to `GO_VERSION: "1.25"` with `GOTOOLCHAIN=local`, preventing automatic toolchain download and causing magefiles to fail to compile.

## Changes

- **Modified `.github/workflows/nightly.yml`**: Updated `GO_VERSION` from `1.25` to `1.26`

## Additional Notes

Fixes the failure seen in https://github.com/flipt-io/flipt/actions/runs/22160727197/job/64076498641