### PR TITLE
chore: migrate goreleaser configs to dockers_v2 and homebrew_casks

### DIFF
--- a/.goreleaser.nightly.yml
+++ b/.goreleaser.nightly.yml
@@ -50,40 +50,17 @@ nightly:
 changelog:
   disable: true
 
-dockers:
+dockers_v2:
   - dockerfile: ./build/Dockerfile
-    use: buildx
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "flipt/flipt:{{ .Version }}-amd64"
-      - "ghcr.io/flipt-io/flipt:{{ .Version }}-amd64"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-
-  - dockerfile: ./build/Dockerfile
-    use: buildx
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "flipt/flipt:{{ .Version }}-arm64"
-      - "ghcr.io/flipt-io/flipt:{{ .Version }}-arm64"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-
-docker_manifests:
-  - name_template: "flipt/flipt:{{ .Version }}"
-    image_templates:
-      - "flipt/flipt:{{ .Version }}-amd64"
-      - "flipt/flipt:{{ .Version }}-arm64"
-
-  - name_template: "ghcr.io/flipt-io/flipt:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/flipt-io/flipt:{{ .Version }}-amd64"
-      - "ghcr.io/flipt-io/flipt:{{ .Version }}-arm64"
+    images:
+      - "flipt/flipt"
+      - "ghcr.io/flipt-io/flipt"
+    tags:
+      - "{{ .Version }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,86 +77,34 @@ changelog:
     - title: "Other"
       order: 3
 
-dockers:
+dockers_v2:
   - dockerfile: ./build/Dockerfile
-    use: buildx
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "flipt/flipt:v{{ .Tag }}-amd64"
-      - "flipt/flipt:v{{ .Major }}-amd64"
-      - "ghcr.io/flipt-io/flipt:v{{ .Tag }}-amd64"
-      - "ghcr.io/flipt-io/flipt:v{{ .Major }}-amd64"
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-
-  - dockerfile: ./build/Dockerfile
-    use: buildx
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "flipt/flipt:v{{ .Tag }}-arm64"
-      - "flipt/flipt:v{{ .Major }}-arm64"
-      - "ghcr.io/flipt-io/flipt:v{{ .Tag }}-arm64"
-      - "ghcr.io/flipt-io/flipt:v{{ .Major }}-arm64"
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-
-docker_manifests:
-  - name_template: "flipt/flipt:v{{ .Tag }}"
-    image_templates:
-      - "flipt/flipt:v{{ .Tag }}-amd64"
-      - "flipt/flipt:v{{ .Tag }}-arm64"
-
-  - name_template: "ghcr.io/flipt-io/flipt:v{{ .Tag }}"
-    image_templates:
-      - "ghcr.io/flipt-io/flipt:v{{ .Tag }}-amd64"
-      - "ghcr.io/flipt-io/flipt:v{{ .Tag }}-arm64"
-
-  - name_template: "flipt/flipt:v{{ .Major }}"
-    image_templates:
-      - "flipt/flipt:v{{ .Major }}-amd64"
-      - "flipt/flipt:v{{ .Major }}-arm64"
-
-  - name_template: "ghcr.io/flipt-io/flipt:v{{ .Major }}"
-    image_templates:
-      - "ghcr.io/flipt-io/flipt:v{{ .Major }}-amd64"
-      - "ghcr.io/flipt-io/flipt:v{{ .Major }}-arm64"
+    images:
+      - "flipt/flipt"
+      - "ghcr.io/flipt-io/flipt"
+    tags:
+      - "v{{ .Tag }}"
+      - "v{{ .Major }}"
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Version}}"
 
 announce:
   discord:
     enabled: true
 
-brews:
+homebrew_casks:
   - name: flipt@2
     homepage: https://flipt.io
     description: A Git-first, CloudNative feature management solution
-    license: FCL-1.0-MIT
-    directory: Formula
+    directory: Casks
     skip_upload: auto
-    install: |
-      bin.install "flipt"
-      output = Utils.popen_read("SHELL=bash #{bin}/flipt completion bash")
-      (bash_completion/"flipt").write output
-      output = Utils.popen_read("SHELL=zsh #{bin}/flipt completion zsh")
-      (zsh_completion/"_flipt").write output
-
-    post_install: |
-      (var/"log/flipt").mkpath
-
-    service: |
-      run [opt_bin/"flipt", "server"]
-      environment_variables PATH: std_service_path_env
-      keep_alive true
-      error_log_path "#{var}/log/flipt/server-stderr.log"
-      log_path "#{var}/log/flipt/server-stdout.log"
-
+    binaries:
+      - flipt
     repository:
       owner: flipt-io
       name: homebrew-brew


### PR DESCRIPTION
## Summary

- Replace deprecated `dockers` + `docker_manifests` with `dockers_v2` in `.goreleaser.yml` and `.goreleaser.nightly.yml`
- Replace deprecated `brews` with `homebrew_casks` in `.goreleaser.yml`

Closes #5503

## Changes

### Docker (`dockers_v2`)

The two per-architecture `dockers` entries and separate `docker_manifests` entries are consolidated into a single `dockers_v2` block. GoReleaser handles per-platform builds and manifest creation internally. The resulting Docker images, tags, and multi-arch manifests are identical:

- `flipt/flipt:v{tag}`, `flipt/flipt:v{major}` (amd64 + arm64 manifests)
- `ghcr.io/flipt-io/flipt:v{tag}`, `ghcr.io/flipt-io/flipt:v{major}` (amd64 + arm64 manifests)
- Nightly: `{version}` tag on both registries

OCI labels are preserved via the `labels:` map (replacing `--label=` in `build_flag_templates`).

### Homebrew (`homebrew_casks`)

The `brews` section is replaced with `homebrew_casks`. Binary installation uses the cask-native `binaries: [flipt]` field.

**Intentionally dropped (need different approaches in casks):**

- **Shell completions** — The formula generated these at install time via `Utils.popen_read`. The cask `completions:` field requires pre-generated files in the release archive. Could be added as a follow-up by generating completion files during the build and including them in `archives.files`.
- **Homebrew service definition** — The formula's service DSL (launchd) has no direct cask equivalent. The cask `service:` field references a `.service` file rather than using a Ruby DSL block.
- **Post-install log directory** — `(var/"log/flipt").mkpath` was formula-specific. Could be added via `hooks.post.install` if needed.

### Not changed

- `build/Dockerfile` — no changes needed; `dockers_v2` handles per-platform binary staging
- `.goreleaser.darwin.yml`, `.goreleaser.linux.yml` — build-only configs with no deprecated sections

## Testing

- YAML syntax validated
- Verified semantic equivalence of Docker image/tag/manifest output
- Confirmed template variables (`.Tag`, `.Major`, `.Version`) correctly account for `monorepo.tag_prefix: v`