### PR TITLE
 fix(authn): forward state and token cookies to distinct metadata keys

### DIFF
--- a/internal/server/authn/method/http.go
+++ b/internal/server/authn/method/http.go
@@ -48,7 +48,7 @@ func ForwardCookies(ctx context.Context, req *http.Request) metadata.MD {
 	md := metadata.MD{}
 	for _, key := range []string{stateCookieKey, tokenCookieKey} {
 		if cookie, err := req.Cookie(key); err == nil {
-			md[stateCookieKey] = []string{cookie.Value}
+			md[key] = []string{cookie.Value}
 		}
 	}
 

--- a/internal/server/authn/method/http_test.go
+++ b/internal/server/authn/method/http_test.go
@@ -2,6 +2,7 @@ package method
 
 import (
 	"context"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -27,4 +28,15 @@ func TestForwardPrefix(t *testing.T) {
 			assert.Equal(t, tt.expected, md.Get(ForwardedPrefixKey))
 		})
 	}
+}
+
+func TestForwardCookies(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/auth/callback", nil)
+	req.AddCookie(&http.Cookie{Name: stateCookieKey, Value: "state-value"})
+	req.AddCookie(&http.Cookie{Name: tokenCookieKey, Value: "token-value"})
+
+	md := ForwardCookies(context.Background(), req)
+
+	assert.Equal(t, []string{"state-value"}, md.Get(stateCookieKey))
+	assert.Equal(t, []string{"token-value"}, md.Get(tokenCookieKey))
 }


### PR DESCRIPTION
same as #5479 but for v1