### PR TITLE
fix: set EnvironmentKey on evaluation requests in environment integration tests

### DIFF
--- a/build/testing/integration/environments/api_test.go
+++ b/build/testing/integration/environments/api_test.go
@@ -194,8 +194,9 @@ func TestAPI(t *testing.T) {
 								revision = enabled.Revision
 
 								resp, err := evalClient.Variant(ctx, &evaluation.EvaluationRequest{
-									NamespaceKey: namespace.Key,
-									FlagKey:      "test",
+									EnvironmentKey: env,
+									NamespaceKey:   namespace.Key,
+									FlagKey:        "test",
 								})
 								require.NoError(t, err)
 
@@ -280,8 +281,9 @@ func TestAPI(t *testing.T) {
 								assert.Equal(t, booleanEnabled, fetchedBooleanEnabled)
 
 								resp, err := evalClient.Boolean(ctx, &evaluation.EvaluationRequest{
-									NamespaceKey: namespace.Key,
-									FlagKey:      "boolean_enabled",
+									EnvironmentKey: env,
+									NamespaceKey:   namespace.Key,
+									FlagKey:        "boolean_enabled",
 								})
 								require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

- Fixed flaky environment integration tests (`envs` and `envs/dir`) caused by evaluation requests not specifying `EnvironmentKey`
- Without the key, evaluations always hit the default environment — when Go's random map iteration ran "production" first, flags didn't exist there yet, causing intermittent "not found" errors

## Changes

- **`build/testing/integration/environments/api_test.go`**: Added `EnvironmentKey: env` to the `Variant` and `Boolean` evaluation requests so they evaluate against the correct environment being tested

Fixes #5413