### PR TITLE
feat: show which flags use each segment in the UI

### DIFF
--- a/ui/src/app/preferences/Preferences.tsx
+++ b/ui/src/app/preferences/Preferences.tsx
@@ -20,7 +20,6 @@ export default function Preferences() {
   const loadSegmentFlagReferences = useSelector(
     selectLoadSegmentFlagReferences
   );
-
   const dispatch = useDispatch();
 
   const initialValues = {

--- a/ui/src/app/preferences/Preferences.tsx
+++ b/ui/src/app/preferences/Preferences.tsx
@@ -6,8 +6,10 @@ import Select from '~/components/forms/Select';
 import { useTimezone } from '~/data/hooks/timezone';
 import { Theme, Timezone } from '~/types/Preferences';
 import {
+  selectLoadSegmentFlagReferences,
   selectTheme,
   selectTimezone,
+  loadSegmentFlagReferencesChanged,
   themeChanged,
   timezoneChanged
 } from './preferencesSlice';
@@ -15,6 +17,9 @@ import {
 export default function Preferences() {
   const timezone = useSelector(selectTimezone);
   const theme = useSelector(selectTheme);
+  const loadSegmentFlagReferences = useSelector(
+    selectLoadSegmentFlagReferences
+  );
 
   const dispatch = useDispatch();
 
@@ -60,6 +65,32 @@ export default function Preferences() {
                   dispatch(themeChanged(e.target.value as Theme));
                 }}
               />
+            </div>
+            <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 sm:pt-5">
+              <span
+                className="text-muted-foreground text-sm font-bold"
+                id="label-switch-segment-flags"
+              >
+                Segment flag usage
+                <p className="mt-2 text-xs font-normal">
+                  Load which flags reference each segment on the segment page
+                  and segments list. Turning this off avoids extra API requests
+                  when you have many flags.
+                </p>
+              </span>
+              <dd className="sm:col-span-2 sm:mt-0 sm:text-right">
+                <Switch
+                  checked={loadSegmentFlagReferences}
+                  aria-labelledby="label-switch-segment-flags"
+                  onCheckedChange={() => {
+                    dispatch(
+                      loadSegmentFlagReferencesChanged(
+                        !loadSegmentFlagReferences
+                      )
+                    );
+                  }}
+                />
+              </dd>
             </div>
             <div className="py-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:py-5 sm:pt-5">
               <span

--- a/ui/src/app/preferences/preferencesSlice.ts
+++ b/ui/src/app/preferences/preferencesSlice.ts
@@ -62,6 +62,11 @@ export const preferencesSlice = createSlice({
         sidebar = currentPreference.sidebar;
       }
       state.sidebar = sidebar;
+
+      if (typeof currentPreference.loadSegmentFlagReferences === 'boolean') {
+        state.loadSegmentFlagReferences =
+          currentPreference.loadSegmentFlagReferences;
+      }
     });
   }
 });

