### PR TITLE
fix(storage/object): skip snapshot rebuilds for known objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.38.14
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1
 	github.com/blang/semver/v4 v4.0.0
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/docker/go-connections v0.7.0
 	github.com/fatih/color v1.19.0
@@ -137,7 +138,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.9 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.12 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 // indirect
@@ -156,7 +157,6 @@ require (
 	github.com/bytecodealliance/wasmtime-go/v39 v39.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.15 h1:fyvgWTszojq8hEnMi8PPBTvZdTt
 github.com/aws/aws-sdk-go-v2/credentials v1.19.15/go.mod h1:gJiYyMOjNg8OEdRWOf3CrFQxM2a98qmrtjx1zuiQfB8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22 h1:IOGsJ1xVWhsi+ZO7/NW8OuZZBtMJLZbk4P5HDjJO0jQ=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.22/go.mod h1:b+hYdbU+jGKfXE8kKM6g1+h+L/Go3vMvzlxBsiuGsxg=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.12 h1:Zy6Tme1AA13kX8x3CnkHx5cqdGWGaj/anwOiWGnA0Xo=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.12/go.mod h1:ql4uXYKoTM9WUAUSmthY4AtPVrlTBZOvnBJTiCUdPxI=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.15 h1:dZtEWZXGstKR/3imex5lC6WmdlH+na12AoYqi+dzrtk=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.22.15/go.mod h1:H8jD3r6e2bNQvdOK47TiYkxZfegWbAbyCkqPaL5FYNw=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=

--- a/internal/storage/fs/object/store.go
+++ b/internal/storage/fs/object/store.go
@@ -1,13 +1,18 @@
 package object
 
 import (
+	"cmp"
 	"context"
 	"encoding/hex"
 	"errors"
 	"io"
 	"io/fs"
+	"slices"
+	"strconv"
 	"sync"
 	"time"
+
+	"github.com/cespare/xxhash/v2"
 
 	"go.flipt.io/flipt/internal/containers"
 	"go.flipt.io/flipt/internal/storage"
@@ -29,6 +34,7 @@ type SnapshotStore struct {
 
 	mu   sync.RWMutex
 	snap storage.ReadOnlyStore
+	hash uint64
 }
 
 func NewSnapshotStore(ctx context.Context, logger *zap.Logger, scheme string, bucket *gcblob.Bucket, opts ...containers.Option[SnapshotStore]) (*SnapshotStore, error) {
@@ -78,60 +84,105 @@ func (s *SnapshotStore) String() string {
 
 // Update fetches a new snapshot and swaps it out for the current one.
 func (s *SnapshotStore) update(ctx context.Context) (bool, error) {
-	snap, err := s.build(ctx)
+	files, hash, err := s.list(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	s.mu.RLock()
+	previousHash := s.hash
+	hasSnapshot := s.snap != nil
+	s.mu.RUnlock()
+
+	if hasSnapshot && hash != 0 && previousHash == hash {
+		return false, nil
+	}
+
+	snap, err := s.build(ctx, files)
 	if err != nil {
 		return false, err
 	}
 
 	s.mu.Lock()
+	s.hash = hash
 	s.snap = snap
 	s.mu.Unlock()
 
 	return true, nil
 }
 
-func (s *SnapshotStore) build(ctx context.Context) (*storagefs.Snapshot, error) {
-	idx, err := s.getIndex(ctx)
+func (s *SnapshotStore) build(ctx context.Context, files []*File) (*storagefs.Snapshot, error) {
+	var err error
+	fsFiles := make([]fs.File, 0, len(files))
+	for _, item := range files {
+		item.body, err = s.bucket.NewReader(ctx, item.key, &gcblob.ReaderOptions{})
+		if err != nil {
+			return nil, err
+		}
+		fsFiles = append(fsFiles, item)
+	}
+	snapshot, err := storagefs.SnapshotFromFiles(s.logger, fsFiles)
 	if err != nil {
 		return nil, err
+	}
+	return snapshot, nil
+}
+
+func (s *SnapshotStore) list(ctx context.Context) ([]*File, uint64, error) {
+	idx, err := s.getIndex(ctx)
+	if err != nil {
+		return nil, 0, err
 	}
 
 	iterator := s.bucket.List(&gcblob.ListOptions{})
 
-	var files []fs.File
+	var files []*File
+	unknownHash := false
 	for {
 		item, err := iterator.Next(ctx)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			return nil, err
+			return nil, 0, err
 		}
 
 		if !idx.Match(item.Key) {
 			continue
 		}
 
-		rd, err := s.bucket.NewReader(ctx, item.Key, &gcblob.ReaderOptions{})
-		if err != nil {
-			return nil, err
+		if item.MD5 == nil {
+			unknownHash = true
 		}
 
 		files = append(files, NewFile(
 			item.Key,
 			item.Size,
-			rd,
+			nil,
 			item.ModTime,
 			hex.EncodeToString(item.MD5),
 		))
 	}
 
-	return storagefs.SnapshotFromFiles(s.logger, files)
+	slices.SortFunc(files, func(a *File, b *File) int { return cmp.Compare(a.key, b.key) })
+
+	if unknownHash {
+		return files, 0, nil
+	}
+
+	h := xxhash.New()
+	for _, f := range files {
+		_, _ = h.WriteString(f.key)
+		_, _ = h.WriteString(f.etag)
+		_, _ = h.WriteString(strconv.FormatInt(f.length, 16))
+		_, _ = h.WriteString(f.modTime.String())
+	}
+
+	return files, h.Sum64(), nil
 }
 
 func (s *SnapshotStore) getIndex(ctx context.Context) (*storagefs.FliptIndex, error) {
 	rd, err := s.bucket.NewReader(ctx, storagefs.IndexFileName, &gcblob.ReaderOptions{})
-
 	if err != nil {
 		if gcerrors.Code(err) != gcerrors.NotFound {
 			return nil, err

--- a/internal/storage/fs/object/store_test.go
+++ b/internal/storage/fs/object/store_test.go
@@ -54,7 +54,8 @@ func Test_Store(t *testing.T) {
 			return
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
+
 		client := s3Client(t, minioURL)
 		_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
 			Bucket: &bucketName,
@@ -97,7 +98,7 @@ func Test_Store(t *testing.T) {
 		os.Setenv("AZURE_STORAGE_IS_LOCAL_EMULATOR", strconv.FormatBool(u.Scheme == "http"))
 		os.Setenv("AZURE_STORAGE_DOMAIN", u.Host)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		client := azureClient(t, azuriteURL)
 		_, err = client.CreateContainer(ctx, bucketName, &azblob.CreateContainerOptions{})
 		require.NoError(t, err)
@@ -125,7 +126,7 @@ func Test_Store(t *testing.T) {
 			return
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		client := gcsClient(t)
 		bucket := client.Bucket(bucketName)
@@ -140,12 +141,57 @@ func Test_Store(t *testing.T) {
 			return fmt.Sprintf("%s://%s", gcsblob.Scheme, bucketName)
 		})
 	})
+
+	t.Run("memblob_without_md5_rebuilds_on_overwrite", func(t *testing.T) {
+		ctx := t.Context()
+		bucket := memblob.OpenBucket(&memblob.Options{NoMD5: true})
+		t.Cleanup(func() { require.NoError(t, bucket.Close()) })
+
+		require.NoError(t, bucket.WriteAll(ctx, "features.yml", []byte(`namespace: production
+flags:
+    - key: foo
+      name: Foo`), &gcblob.WriterOptions{}))
+
+		store, err := NewSnapshotStore(
+			ctx,
+			zaptest.NewLogger(t),
+			memblob.Scheme,
+			bucket,
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = store.Close() })
+
+		require.NoError(t, store.View(ctx, func(s storage.ReadOnlyStore) error {
+			_, err := s.GetFlag(ctx, storage.NewResource("production", "foo"))
+			require.NoError(t, err)
+			_, err = s.GetFlag(ctx, storage.NewResource("production", "bar"))
+			require.Error(t, err)
+			return nil
+		}))
+
+		require.NoError(t, bucket.WriteAll(ctx, "features.yml", []byte(`namespace: production
+flags:
+    - key: bar
+      name: Bar`), &gcblob.WriterOptions{}))
+
+		modified, err := store.update(ctx)
+		require.NoError(t, err)
+		require.True(t, modified)
+
+		require.NoError(t, store.View(ctx, func(s storage.ReadOnlyStore) error {
+			_, err := s.GetFlag(ctx, storage.NewResource("production", "foo"))
+			require.Error(t, err)
+			_, err = s.GetFlag(ctx, storage.NewResource("production", "bar"))
+			require.NoError(t, err)
+			return nil
+		}))
+	})
 }
 
 func testStore(t *testing.T, fn func(t *testing.T) string) {
 	t.Helper()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	t.Run("WithoutPrefix", func(t *testing.T) {
 		ch := make(chan struct{})
@@ -201,7 +247,7 @@ func testStore(t *testing.T, fn func(t *testing.T) string) {
 
 		// update features.yml
 		path := "features.yml"
-		require.NoError(t, bucket.WriteAll(context.TODO(), path,
+		require.NoError(t, bucket.WriteAll(t.Context(), path,
 			[]byte(`namespace: production
 flags:
     - key: foo
@@ -218,13 +264,13 @@ flags:
 		t.Log("received new snapshot")
 
 		require.NoError(t, store.View(ctx, func(s storage.ReadOnlyStore) error {
-			_, err = s.GetNamespace(context.TODO(), storage.NewNamespace("production"))
+			_, err = s.GetNamespace(t.Context(), storage.NewNamespace("production"))
 			require.NoError(t, err)
 
-			_, err = s.GetFlag(context.TODO(), storage.NewResource("production", "foo"))
+			_, err = s.GetFlag(t.Context(), storage.NewResource("production", "foo"))
 			require.NoError(t, err)
 
-			_, err = s.GetNamespace(context.TODO(), storage.NewNamespace("prefix"))
+			_, err = s.GetNamespace(t.Context(), storage.NewNamespace("prefix"))
 			require.NoError(t, err)
 
 			return nil
@@ -310,7 +356,7 @@ func writeTestDataToBucket(t *testing.T, ctx context.Context, bucket *gcblob.Buc
 func s3Client(t *testing.T, endpoint string) *s3.Client {
 	t.Helper()
 
-	cfg, err := config.LoadDefaultConfig(context.Background(),
+	cfg, err := config.LoadDefaultConfig(t.Context(),
 		config.WithRegion("minio"))
 	require.NoError(t, err)
 
@@ -338,7 +384,7 @@ func azureClient(t *testing.T, endpoint string) *azblob.Client {
 
 func gcsClient(t *testing.T) *gstorage.Client {
 	t.Helper()
-	client, err := gstorage.NewClient(context.Background())
+	client, err := gstorage.NewClient(t.Context())
 	require.NoError(t, err)
 	return client
 }


### PR DESCRIPTION
Compute xxhash of file metadata (key, etag, length, modTime) to detect changes without rebuilding the snapshot. Skip rebuilds when hash matches.