### PR TITLE
fix(authn): correct struct tag typo jsom -> json for Expiration in kubernetes auth claims

### DIFF
--- a/internal/server/authn/method/kubernetes/server.go
+++ b/internal/server/authn/method/kubernetes/server.go
@@ -27,7 +27,7 @@ type resource struct {
 }
 
 type claims struct {
-	Expiration int64    `jsom:"exp"`
+	Expiration int64    `json:"exp"`
 	Identity   identity `json:"kubernetes.io"`
 }
 

--- a/internal/server/authn/method/kubernetes/server_internal_test.go
+++ b/internal/server/authn/method/kubernetes/server_internal_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -117,6 +118,14 @@ func Test_Server_VerifyServiceAccount(t *testing.T) {
 func Test_Server_SkipsAuthentication(t *testing.T) {
 	server := &Server{}
 	assert.True(t, server.SkipsAuthentication(context.Background()))
+}
+
+func Test_Claims_Expiration(t *testing.T) {
+	var c claims
+	err := json.Unmarshal([]byte(`{"exp": 1234567890, "kubernetes.io": {"namespace": "test"}}`), &c)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1234567890), c.Expiration)
+	assert.Equal(t, "test", c.Identity.Namespace)
 }
 
 type mockTokenVerifier map[string]claims


### PR DESCRIPTION
The claims struct had a malformed JSON struct tag ('jsom' instead of 'json') on the Expiration field, which prevented the 'exp' claim from being properly deserialized from JWT tokens.