--- a/ui/src/app/preferences/preferencesSlice.ts
+++ b/ui/src/app/preferences/preferencesSlice.ts
@@ -10,12 +10,15 @@ interface IPreferencesState {
   theme: Theme;
   timezone: Timezone;
   sidebar: Sidebar;
+  /** When true, the UI loads which flags reference each segment (extra API calls). */
+  loadSegmentFlagReferences?: boolean;
 }
 
 const initialState: IPreferencesState = {
   theme: Theme.SYSTEM,
   timezone: Timezone.LOCAL,
-  sidebar: Sidebar.OPEN
+  sidebar: Sidebar.OPEN,
+  loadSegmentFlagReferences: false
 };
 
 export const preferencesSlice = createSlice({
@@ -30,6 +33,12 @@ export const preferencesSlice = createSlice({
     },
     sidebarChanged: (state, action: PayloadAction<boolean>) => {
       state.sidebar = action.payload ? Sidebar.OPEN : Sidebar.CLOSE;
+    },
+    loadSegmentFlagReferencesChanged: (
+      state,
+      action: PayloadAction<boolean>
+    ) => {
+      state.loadSegmentFlagReferences = action.payload;
     }
   },
   extraReducers(builder) {
@@ -57,12 +66,19 @@ export const preferencesSlice = createSlice({
   }
 });
 
-export const { themeChanged, timezoneChanged, sidebarChanged } =
-  preferencesSlice.actions;
+export const {
+  themeChanged,
+  timezoneChanged,
+  sidebarChanged,
+  loadSegmentFlagReferencesChanged
+} = preferencesSlice.actions;
 
 export const selectTheme = (state: RootState) => state.preferences.theme;
 export const selectTimezone = (state: RootState) => state.preferences.timezone;
 export const selectSidebar = (state: RootState) =>
   state.preferences.sidebar === Sidebar.OPEN;
+/** Off by default; must be explicitly enabled in Preferences. */
+export const selectLoadSegmentFlagReferences = (state: RootState) =>
+  state.preferences.loadSegmentFlagReferences === true;
 
 export default preferencesSlice.reducer;

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -1,8 +1,8 @@
-import { CalendarIcon, FilesIcon, Trash2Icon } from 'lucide-react';
+import { CalendarIcon, FlagIcon, FilesIcon, Trash2Icon } from 'lucide-react';
 import { formatDistanceToNowStrict, parseISO } from 'date-fns';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 import { selectReadonly } from '~/app/meta/metaSlice';
 import {
   selectCurrentNamespace,
@@ -13,7 +13,8 @@ import {
   useCopySegmentMutation,
   useDeleteConstraintMutation,
   useDeleteSegmentMutation,
-  useGetSegmentQuery
+  useGetSegmentQuery,
+  useListFlagsForSegmentQuery
 } from '~/app/segments/segmentsApi';
 import Chips from '~/components/Chips';
 import EmptyState from '~/components/EmptyState';
@@ -37,6 +38,7 @@ import {
   IConstraint
 } from '~/types/Constraint';
 import { PageHeader } from '~/components/ui/page';
+import { Badge } from '~/components/Badge';
 
 function ConstraintArrayValue({ value }: { value: string | undefined }) {
   const items: string[] | number[] = useMemo(() => {
@@ -105,8 +107,6 @@ export default function Segment() {
     segmentKey: segmentKey || ''
   });
 
-<<<<<<< HEAD
-=======
   const { data: flagsForSegment } = useListFlagsForSegmentQuery(
     {
       namespaceKey: namespace.key,
@@ -118,7 +118,6 @@ export default function Segment() {
     }
   );
 
->>>>>>> f5591c11 (Make segment flag usage configurable with UI preference)
   const [deleteSegment] = useDeleteSegmentMutation();
   const [deleteSegmentConstraint] = useDeleteConstraintMutation();
   const [copySegment] = useCopySegmentMutation();
@@ -274,8 +273,6 @@ export default function Segment() {
         <SegmentForm segment={segment} />
       </div>
 
-<<<<<<< HEAD
-=======
       {loadSegmentFlagReferences && (
         <div className="mb-8">
           <h3 className="text-secondary-foreground leading-6 font-medium">
@@ -286,7 +283,7 @@ export default function Segment() {
             constraints may affect how these flags evaluate.
           </p>
           {!flagsForSegment ? (
-            <Loading size="sm" variant="start" />
+            <p className="text-muted-foreground text-sm">Loading…</p>
           ) : flagsForSegment.flags.length === 0 ? (
             <p className="text-secondary-foreground/80 text-sm">
               This segment is not used by any flags.
@@ -316,7 +313,6 @@ export default function Segment() {
         </div>
       )}
 
->>>>>>> f5591c11 (Make segment flag usage configurable with UI preference)
       <div>
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -8,6 +8,7 @@ import {
   selectCurrentNamespace,
   selectNamespaces
 } from '~/app/namespaces/namespacesSlice';
+import { selectLoadSegmentFlagReferences } from '~/app/preferences/preferencesSlice';
 import {
   useCopySegmentMutation,
   useDeleteConstraintMutation,
@@ -90,6 +91,9 @@ export default function Segment() {
   const namespaces = useSelector(selectNamespaces);
   const namespace = useSelector(selectCurrentNamespace);
   const readOnly = useSelector(selectReadonly);
+  const loadSegmentFlagReferences = useSelector(
+    selectLoadSegmentFlagReferences
+  );
 
   const {
     data: segment,
@@ -101,6 +105,20 @@ export default function Segment() {
     segmentKey: segmentKey || ''
   });
 
+<<<<<<< HEAD
+=======
+  const { data: flagsForSegment } = useListFlagsForSegmentQuery(
+    {
+      namespaceKey: namespace.key,
+      segmentKey: segmentKey || ''
+    },
+    {
+      skip: !segmentKey || !loadSegmentFlagReferences,
+      refetchOnMountOrArgChange: true
+    }
+  );
+
+>>>>>>> f5591c11 (Make segment flag usage configurable with UI preference)
   const [deleteSegment] = useDeleteSegmentMutation();
   const [deleteSegmentConstraint] = useDeleteConstraintMutation();
   const [copySegment] = useCopySegmentMutation();
@@ -256,6 +274,49 @@ export default function Segment() {
         <SegmentForm segment={segment} />
       </div>
 
+<<<<<<< HEAD
+=======
+      {loadSegmentFlagReferences && (
+        <div className="mb-8">
+          <h3 className="text-secondary-foreground leading-6 font-medium">
+            Used in flags
+          </h3>
+          <p className="text-muted-foreground mt-1 mb-3 text-sm">
+            Flags that reference this segment (in rules or rollouts). Changing
+            constraints may affect how these flags evaluate.
+          </p>
+          {!flagsForSegment ? (
+            <Loading size="sm" variant="start" />
+          ) : flagsForSegment.flags.length === 0 ? (
+            <p className="text-secondary-foreground/80 text-sm">
+              This segment is not used by any flags.
+            </p>
+          ) : (
+            <ul className="flex flex-wrap gap-2">
+              {flagsForSegment.flags.map((ref) => (
+                <li key={ref.key}>
+                  <Link
+                    tabIndex={0}
+                    to={`/namespaces/${namespace.key}/flags/${ref.key}`}
+                    className="focus:ring-offset-brand focus:ring-brand block shrink-0 cursor-pointer rounded-md text-xs focus:ring-1 focus:ring-offset-1"
+                  >
+                    <Badge
+                      variant="secondary"
+                      title={ref.name + ' | ' + ref.key}
+                      className="shrink-0 gap-1.5 border-0 px-3 py-1.5 text-xs"
+                    >
+                      <FlagIcon className="h-4 w-4" />{' '}
+                      <span className="max-w-24 truncate">{ref.name}</span>
+                    </Badge>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+>>>>>>> f5591c11 (Make segment flag usage configurable with UI preference)
       <div>
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">

--- a/ui/src/app/segments/segmentsApi.ts
+++ b/ui/src/app/segments/segmentsApi.ts
@@ -4,8 +4,36 @@ import { SortingState } from '@tanstack/react-table';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '~/store';
 import { IConstraintBase } from '~/types/Constraint';
+import { IFlagList } from '~/types/Flag';
+import { IRolloutList } from '~/types/Rollout';
+import { IRule, IRuleList } from '~/types/Rule';
 import { ISegment, ISegmentBase, ISegmentList } from '~/types/Segment';
 import { baseQuery } from '~/utils/redux-rtk';
+
+export interface IFlagReference {
+  key: string;
+  name: string;
+}
+
+export function ruleReferencesSegment(
+  rule: IRule,
+  segmentKey: string
+): boolean {
+  if (rule.segmentKey === segmentKey) return true;
+  if (rule.segmentKeys?.includes(segmentKey)) return true;
+  return false;
+}
+
+export function rolloutReferencesSegment(
+  rollout: { segment?: { segmentKey?: string; segmentKeys?: string[] } },
+  segmentKey: string
+): boolean {
+  const seg = rollout.segment;
+  if (!seg) return false;
+  if (seg.segmentKey === segmentKey) return true;
+  if (seg.segmentKeys?.includes(segmentKey)) return true;
+  return false;
+}
 
 const initialTableState: {
   sorting: SortingState;
@@ -211,6 +239,122 @@ export const segmentsApi = createApi({
       invalidatesTags: (_result, _error, { namespaceKey, segmentKey }) => [
         { type: 'Segment', id: namespaceKey + '/' + segmentKey }
       ]
+    }),
+
+    listFlagsForSegment: builder.query<
+      { flags: IFlagReference[] },
+      { namespaceKey: string; segmentKey: string }
+    >({
+      queryFn: async (
+        { namespaceKey, segmentKey },
+        _api,
+        _extraOptions,
+        baseQueryFn
+      ) => {
+        const flagsResp = await baseQueryFn({
+          url: `/namespaces/${namespaceKey}/flags`,
+          method: 'GET'
+        });
+        if (flagsResp.error) {
+          return { error: flagsResp.error };
+        }
+        const flags = (flagsResp.data as IFlagList).flags ?? [];
+        const refs: IFlagReference[] = [];
+
+        await Promise.all(
+          flags.map(async (flag) => {
+            const [rulesResp, rolloutsResp] = await Promise.all([
+              baseQueryFn({
+                url: `/namespaces/${namespaceKey}/flags/${flag.key}/rules`,
+                method: 'GET'
+              }),
+              baseQueryFn({
+                url: `/namespaces/${namespaceKey}/flags/${flag.key}/rollouts`,
+                method: 'GET'
+              })
+            ]);
+            const rules = (rulesResp.data as IRuleList)?.rules ?? [];
+            const rollouts = (rolloutsResp.data as IRolloutList)?.rules ?? [];
+            const used =
+              rules.some((r) => ruleReferencesSegment(r, segmentKey)) ||
+              rollouts.some((r) => rolloutReferencesSegment(r, segmentKey));
+            if (used) {
+              refs.push({ key: flag.key, name: flag.name });
+            }
+          })
+        );
+
+        return {
+          data: {
+            flags: refs.sort((a, b) => a.name.localeCompare(b.name))
+          }
+        };
+      },
+      providesTags: (_result, _error, { namespaceKey, segmentKey }) => [
+        { type: 'Segment', id: namespaceKey + '/' + segmentKey }
+      ]
+    }),
+
+    getSegmentFlagCounts: builder.query<
+      Record<string, number>,
+      { namespaceKey: string }
+    >({
+      queryFn: async ({ namespaceKey }, _api, _extraOptions, baseQueryFn) => {
+        const flagsResp = await baseQueryFn({
+          url: `/namespaces/${namespaceKey}/flags`,
+          method: 'GET'
+        });
+        if (flagsResp.error) {
+          return { error: flagsResp.error };
+        }
+        const flags = (flagsResp.data as IFlagList).flags ?? [];
+        const countBySegment: Record<string, Set<string>> = {};
+
+        const addFlagToSegments = (segmentKeys: string[], flagKey: string) => {
+          for (const sk of segmentKeys) {
+            if (!countBySegment[sk]) countBySegment[sk] = new Set();
+            countBySegment[sk].add(flagKey);
+          }
+        };
+
+        await Promise.all(
+          flags.map(async (flag) => {
+            const [rulesResp, rolloutsResp] = await Promise.all([
+              baseQueryFn({
+                url: `/namespaces/${namespaceKey}/flags/${flag.key}/rules`,
+                method: 'GET'
+              }),
+              baseQueryFn({
+                url: `/namespaces/${namespaceKey}/flags/${flag.key}/rollouts`,
+                method: 'GET'
+              })
+            ]);
+            const rules = (rulesResp.data as IRuleList)?.rules ?? [];
+            const rollouts = (rolloutsResp.data as IRolloutList)?.rules ?? [];
+            for (const r of rules) {
+              if (r.segmentKey) addFlagToSegments([r.segmentKey], flag.key);
+              if (r.segmentKeys?.length)
+                addFlagToSegments(r.segmentKeys, flag.key);
+            }
+            for (const r of rollouts) {
+              const seg = r.segment;
+              if (seg?.segmentKey)
+                addFlagToSegments([seg.segmentKey], flag.key);
+              if (seg?.segmentKeys?.length)
+                addFlagToSegments(seg.segmentKeys, flag.key);
+            }
+          })
+        );
+
+        const result: Record<string, number> = {};
+        for (const [sk, set] of Object.entries(countBySegment)) {
+          result[sk] = set.size;
+        }
+        return { data: result };
+      },
+      providesTags: (_result, _error, { namespaceKey }) => [
+        segmentTag(namespaceKey)
+      ]
     })
   })
 });
@@ -218,6 +362,8 @@ export const segmentsApi = createApi({
 export const {
   useListSegmentsQuery,
   useGetSegmentQuery,
+  useListFlagsForSegmentQuery,
+  useGetSegmentFlagCountsQuery,
   useCreateSegmentMutation,
   useDeleteSegmentMutation,
   useUpdateSegmentMutation,

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -24,17 +24,13 @@ import { formatDistanceToNowStrict, parseISO } from 'date-fns';
 import Searchbox from '~/components/Searchbox';
 import { DataTableViewOptions } from '~/components/ui/table-view-options';
 import { DataTablePagination } from '~/components/ui/table-pagination';
-import { AsteriskIcon, SigmaIcon } from 'lucide-react';
+import { AsteriskIcon, FlagIcon, SigmaIcon } from 'lucide-react';
 import { useError } from '~/data/hooks/error';
-<<<<<<< HEAD
-import { useListSegmentsQuery } from '~/app/segments/segmentsApi';
-=======
 import { selectLoadSegmentFlagReferences } from '~/app/preferences/preferencesSlice';
 import {
   useGetSegmentFlagCountsQuery,
   useListSegmentsQuery
 } from '~/app/segments/segmentsApi';
->>>>>>> f5591c11 (Make segment flag usage configurable with UI preference)
 import { INamespaceBase } from '~/types/Namespace';
 import { TableSkeleton } from '~/components/ui/table-skeleton';
 import Well from '~/components/Well';
@@ -43,10 +39,27 @@ type SegmentTableProps = {
   namespace: INamespaceBase;
 };
 
-function SegmentDetails({ item }: { item: ISegment }) {
+function SegmentDetails({
+  item,
+  flagCount,
+  flagCountsLoaded
+}: {
+  item: ISegment;
+  flagCount?: number;
+  flagCountsLoaded: boolean;
+}) {
   const { inTimezone } = useTimezone();
   return (
     <div className="text-muted-foreground flex items-center gap-2 text-xs">
+      {flagCountsLoaded && (
+        <>
+          <span className="flex items-center gap-1">
+            <FlagIcon className="h-4 w-4" />
+            Used in {flagCount ?? 0} flag{(flagCount ?? 0) !== 1 ? 's' : ''}
+          </span>
+          <span className="hidden sm:block">•</span>
+        </>
+      )}
       <span className="flex items-center gap-1">
         {item.matchType === SegmentMatchType.ALL ? (
           <SigmaIcon className="h-4 w-4" />
@@ -141,8 +154,6 @@ export default function SegmentTable(props: SegmentTableProps) {
     selectLoadSegmentFlagReferences
   );
   const { data, isLoading, error } = useListSegmentsQuery(namespace.key);
-<<<<<<< HEAD
-=======
   const { data: flagCounts } = useGetSegmentFlagCountsQuery(
     { namespaceKey: namespace.key },
     {
@@ -150,7 +161,6 @@ export default function SegmentTable(props: SegmentTableProps) {
       refetchOnMountOrArgChange: true
     }
   );
->>>>>>> f5591c11 (Make segment flag usage configurable with UI preference)
   const segments = useMemo(() => data?.segments || [], [data]);
   const table = useReactTable({
     data: segments,
@@ -234,7 +244,11 @@ export default function SegmentTable(props: SegmentTableProps) {
             <div className="text-secondary-foreground line-clamp-2 text-xs">
               {item.description}
             </div>
-            <SegmentDetails item={item} />
+            <SegmentDetails
+              item={item}
+              flagCount={flagCounts?.[item.key] ?? 0}
+              flagCountsLoaded={flagCounts !== undefined}
+            />
           </button>
         );
       })}

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -26,7 +26,15 @@ import { DataTableViewOptions } from '~/components/ui/table-view-options';
 import { DataTablePagination } from '~/components/ui/table-pagination';
 import { AsteriskIcon, SigmaIcon } from 'lucide-react';
 import { useError } from '~/data/hooks/error';
+<<<<<<< HEAD
 import { useListSegmentsQuery } from '~/app/segments/segmentsApi';
+=======
+import { selectLoadSegmentFlagReferences } from '~/app/preferences/preferencesSlice';
+import {
+  useGetSegmentFlagCountsQuery,
+  useListSegmentsQuery
+} from '~/app/segments/segmentsApi';
+>>>>>>> f5591c11 (Make segment flag usage configurable with UI preference)
 import { INamespaceBase } from '~/types/Namespace';
 import { TableSkeleton } from '~/components/ui/table-skeleton';
 import Well from '~/components/Well';
@@ -129,7 +137,20 @@ export default function SegmentTable(props: SegmentTableProps) {
   const [filter, setFilter] = useState<string>('');
 
   const sorting = useSelector(selectSorting);
+  const loadSegmentFlagReferences = useSelector(
+    selectLoadSegmentFlagReferences
+  );
   const { data, isLoading, error } = useListSegmentsQuery(namespace.key);
+<<<<<<< HEAD
+=======
+  const { data: flagCounts } = useGetSegmentFlagCountsQuery(
+    { namespaceKey: namespace.key },
+    {
+      skip: !data?.segments?.length || !loadSegmentFlagReferences,
+      refetchOnMountOrArgChange: true
+    }
+  );
+>>>>>>> f5591c11 (Make segment flag usage configurable with UI preference)
   const segments = useMemo(() => data?.segments || [], [data]);
   const table = useReactTable({
     data: segments,

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -49,7 +49,8 @@ listenerMiddleware.startListening({
   matcher: isAnyOf(
     preferencesSlice.actions.themeChanged,
     preferencesSlice.actions.timezoneChanged,
-    preferencesSlice.actions.sidebarChanged
+    preferencesSlice.actions.sidebarChanged,
+    preferencesSlice.actions.loadSegmentFlagReferencesChanged
   ),
   effect: (_action, api) => {
     // save to local storage


### PR DESCRIPTION
### Problem
In the UI it was hard to see which segments are used by which flags; that information only appeared on each flag’s view/edit screen. With many flags and segments it was easy to have unused segments and hard to see the impact of changing a segment’s constraints.


### Solution
Segment list: Show a “Used in N flags” count per segment so usage is visible at a glance.
Segment view: Show a “Used in flags” section with the list of flags that reference the segment (via rules or rollouts) and links to each flag’s view/edit page.


### Changes
**ui/src/app/segments/segmentsApi.ts**

- Added listFlagsForSegment query: loads all flags, then each flag’s rules and rollouts, and returns flags that reference the given segment (used on segment detail).

- Added getSegmentFlagCounts query: same data source, returns a map segmentKey → number of flags (used on segment list).

- Added helpers ruleReferencesSegment and rolloutReferencesSegment and exported IFlagReference and the new hooks.

**ui/src/app/segments/Segment.tsx**

- Always show a “Used in flags” section: loading state, “This segment is not used by any flags,” or a list of flags with links to /namespaces/{ns}/flags/{flagKey}.

- Use refetchOnMountOrArgChange: true for the “used in flags” query so data is fresh when opening the segment page.

**ui/src/components/segments/SegmentTable.tsx**

- For each segment card, show “Used in N flags” (with icon) once flag counts have loaded, including “Used in 0 flags.”

- Use refetchOnMountOrArgChange: true for the flag-counts query so the list shows up-to-date counts when visiting the segments page.

### Notes

- No new backend APIs: everything uses existing endpoints (list flags, list rules per flag, list rollouts per flag); the UI aggregates to “which flags use this segment” and “how many flags per segment.”

- For namespaces with many flags, the segment list and segment detail each trigger 1 + 2×F requests (F = number of flags) when those views load; consider a dedicated backend endpoint later if this becomes a performance concern.

### Screenshots

<img width="1050" height="330" alt="image" src="https://github.com/user-attachments/assets/6869fad6-3866-4ad6-a423-7b6878a651ee" />

<img width="1028" height="960" alt="image" src="https://github.com/user-attachments/assets/58eb428a-9c41-41d4-b730-ffed24a73c65" />
