### PR TITLE
fix: add goarm64 variant to goreleaser prebuilt path template

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,8 +19,10 @@ builds:
       - arm64
     goamd64:
       - v1
+    goarm64:
+      - v8.0
     prebuilt:
-      path: tmp/dist/flipt_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}/flipt
+      path: tmp/dist/flipt_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}{{ with .Arm64 }}_{{ . }}{{ end }}/flipt
     binary: flipt
 
 sboms:


### PR DESCRIPTION
## Summary

- GoReleaser v2 defaults `goarm64` to `v8.0`, adding a `_v8.0` suffix to arm64 build output directories
- The prebuilt path template in `.goreleaser.yml` only accounted for the amd64 variant (`{{ with .Amd64 }}`), so arm64 binary imports failed during release
- Adds explicit `goarm64: [v8.0]` and `{{ with .Arm64 }}` to the path template

Fixes the failing release build: https://github.com/flipt-io/flipt/actions/runs/22772407725/job/66067382137