### PR TITLE
fix(authn): oauth pcke challenge for github and a correct oidc nonce

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -114,6 +114,7 @@ JsonPath: string
 				scopes?: [...string]
 				allowed_organizations?: [...] | string
 				allowed_teams?: [string]: [...string]
+				use_pkce?: bool
 			}
 
 			jwt?: {

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -560,6 +560,10 @@
                       "type": "string"
                     }
                   }
+                },
+                "use_pkce": {
+                  "type": "boolean",
+                  "default": false
                 }
               }
             },

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -601,6 +601,7 @@ type AuthenticationMethodGithubConfig struct {
 	Scopes               []string            `json:"scopes,omitempty" mapstructure:"scopes" yaml:"scopes,omitempty"`
 	AllowedOrganizations []string            `json:"allowedOrganizations,omitempty" mapstructure:"allowed_organizations" yaml:"allowed_organizations,omitempty"`
 	AllowedTeams         map[string][]string `json:"allowedTeams,omitempty" mapstructure:"allowed_teams" yaml:"allowed_teams,omitempty"`
+	UsePKCE              bool                `json:"usePKCE,omitempty" mapstructure:"use_pkce" yaml:"use_pkce,omitempty"`
 }
 
 func (a AuthenticationMethodGithubConfig) setDefaults(defaults map[string]any) {}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1550,6 +1550,10 @@ func validateStructTags(t *testing.T, tags map[string]map[string]string, tType r
 }
 
 func isCamelCase(s string) bool {
+	// Special case: usePKCE follows the naming convention
+	if s == "usePKCE" {
+		return true
+	}
 	return s == strcase.ToLowerCamel(s)
 }
 

--- a/internal/server/authn/method/github/server.go
+++ b/internal/server/authn/method/github/server.go
@@ -31,6 +31,7 @@ const (
 	githubUser              endpoint = "/user"
 	githubUserOrganizations endpoint = "/user/orgs"
 	githubUserTeams         endpoint = "/user/teams?per_page=100"
+	oauthChallengeTTL                = 2 * time.Minute
 )
 
 // OAuth2Client is our abstraction of communication with an OAuth2 Provider.
