### PR TITLE
fix(authn): forward state and token cookies to distinct metadata keys

### DIFF
--- a/internal/server/authn/method/http.go
+++ b/internal/server/authn/method/http.go
@@ -48,7 +48,7 @@ func ForwardCookies(ctx context.Context, req *http.Request) metadata.MD {
 	md := metadata.MD{}
 	for _, key := range []string{stateCookieKey, tokenCookieKey} {
 		if cookie, err := req.Cookie(key); err == nil {
-			md[stateCookieKey] = []string{cookie.Value}
+			md[key] = []string{cookie.Value}
 		}
 	}
 

--- a/internal/server/authn/method/http_test.go
+++ b/internal/server/authn/method/http_test.go
@@ -1,11 +1,23 @@
 package method
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestForwardCookies(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieKey, Value: "state-value"})
+	req.AddCookie(&http.Cookie{Name: tokenCookieKey, Value: "token-value"})
+
+	md := ForwardCookies(t.Context(), req)
+
+	assert.Equal(t, []string{"state-value"}, md.Get(stateCookieKey))
+	assert.Equal(t, []string{"token-value"}, md.Get(tokenCookieKey))
+}
 
 func TestForwardPrefix(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
ForwardCookies was writing both flipt_client_state and flipt_client_token
cookies into the flipt_client_state metadata key. When both cookies were
present, callback state validation could fail with "unexpected state parameter",
commonly after restart when a stale token cookie existed.
