### PR TITLE
fix: bump node version from 18 to 20 in CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
           cache-dependency-path: ui/package-lock.json
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install GCC for arm64
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "20"
 
       - name: Install GCC for arm64
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
           cache-dependency-path: ui/package-lock.json
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
       - arm64
     goamd64:
       - v1
+    goarm64:
+      - v8.0
     prebuilt:
       path: tmp/dist/flipt_{{ .Os }}_{{ .Arch }}{{ with .Amd64 }}_{{ . }}{{ end }}{{ with .Arm64 }}_{{ . }}{{ end }}/flipt
     binary: flipt


### PR DESCRIPTION
## Summary

- Bumps Node.js from 18 to 20 across all CI workflows (release, nightly, lint, test)
- Multiple UI dependencies now require Node >= 20 (`@tailwindcss/oxide`, `prettier-plugin-tailwindcss`, `react-router`, `tailwindcss-radix`)
- Also adds explicit `goarm64: v8.0` to goreleaser config

Fixes the failing v2.8.0 release build: https://github.com/flipt-io/flipt/actions/runs/22775225026/job/66066639609