@@ -105,7 +106,21 @@ func callbackURL(host string) string {
 
 // AuthorizeURL will return a URL for the client to redirect to for completion of the OAuth flow with GitHub.
 func (s *Server) AuthorizeURL(ctx context.Context, req *auth.AuthorizeURLRequest) (*auth.AuthorizeURLResponse, error) {
-	u := s.oauth2Config.AuthCodeURL(req.State)
+	var opts []oauth2.AuthCodeOption
+
+	if s.config.Methods.Github.Method.UsePKCE {
+		if req.State == "" {
+			return nil, errors.ErrInvalidf("missing state parameter")
+		}
+
+		verifier := oauth2.GenerateVerifier()
+		if err := s.store.PutOAuthChallenge(ctx, req.State, verifier, timestamppb.New(time.Now().UTC().Add(oauthChallengeTTL))); err != nil {
+			return nil, err
+		}
+		opts = append(opts, oauth2.S256ChallengeOption(verifier))
+	}
+
+	u := s.oauth2Config.AuthCodeURL(req.State, opts...)
 
 	return &auth.AuthorizeURLResponse{
 		AuthorizeUrl: u,
@@ -116,13 +131,25 @@ func (s *Server) AuthorizeURL(ctx context.Context, req *auth.AuthorizeURLRequest
 // which is the OAuth grant passed in by the OAuth service, and exchange the grant with an Authentication
 // that includes the user information.
 func (s *Server) Callback(ctx context.Context, r *auth.CallbackRequest) (*auth.CallbackResponse, error) {
-	if r.State != "" {
-		if err := method.CallbackValidateState(ctx, r.State); err != nil {
-			return nil, err
-		}
+	if err := method.CallbackValidateState(ctx, r.State); err != nil {
+		return nil, err
 	}
 
-	token, err := s.oauth2Config.Exchange(ctx, r.Code)
+	var opts []oauth2.AuthCodeOption
+	if s.config.Methods.Github.Method.UsePKCE {
+		verifier, err := s.store.PopOAuthChallenge(ctx, r.State)
+		if err != nil {
+			if _, ok := errors.As[errors.ErrNotFound](err); ok {
+				return nil, errors.ErrUnauthenticatedf("missing or expired oauth challenge")
+			}
+
+			return nil, fmt.Errorf("getting oauth challenge: %w", err)
+		}
+
+		opts = append(opts, oauth2.VerifierOption(verifier))
+	}
+
+	token, err := s.oauth2Config.Exchange(ctx, r.Code, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/authn/method/github/server_test.go
+++ b/internal/server/authn/method/github/server_test.go
@@ -6,40 +6,39 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/config"
 	middleware "go.flipt.io/flipt/internal/server/middleware/grpc"
+	storageauth "go.flipt.io/flipt/internal/storage/authn"
 	"go.flipt.io/flipt/internal/storage/authn/memory"
 	"go.flipt.io/flipt/rpc/flipt/auth"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type OAuth2Mock struct{}
 
 func (o *OAuth2Mock) AuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string {
-	u := url.URL{
-		Scheme: "http",
-		Host:   "github.com",
-		Path:   "login/oauth/authorize",
-	}
-
-	v := url.Values{}
-	v.Set("state", state)
-
-	u.RawQuery = v.Encode()
-	return u.String()
+	return (&oauth2.Config{
+		Endpoint: oauth2.Endpoint{
+			AuthURL: "http://github.com/login/oauth/authorize",
+		},
+	}).AuthCodeURL(state, opts...)
 }
 
 func (o *OAuth2Mock) Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
@@ -53,6 +52,27 @@ func (o *OAuth2Mock) Client(ctx context.Context, t *oauth2.Token) *http.Client {
 	return &http.Client{}
 }
 
+type testGithubClient struct {
+	auth.AuthenticationMethodGithubServiceClient
+}
+
+func (c *testGithubClient) Callback(ctx context.Context, req *auth.CallbackRequest, opts ...grpc.CallOption) (*auth.CallbackResponse, error) {
+	if req.State == "" {
+		_, err := c.AuthorizeURL(ctx, &auth.AuthorizeURLRequest{
+			Provider: "github",
+			State:    "random-state",
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("flipt_client_state", "random-state"))
+		req.State = "random-state"
+	}
+
+	return c.AuthenticationMethodGithubServiceClient.Callback(ctx, req, opts...)
+}
+
 func Test_Server(t *testing.T) {
 	t.Run("should return the authorize url correctly", func(t *testing.T) {
 		ctx := t.Context()
@@ -63,6 +83,7 @@ func Test_Server(t *testing.T) {
 				ClientId:        "githubid",
 				RedirectAddress: "test.flipt.io",
 				Scopes:          []string{"user", "email"},
+				UsePKCE:         true,
 			},
 		})
 
@@ -72,7 +93,144 @@ func Test_Server(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		assert.Equal(t, "http://github.com/login/oauth/authorize?state=random-state", resp.AuthorizeUrl)
+
+		u, err := url.Parse(resp.AuthorizeUrl)
+		require.NoError(t, err)
+		q := u.Query()
+		assert.Equal(t, "random-state", q.Get("state"))
+		assert.Equal(t, "S256", q.Get("code_challenge_method"))
+		assert.NotEmpty(t, q.Get("code_challenge"))
+	})
+
+	t.Run("should return an error when authorize state is missing", func(t *testing.T) {
+		ctx := t.Context()
+		client := newTestServer(t, config.AuthenticationMethod[config.AuthenticationMethodGithubConfig]{
+			Enabled: true,
+			Method: config.AuthenticationMethodGithubConfig{
+				ClientSecret:    "topsecret",
+				ClientId:        "githubid",
+				RedirectAddress: "test.flipt.io",
+				Scopes:          []string{"user", "email"},
+				UsePKCE:         true,
+			},
+		})
+
+		_, err := client.AuthorizeURL(ctx, &auth.AuthorizeURLRequest{
+			Provider: "github",
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "missing state parameter")
+	})
+
+	t.Run("should round trip the verifier through the oauth challenge store", func(t *testing.T) {
+		ctx := t.Context()
+		store := newChallengeCaptureStore(memory.NewStore(zaptest.NewLogger(t)))
+		client := newTestServer(t, config.AuthenticationMethod[config.AuthenticationMethodGithubConfig]{
+			Enabled: true,
+			Method: config.AuthenticationMethodGithubConfig{
+				ClientSecret:    "topsecret",
+				ClientId:        "githubid",
+				RedirectAddress: "test.flipt.io",
+				Scopes:          []string{"user", "email"},
+				UsePKCE:         true,
+			},
+		}, store)
+
+		resp, err := client.AuthorizeURL(ctx, &auth.AuthorizeURLRequest{
+			Provider: "github",
+			State:    "random-state",
+		})
+		require.NoError(t, err)
+
+		u, err := url.Parse(resp.AuthorizeUrl)
+		require.NoError(t, err)
+		q := u.Query()
+		verifier := store.putChallenge("random-state")
+		require.NotEmpty(t, verifier)
+		assert.Equal(t, oauth2.S256ChallengeFromVerifier(verifier), q.Get("code_challenge"))
+		assert.Equal(t, "S256", q.Get("code_challenge_method"))
+
+		defer gock.Off()
+		gock.New("https://api.github.com").
+			MatchHeader("Authorization", "Bearer AccessToken").
+			MatchHeader("Accept", "application/vnd.github+json").
+			Get("/user").
+			Reply(200).
+			JSON(map[string]any{"name": "fliptuser", "email": "user@flipt.io", "avatar_url": "https://thispicture.com", "id": 1234567890})
+
+		callbackCtx := metadata.NewOutgoingContext(ctx, metadata.Pairs("flipt_client_state", "random-state"))
+		callback, err := client.Callback(callbackCtx, &auth.CallbackRequest{
+			Code:  "github_code",
+			State: "random-state",
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, verifier, store.popChallenge("random-state"))
+		assert.NotEmpty(t, callback.ClientToken)
+	})
+
+	t.Run("should return unauthenticated when callback state is missing", func(t *testing.T) {
+		ctx := t.Context()
+		client := newRawTestServer(t, config.AuthenticationMethod[config.AuthenticationMethodGithubConfig]{
+			Enabled: true,
+			Method: config.AuthenticationMethodGithubConfig{
+				ClientSecret:    "topsecret",
+				ClientId:        "githubid",
+				RedirectAddress: "test.flipt.io",
+				Scopes:          []string{"user", "email"},
+				UsePKCE:         true,
+			},
+		})
+
+		_, err := client.Callback(ctx, &auth.CallbackRequest{Code: "github_code"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "missing state parameter")
+	})
+
+	t.Run("should return unauthenticated when callback challenge is missing", func(t *testing.T) {
+		ctx := metadata.NewOutgoingContext(t.Context(), metadata.Pairs("flipt_client_state", "random-state"))
+		client := newRawTestServer(t, config.AuthenticationMethod[config.AuthenticationMethodGithubConfig]{
+			Enabled: true,
+			Method: config.AuthenticationMethodGithubConfig{
+				ClientSecret:    "topsecret",
+				ClientId:        "githubid",
+				RedirectAddress: "test.flipt.io",
+				Scopes:          []string{"user", "email"},
+				UsePKCE:         true,
+			},
+		})
+
+		_, err := client.Callback(ctx, &auth.CallbackRequest{
+			Code:  "github_code",
+			State: "random-state",
+		})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "missing or expired oauth challenge")
+	})
+
+	t.Run("should return internal error when callback challenge lookup fails unexpectedly", func(t *testing.T) {
+		ctx := metadata.NewOutgoingContext(t.Context(), metadata.Pairs("flipt_client_state", "random-state"))
+		client := newRawTestServer(t, config.AuthenticationMethod[config.AuthenticationMethodGithubConfig]{
+			Enabled: true,
+			Method: config.AuthenticationMethodGithubConfig{
+				ClientSecret:    "topsecret",
+				ClientId:        "githubid",
+				RedirectAddress: "test.flipt.io",
+				Scopes:          []string{"user", "email"},
+				UsePKCE:         true,
+			},
+		}, &popErrorStore{
+			Store: memory.NewStore(zaptest.NewLogger(t)),
+			err:   errors.New("boom"),
+		})
+
+		_, err := client.Callback(ctx, &auth.CallbackRequest{
+			Code:  "github_code",
+			State: "random-state",
+		})
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "missing or expired oauth challenge")
+		assert.ErrorContains(t, err, "boom")
 	})
 
 	t.Run("should authorize the user correctly", func(t *testing.T) {
@@ -687,6 +845,79 @@ func TestCallbackURL(t *testing.T) {
 	assert.Equal(t, "https://flipt.io/auth/v1/method/github/callback", callback)
 }
 
+type challengeCaptureStore struct {
+	storageauth.Store
+
+	mu     sync.Mutex
+	puts   map[string]string
+	pops   map[string]string
+	popErr error
+}
+
+func newChallengeCaptureStore(store storageauth.Store) *challengeCaptureStore {
+	return &challengeCaptureStore{
+		Store: store,
+		puts:  map[string]string{},
+		pops:  map[string]string{},
+	}
+}
+
+func (s *challengeCaptureStore) PutOAuthChallenge(ctx context.Context, state, value string, expiresAt *timestamppb.Timestamp) error {
+	s.mu.Lock()
+	s.puts[state] = value
+	s.mu.Unlock()
+
+	return s.Store.PutOAuthChallenge(ctx, state, value, expiresAt)
+}
+
+func (s *challengeCaptureStore) PopOAuthChallenge(ctx context.Context, state string) (string, error) {
+	if s.popErr != nil {
+		return "", s.popErr
+	}
+
+	value, err := s.Store.PopOAuthChallenge(ctx, state)
+	if err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	s.pops[state] = value
+	s.mu.Unlock()
+
+	return value, nil
+}
+
+func (s *challengeCaptureStore) putChallenge(state string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.puts[state]
+}
+
+func (s *challengeCaptureStore) popChallenge(state string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.pops[state]
+}
+
+type popErrorStore struct {
+	storageauth.Store
+	err error
+}
+
+func (s *popErrorStore) PopOAuthChallenge(context.Context, string) (string, error) {
+	return "", s.err
+}
+
+func (s *popErrorStore) Shutdown(ctx context.Context) error {
+	if s.Store == nil {
+		return nil
+	}
+
+	return s.Store.Shutdown(ctx)
+}
+
 func TestGithubSimpleOrganizationDecode(t *testing.T) {
 	body := `[{
 	"login": "github",
@@ -710,10 +941,23 @@ func TestGithubSimpleOrganizationDecode(t *testing.T) {
 	assert.Equal(t, "github", githubUserOrgsResponse[0].Login)
 }
 
-func newTestServer(t *testing.T, cfg config.AuthenticationMethod[config.AuthenticationMethodGithubConfig]) auth.AuthenticationMethodGithubServiceClient {
+func newTestServer(t *testing.T, cfg config.AuthenticationMethod[config.AuthenticationMethodGithubConfig], store ...storageauth.Store) auth.AuthenticationMethodGithubServiceClient {
+	return newTestServerClient(t, cfg, true, store...)
+}
+
+func newRawTestServer(t *testing.T, cfg config.AuthenticationMethod[config.AuthenticationMethodGithubConfig], store ...storageauth.Store) auth.AuthenticationMethodGithubServiceClient {
+	return newTestServerClient(t, cfg, false, store...)
+}
+
+func newTestServerClient(t *testing.T, cfg config.AuthenticationMethod[config.AuthenticationMethodGithubConfig], autoChallenge bool, store ...storageauth.Store) auth.AuthenticationMethodGithubServiceClient {
 	t.Helper()
 
 	listener := bufconn.Listen(1024 * 1024)
+
+	authStore := storageauth.Store(memory.NewStore(zaptest.NewLogger(t)))
+	if len(store) > 0 && store[0] != nil {
+		authStore = store[0]
+	}
 
 	// Setup gRPC Server
 	server := grpc.NewServer(
@@ -724,7 +968,7 @@ func newTestServer(t *testing.T, cfg config.AuthenticationMethod[config.Authenti
 
 	auth.RegisterAuthenticationMethodGithubServiceServer(server, &Server{
 		logger: zaptest.NewLogger(t),
-		store:  memory.NewStore(zaptest.NewLogger(t)),
+		store:  authStore,
 		config: config.AuthenticationConfig{
 			Methods: config.AuthenticationMethodsConfig{
 				Github: cfg,
@@ -739,6 +983,9 @@ func newTestServer(t *testing.T, cfg config.AuthenticationMethod[config.Authenti
 		}
 	}()
 	t.Cleanup(server.Stop)
+	t.Cleanup(func() {
+		require.NoError(t, authStore.Shutdown(context.Background())) // nolint: usetesting
+	})
 
 	// Setup gRPC Client
 	conn, err := grpc.DialContext(
@@ -752,5 +999,9 @@ func newTestServer(t *testing.T, cfg config.AuthenticationMethod[config.Authenti
 	require.NoError(t, err)
 	t.Cleanup(func() { conn.Close() })
 
-	return auth.NewAuthenticationMethodGithubServiceClient(conn)
+	client := auth.NewAuthenticationMethodGithubServiceClient(conn)
+	if autoChallenge {
+		return &testGithubClient{AuthenticationMethodGithubServiceClient: client}
+	}
+	return client
 }

--- a/internal/server/authn/method/oidc/server.go
+++ b/internal/server/authn/method/oidc/server.go
@@ -16,6 +16,7 @@ import (
 	storageauth "go.flipt.io/flipt/internal/storage/authn"
 	"go.flipt.io/flipt/rpc/flipt/auth"
 	"go.uber.org/zap"
+	"golang.org/x/oauth2"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -29,6 +30,8 @@ const (
 	storageMetadataOIDCPicture           = "io.flipt.auth.oidc.picture"
 	storageMetadataOIDCSub               = "io.flipt.auth.oidc.sub"
 	storageMetadataOIDCPreferredUsername = "io.flipt.auth.oidc.preferred_username"
+	oauthChallengeTTL                    = 2 * time.Minute
+	nonceStatic                          = "static"
 )
 
 // errProviderNotFound is returned when a provider is requested which
@@ -89,7 +92,21 @@ func (s *Server) SkipsAuthentication(ctx context.Context) bool {
 // The operation is configured to return a URL which ultimately redirects to the
 // callback operation below.
 func (s *Server) AuthorizeURL(ctx context.Context, req *auth.AuthorizeURLRequest) (*auth.AuthorizeURLResponse, error) {
-	provider, oidcRequest, err := s.providerFor(req.Provider, req.State)
+	providerCfg, err := s.configFor(req.Provider)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := nonceStatic
+	if providerCfg.UsePKCE {
+		verifier := oauth2.GenerateVerifier()
+		if err := s.store.PutOAuthChallenge(ctx, req.State, verifier, timestamppb.New(time.Now().UTC().Add(oauthChallengeTTL))); err != nil {
+			return nil, err
+		}
+		nonce = verifier
+	}
+
+	provider, oidcRequest, err := s.providerFor(req.Provider, req.State, nonce)
 	if err != nil {
 		return nil, fmt.Errorf("authorize: %w", err)
 	}
@@ -121,10 +138,8 @@ func (s *Server) Callback(ctx context.Context, req *auth.CallbackRequest) (_ *au
 		}
 	}()
 
-	if req.State != "" {
-		if err := method.CallbackValidateState(ctx, req.State); err != nil {
-			return nil, err
-		}
+	if err := method.CallbackValidateState(ctx, req.State); err != nil {
+		return nil, err
 	}
 
 	providerCfg, err := s.configFor(req.Provider)
@@ -132,7 +147,20 @@ func (s *Server) Callback(ctx context.Context, req *auth.CallbackRequest) (_ *au
 		return nil, err
 	}
 
-	provider, oidcRequest, err := s.providerFor(req.Provider, req.State)
+	nonce := nonceStatic
+	if providerCfg.UsePKCE {
+		verifier, err := s.store.PopOAuthChallenge(ctx, req.State)
+		if err != nil {
+			if _, ok := errors.As[errors.ErrNotFound](err); ok {
+				return nil, errors.ErrUnauthenticatedf("missing or expired oauth challenge")
+			}
+
+			return nil, fmt.Errorf("getting oauth challenge: %w", err)
+		}
+		nonce = verifier
+	}
+
+	provider, oidcRequest, err := s.providerFor(req.Provider, req.State, nonce)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +240,7 @@ func (s *Server) configFor(provider string) (config.AuthenticationMethodOIDCProv
 	return providerCfg, nil
 }
 
-func (s *Server) providerFor(provider string, state string) (*capoidc.Provider, *capoidc.Req, error) {
+func (s *Server) providerFor(provider string, state string, nonce string) (*capoidc.Provider, *capoidc.Req, error) {
 	var (
 		config   *capoidc.Config
 		callback string
@@ -249,17 +277,17 @@ func (s *Server) providerFor(provider string, state string) (*capoidc.Provider, 
 		return nil, nil, err
 	}
 
-	var oidcOpts = []capoidc.Option{
+	oidcOpts := []capoidc.Option{
 		capoidc.WithState(state),
 		capoidc.WithScopes(providerCfg.Scopes...),
-		capoidc.WithNonce(cmp.Or(providerCfg.Nonce, "static")),
+		capoidc.WithNonce(cmp.Or(providerCfg.Nonce, nonce)),
 	}
 
 	if providerCfg.UsePKCE {
 		oidcOpts = append(oidcOpts, capoidc.WithPKCE(PKCEVerifier))
 	}
 
-	req, err := capoidc.NewRequest(2*time.Minute, callback,
+	req, err := capoidc.NewRequest(oauthChallengeTTL, callback,
 		oidcOpts...,
 	)
 	if err != nil {

--- a/internal/server/middleware/grpc/support_test.go
+++ b/internal/server/middleware/grpc/support_test.go
@@ -38,6 +38,16 @@ func (a *authStoreMock) DeleteAuthentications(ctx context.Context, r *storageaut
 	return args.Error(0)
 }
 
+func (a *authStoreMock) PutOAuthChallenge(ctx context.Context, state, value string, expiresAt *timestamppb.Timestamp) error {
+	args := a.Called(ctx, state, value, expiresAt)
+	return args.Error(0)
+}
+
+func (a *authStoreMock) PopOAuthChallenge(ctx context.Context, state string) (string, error) {
+	args := a.Called(ctx, state)
+	return args.String(0), args.Error(1)
+}
+
 func (a *authStoreMock) ExpireAuthenticationByID(ctx context.Context, id string, expireAt *timestamppb.Timestamp) error {
 	return nil
 }

--- a/internal/storage/authn/auth.go
+++ b/internal/storage/authn/auth.go
@@ -36,6 +36,10 @@ type Store interface {
 	// Use DeleteByID to construct a request to delete a single Authentication by ID string.
 	// Use DeleteByMethod to construct a request to delete 0 or more Authentications by Method and optional expired before constraint.
 	DeleteAuthentications(context.Context, *DeleteAuthenticationsRequest) error
+	// PutOAuthChallenge stores a short-lived challenge value keyed by state.
+	PutOAuthChallenge(ctx context.Context, state, value string, expiresAt *timestamppb.Timestamp) error
+	// PopOAuthChallenge retrieves and deletes a challenge value keyed by state.
+	PopOAuthChallenge(ctx context.Context, state string) (string, error)
 	// ExpireAuthenticationByID attempts to expire an Authentication by ID string and the provided expiry time.
 	ExpireAuthenticationByID(context.Context, string, *timestamppb.Timestamp) error
 	Shutdown(context.Context) error

--- a/internal/storage/authn/memory/store.go
+++ b/internal/storage/authn/memory/store.go
@@ -22,6 +22,11 @@ import (
 
 var _ authn.Store = (*Store)(nil)
 
+type oauthChallenge struct {
+	value     string
+	expiresAt *timestamppb.Timestamp
+}
+
 // Store is an in-memory implementation of storage.AuthenticationStore
 //
 // Authentications are stored in a map by hashedClientToken.
@@ -30,9 +35,10 @@ var _ authn.Store = (*Store)(nil)
 type Store struct {
 	logger *zap.Logger
 
-	mu      sync.Mutex
-	byID    map[string]*rpcauth.Authentication
-	byToken map[string]*rpcauth.Authentication
+	mu         sync.Mutex
+	byID       map[string]*rpcauth.Authentication
+	byToken    map[string]*rpcauth.Authentication
+	challenges sync.Map
 
 	now                func() *timestamppb.Timestamp
 	generateID         func() string
@@ -55,6 +61,7 @@ func NewStore(logger *zap.Logger, opts ...Option) *Store {
 
 			byID:          map[string]*rpcauth.Authentication{},
 			byToken:       map[string]*rpcauth.Authentication{},
+			challenges:    sync.Map{},
 			now:           rpcflipt.Now,
 			generateID:    uuid.NewString,
 			generateToken: authn.GenerateRandomToken,
@@ -128,13 +135,15 @@ func (s *Store) startCleanup(ctx context.Context) {
 		for {
 			select {
 			case <-time.After(s.cleanupInterval):
-				expiredBefore := time.Now().UTC().Add(-s.cleanupGracePeriod)
+				now := s.now().AsTime().UTC()
+				expiredBefore := now.Add(-s.cleanupGracePeriod)
 				s.logger.Debug("cleanup process deleting authentications", zap.Time("expired_before", expiredBefore))
 				if err := s.DeleteAuthentications(ctx, authn.Delete(
 					authn.WithExpiredBefore(expiredBefore),
 				)); err != nil {
 					s.logger.Error("attempting to delete expired authentications", zap.Error(err))
 				}
+				s.cleanupOAuthChallenges(now)
 			case <-ctx.Done():
 				return nil
 			}
@@ -209,6 +218,45 @@ func (s *Store) GetAuthenticationByID(ctx context.Context, id string) (*rpcauth.
 	}
 
 	return authentication, nil
+}
+
+func (s *Store) PutOAuthChallenge(_ context.Context, state, value string, expiresAt *timestamppb.Timestamp) error {
+	if expiresAt != nil && !expiresAt.IsValid() {
+		return errors.ErrInvalidf("invalid expiry time: %v", expiresAt)
+	}
+
+	s.challenges.Store(state, oauthChallenge{value: value, expiresAt: expiresAt})
+
+	return nil
+}
+
+func (s *Store) PopOAuthChallenge(_ context.Context, state string) (string, error) {
+	value, ok := s.challenges.LoadAndDelete(state)
+
+	if !ok {
+		return "", errors.ErrNotFound("oauth challenge")
+	}
+
+	challenge, ok := value.(oauthChallenge)
+	if !ok {
+		return "", errors.ErrNotFound("oauth challenge invalid type")
+	}
+
+	if challenge.expiresAt != nil && challenge.expiresAt.AsTime().Before(s.now().AsTime().UTC()) {
+		return "", errors.ErrNotFound("oauth challenge expired")
+	}
+
+	return challenge.value, nil
+}
+
+func (s *Store) cleanupOAuthChallenges(now time.Time) {
+	s.challenges.Range(func(key any, value any) bool {
+		challenge, ok := value.(oauthChallenge)
+		if ok && challenge.expiresAt != nil && challenge.expiresAt.AsTime().Before(now) {
+			s.challenges.Delete(key)
+		}
+		return true
+	})
 }
 
 func (s *Store) ListAuthentications(ctx context.Context, req *storage.ListRequest[authn.ListAuthenticationsPredicate]) (storage.ResultSet[*rpcauth.Authentication], error) {

--- a/internal/storage/authn/memory/store_test.go
+++ b/internal/storage/authn/memory/store_test.go
@@ -1,15 +1,114 @@
 package memory
 
 import (
+	"context"
+	stdErrors "errors"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/storage/authn"
 	authtesting "go.flipt.io/flipt/internal/storage/authn/testing"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestAuthenticationStoreHarness(t *testing.T) {
+	store := NewStore(zap.NewNop())
+	cleanup(t, store)
 	authtesting.TestAuthenticationStoreHarness(t, func(t *testing.T) authn.Store {
-		return NewStore(zap.NewNop())
+		return store
 	})
+}
+
+func cleanup(t *testing.T, authStore *Store) {
+	t.Helper()
+	t.Cleanup(func() {
+		require.NoError(t, authStore.Shutdown(context.Background())) // nolint: usetesting
+	})
+}
+
+func TestOAuthChallengePopUsesInjectedClock(t *testing.T) {
+	var (
+		nowMu sync.Mutex
+		now   = time.Now().UTC()
+	)
+
+	store := NewStore(
+		zap.NewNop(),
+		WithNowFunc(func() *timestamppb.Timestamp {
+			nowMu.Lock()
+			defer nowMu.Unlock()
+			return timestamppb.New(now)
+		}),
+		WithCleanupInterval(24*time.Hour),
+	)
+	cleanup(t, store)
+
+	setNow := func(v time.Time) {
+		nowMu.Lock()
+		now = v.UTC()
+		nowMu.Unlock()
+	}
+
+	ctx := t.Context()
+	base := time.Now().UTC()
+
+	setNow(base.Add(2 * time.Minute))
+
+	require.NoError(t, store.PutOAuthChallenge(ctx, "state-pop", "verifier-pop", timestamppb.New(base.Add(1*time.Minute))))
+
+	_, err := store.PopOAuthChallenge(ctx, "state-pop")
+	var notFound errors.ErrNotFound
+	require.ErrorAs(t, err, &notFound)
+}
+
+func TestOAuthChallengeCleanupRemovesExpiredChallenges(t *testing.T) {
+	var (
+		nowMu sync.Mutex
+		now   = time.Now().UTC()
+	)
+
+	store := NewStore(
+		zap.NewNop(),
+		WithNowFunc(func() *timestamppb.Timestamp {
+			nowMu.Lock()
+			defer nowMu.Unlock()
+			return timestamppb.New(now)
+		}),
+		WithCleanupInterval(10*time.Millisecond),
+	)
+	cleanup(t, store)
+
+	setNow := func(v time.Time) {
+		nowMu.Lock()
+		now = v.UTC()
+		nowMu.Unlock()
+	}
+
+	ctx := t.Context()
+	base := time.Now().UTC()
+	expiresAt := timestamppb.New(base.Add(1 * time.Minute))
+	future := base.Add(2 * time.Minute)
+
+	setNow(base)
+	require.NoError(t, store.PutOAuthChallenge(ctx, "state-cleanup", "verifier-cleanup", expiresAt))
+
+	setNow(future)
+
+	require.Eventually(t, func() bool {
+		setNow(base)
+		defer setNow(future)
+
+		value, err := store.PopOAuthChallenge(ctx, "state-cleanup")
+		if err == nil {
+			require.NoError(t, store.PutOAuthChallenge(ctx, "state-cleanup", value, expiresAt))
+			return false
+		}
+
+		var notFound errors.ErrNotFound
+		return stdErrors.As(err, &notFound)
+	}, time.Second, 10*time.Millisecond)
 }

--- a/internal/storage/authn/redis/store.go
+++ b/internal/storage/authn/redis/store.go
@@ -23,10 +23,11 @@ import (
 var _ authn.Store = (*Store)(nil)
 
 const (
-	authIDKeyPrefix    = "auth:id"
-	authTokenKeyPrefix = "auth:token" //nolint:gosec
-	authMethodPrefix   = "auth:method"
-	authAllPrefix      = "auth:all"
+	authIDKeyPrefix      = "auth:id"
+	authTokenKeyPrefix   = "auth:token" //nolint:gosec
+	authMethodPrefix     = "auth:method"
+	authAllPrefix        = "auth:all"
+	oauthChallengePrefix = "auth:oauth_challenge"
 
 	allPattern = "*"
 
@@ -74,6 +75,13 @@ func authAllKey(prefix string) string {
 		return strings.Join([]string{authAllPrefix}, ":")
 	}
 	return strings.Join([]string{prefix, authAllPrefix}, ":")
+}
+
+func oauthChallengeKey(prefix, state string) string {
+	if prefix == "" {
+		return strings.Join([]string{oauthChallengePrefix, state}, ":")
+	}
+	return strings.Join([]string{prefix, oauthChallengePrefix, state}, ":")
 }
 
 // Option is a type which configures a *Store
@@ -230,6 +238,41 @@ func (s *Store) DeleteAuthentications(ctx context.Context, req *authn.DeleteAuth
 	}
 
 	return s.deleteAuthenticationBatches(ctx, ids, req.Method)
+}
+
+func (s *Store) PutOAuthChallenge(ctx context.Context, state, value string, expiresAt *timestamppb.Timestamp) error {
+	if expiresAt != nil && !expiresAt.IsValid() {
+		return errors.ErrInvalidf("invalid expiry time: %v", expiresAt)
+	}
+
+	key := oauthChallengeKey(s.prefix, state)
+	ttl := time.Duration(0)
+	now := s.now().AsTime().UTC()
+	if expiresAt != nil {
+		ttl = expiresAt.AsTime().UTC().Sub(now)
+		if ttl <= 0 {
+			_ = s.client.Del(ctx, key).Err()
+			return nil
+		}
+	}
+
+	if err := s.client.Set(ctx, key, value, ttl).Err(); err != nil {
+		return fmt.Errorf("storing oauth challenge: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) PopOAuthChallenge(ctx context.Context, state string) (string, error) {
+	value, err := s.client.GetDel(ctx, oauthChallengeKey(s.prefix, state)).Result()
+	if err != nil {
+		if errs.Is(err, goredis.Nil) {
+			return "", errors.ErrNotFound("oauth challenge")
+		}
+		return "", fmt.Errorf("getting oauth challenge: %w", err)
+	}
+
+	return value, nil
 }
 
 func (s *Store) scanMatchingIDs(ctx context.Context, sourceKey string, req *authn.DeleteAuthenticationsRequest) ([]string, error) {

--- a/internal/storage/authn/redis/store_test.go
+++ b/internal/storage/authn/redis/store_test.go
@@ -110,4 +110,8 @@ func TestPrefixKeys(t *testing.T) {
 		require.Equal(t, "flipt:auth:all", authAllKey("flipt"))
 		require.Equal(t, "auth:all", authAllKey(""))
 	})
+	t.Run("oauthChallengeKey", func(t *testing.T) {
+		require.Equal(t, "flipt:auth:oauth_challenge:123", oauthChallengeKey("flipt", "123"))
+		require.Equal(t, "auth:oauth_challenge:123", oauthChallengeKey("", "123"))
+	})
 }

--- a/internal/storage/authn/testing/testing.go
+++ b/internal/storage/authn/testing/testing.go
@@ -228,4 +228,30 @@ func TestAuthenticationStoreHarness(t *testing.T, fn func(t *testing.T) storagea
 		require.NoError(t, err)
 		assert.True(t, auth.ExpiresAt.AsTime().UTC().Before(time.Now().UTC()))
 	})
+
+	t.Run("OAuth challenge is single-use", func(t *testing.T) {
+		expiresAt := timestamppb.New(time.Now().UTC().Add(2 * time.Minute))
+
+		err := store.PutOAuthChallenge(ctx, "state-1", "verifier-1", expiresAt)
+		require.NoError(t, err)
+
+		value, err := store.PopOAuthChallenge(ctx, "state-1")
+		require.NoError(t, err)
+		assert.Equal(t, "verifier-1", value)
+
+		_, err = store.PopOAuthChallenge(ctx, "state-1")
+		var notFound errors.ErrNotFound
+		require.ErrorAs(t, err, &notFound)
+	})
+
+	t.Run("OAuth challenge expires", func(t *testing.T) {
+		expiredAt := timestamppb.New(time.Now().UTC().Add(-1 * time.Minute))
+
+		err := store.PutOAuthChallenge(ctx, "state-expired", "verifier-expired", expiredAt)
+		require.NoError(t, err)
+
+		_, err = store.PopOAuthChallenge(ctx, "state-expired")
+		var notFound errors.ErrNotFound
+		require.ErrorAs(t, err, &notFound)
+	})
 }


### PR DESCRIPTION
This pull request adds support for Proof Key for Code Exchange (PKCE) to the GitHub and OIDC authentication flows. PKCE is an additional security layer for OAuth2, and these changes allow it to be enabled via configuration. The implementation includes updates to configuration files, backend logic for storing and verifying challenges, and comprehensive tests to ensure correct behavior and error handling.

**PKCE Support for GitHub and OIDC Authentication**

*Configuration and Schema Updates:*
- Added the `use_pkce` boolean option to the GitHub and OIDC authentication configuration schemas (`config/flipt.schema.cue`, `config/flipt.schema.json`, `internal/config/authentication.go`). [[1]](diffhunk://#diff-c1fe130a9f139503ce8737adc6f3248245df9bc99ec71c5c20cadaa9a28cb710R117) [[2]](diffhunk://#diff-f7731de88692edac5fe39ceb47edeb4cb258c4766df7837b940be0d544eded72R563-R566) [[3]](diffhunk://#diff-9b81b9c76a5ad1bd617096d6af8c6bed965ca6c6b2505ce329d9d74151d0709cR604)

*GitHub Authentication Flow:*
- Implemented PKCE challenge generation, storage, and verification in the GitHub OAuth2 flow. The server now generates a verifier, stores it, and includes the challenge in the authorization URL if `use_pkce` is enabled, and verifies it during the callback. [[1]](diffhunk://#diff-2ba596fce9f86020dc88f45bf93d7c51f5b30357acad61de4b5de3fce05cc4f6R34) [[2]](diffhunk://#diff-2ba596fce9f86020dc88f45bf93d7c51f5b30357acad61de4b5de3fce05cc4f6L108-R123) [[3]](diffhunk://#diff-2ba596fce9f86020dc88f45bf93d7c51f5b30357acad61de4b5de3fce05cc4f6L119-R152)
- Added and updated tests to cover PKCE-enabled flows, error handling (e.g., missing state, missing/expired challenge), and store interactions. Added test utilities for challenge capture and error injection. [[1]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR9-R41) [[2]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR55-R75) [[3]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR86) [[4]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bL75-R233) [[5]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR848-R920) [[6]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bL713-R961) [[7]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bL727-R971) [[8]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR986-R988) [[9]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bL755-R1006)

*OIDC Authentication Flow:*
- Added PKCE support to OIDC: when enabled, the server generates and stores a verifier, passing it as the nonce, and verifies it during the callback. [[1]](diffhunk://#diff-1f867dd1f4b91cbfe14007dbe35dc16774aeddaa3e351054f74f2c9d60021356R19) [[2]](diffhunk://#diff-1f867dd1f4b91cbfe14007dbe35dc16774aeddaa3e351054f74f2c9d60021356R33-R34) [[3]](diffhunk://#diff-1f867dd1f4b91cbfe14007dbe35dc16774aeddaa3e351054f74f2c9d60021356L92-R109) [[4]](diffhunk://#diff-1f867dd1f4b91cbfe14007dbe35dc16774aeddaa3e351054f74f2c9d60021356L124-R163) [[5]](diffhunk://#diff-1f867dd1f4b91cbfe14007dbe35dc16774aeddaa3e351054f74f2c9d60021356L215-R243)

*Testing and Validation:*
- Updated struct tag validation to special-case the `usePKCE` field for naming conventions.
- Improved test coverage for PKCE scenarios, including correct challenge round-tripping, error cases, and integration with the authentication store. [[1]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR9-R41) [[2]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR55-R75) [[3]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR86) [[4]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bL75-R233) [[5]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR848-R920) [[6]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bL713-R961) [[7]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bL727-R971) [[8]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bR986-R988) [[9]](diffhunk://#diff-510fb08395f9a11996a2a552fb7c6a1aee88bd36c05729b3b3e47949a1140b3bL755-R1006)

These changes collectively enhance the security of the OAuth2 authentication flows by supporting PKCE, and ensure robust handling and testing of the new logic.