### PR TITLE
docs(sdk): fix Go SDK package examples

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -5,7 +5,7 @@
 The Flipt Go SDK supports developing applications in Go against Flipt.
 It also supports the ability to access the resource management APIs and other systems, such as authentication and metadata.
 
-The SDK supports both Flipts `gRPC` and `HTTP` RPC APIs.
+The SDK supports both Flipt's `gRPC` and `HTTP` RPC APIs.
 A majority of this client is generated directly from Flipt's `protobuf` definitions.
 The [Flipt SDK Generator](../../internal/cmd/protoc-gen-go-flipt-sdk/) can be found locally within this repository.
 
@@ -32,7 +32,7 @@ go get go.flipt.io/flipt/sdk/go
 
 Constructing an SDK client is easy.
 
-1. Pick your transport of choice. Both`grpc` or `http` are sub-packages with respective implementations.
+1. Pick your transport of choice. Both `grpc` and `http` are sub-packages with respective implementations.
 2. Pass a constructed `Transport` implementation to `sdk.New(...)`.
 3. Optionally pass in a `sdk.ClientAuthenticationProvider` to authenticate your RPC calls.
 

--- a/sdk/go/doc.go
+++ b/sdk/go/doc.go
@@ -12,7 +12,7 @@ The main entrypoint within this package is [New], which takes an instance of [Tr
 
 # GRPC Transport
 
-The following is an example of creating and instance of the SDK using the gRPC transport.
+The following is an example of creating an instance of the SDK using the gRPC transport.
 
 	func main() {
 		conn, _ := grpc.NewClient("localhost:9000")
@@ -31,7 +31,7 @@ The following is an example of creating an instance of the SDK using the HTTP tr
 
 # Authenticating the SDK
 
-The remote procedure calls mades by this SDK are authenticated via a [ClientAuthenticationProvider] implementation.
+The remote procedure calls made by this SDK are authenticated via a [ClientAuthenticationProvider] implementation.
 This can be supplied to [New] via the [WithAuthenticationProvider] option.
 Note that each of these methods will only work if the target Flipt server instance has the authentication method enabled.
 
@@ -57,10 +57,10 @@ This provider sets a pre-generated JSON web-token via the Authentication header 
 
 - [KubernetesAuthenticationProvider](https://www.flipt.io/docs/authentication/methods#kubernetes):
 
-This automatically uses the service account token on the host and exchanges it with Flipt for a Flipt client token credential. The credential is then used to authenticate requests, again via the Authentication header and the Bearer scheme. It ensures that the client token is not-expired and requests fresh tokens automatically without intervention. Use this method to automatically authenticate your application with a Flipt deployed into the same Kubernetes cluster.
+This automatically uses the service account token on the host and exchanges it with Flipt for a Flipt client token credential. The credential is then used to authenticate requests, again via the Authentication header and the Bearer scheme. It ensures that the client token is not expired and requests fresh tokens automatically without intervention. Use this method to automatically authenticate your application with a Flipt deployed into the same Kubernetes cluster.
 
 	func main() {
-	    provider := sdk.NewKuberntesAuthenticationProvider(transport)
+	    provider := sdk.NewKubernetesAuthenticationProvider(transport)
 	    client := sdk.New(transport, sdk.WithAuthenticationProvider(provider))
 	}
 
@@ -129,13 +129,13 @@ Learn more about the Variant flag type: <https://www.flipt.io/docs/concepts#vari
 	}
 
 	fmt.Println(resp.VariantKey)
-	fmt.Println(resp.VariantAttachment) Optional
+	fmt.Println(resp.VariantAttachment) // Optional
 
 # Batch
 
 The Batch method returns a response containing the evaluation results for a batch of requests. These requests can be for a mix of boolean and variant flags.
 
-	resp, err := client.Batch(ctx, &evaluation.BatchRequest{
+	resp, err := client.Batch(ctx, &evaluation.BatchEvaluationRequest{
 		RequestId: "my_request_id",
 		Requests: []*evaluation.EvaluationRequest{
 			{


### PR DESCRIPTION
## Summary

Tiny docs papercut. The Go SDK package docs had a typoed Kubernetes helper and used `evaluation.BatchRequest`, which doesnt exist, so copy paste was kinda cooked.

Also cleaned two README nits while I was there.

## Repro
Before the fix:

`cd sdk/go && go doc go.flipt.io/flipt/sdk/go | rg "NewKuberntes|BatchRequest|VariantAttachment"`

That showed:

`NewKuberntesAuthenticationProvider`
`evaluation.BatchRequest`
`fmt.Println(resp.VariantAttachment) Optional`

## Verification
`cd sdk/go && go test ./...`
`cd sdk/go && go doc go.flipt.io/flipt/sdk/go | rg "NewKubernetesAuthenticationProvider|BatchEvaluationRequest"`

No related issue found in a quick search.