### PR TITLE
feat: publish v2 protobufs to buf.build/flipt-io/v2

### DIFF
--- a/.github/workflows/proto-push.yml
+++ b/.github/workflows/proto-push.yml
@@ -16,23 +16,19 @@ jobs:
           setup_only: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: also include v2/environments
       - uses: bufbuild/buf-action@v1
         with:
-          input: "rpc/flipt"
+          input: "rpc/v2"
           lint: true
 
-      # TODO: also include v2/environments
       - uses: bufbuild/buf-action@v1
         with:
-          input: "rpc/flipt"
+          input: "rpc/v2"
           breaking: true
           breaking_against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=v2"
 
-      # TODO: we need to version the protos for pushing
-      # TODO: also include v2/environments
-#       - uses: bufbuild/buf-action@v1
-#         with:
-#           input: "rpc/flipt"
-#           push: true
-#           token: ${{ secrets.BUF_TOKEN }}
+      - uses: bufbuild/buf-action@v1
+        with:
+          input: "rpc/v2"
+          push: true
+          token: ${{ secrets.BUF_TOKEN }}

--- a/buf.yaml
+++ b/buf.yaml
@@ -3,7 +3,7 @@ modules:
   - path: rpc/flipt
     name: buf.build/flipt-io/flipt
   - path: rpc/v2
-    name: buf.build/flipt-io/flipt-v2
+    name: buf.build/flipt-io/v2
 deps:
   - buf.build/googleapis/googleapis
   - buf.build/grpc-ecosystem/grpc-gateway


### PR DESCRIPTION
## Summary

Publish Flipt v2 protobufs under a dedicated Buf module without impacting v1.

## Changes
- Update `buf.yaml` to publish all v2 protos as one module:
  - `path: rpc/v2`
  - `name: buf.build/flipt-io/v2`
- Enable `v2*` tag workflow in `.github/workflows/proto-push.yml` to:
  - lint `rpc/v2`
  - run breaking checks for `rpc/v2` against `branch=v2`
  - push `rpc/v2` using `BUF_TOKEN`

## Notes
- Keeps `buf.build/flipt-io/flipt` unchanged.
- Implemented on branch `feat/buf-v2-publish` in response to paperclip follow-up.
