### PR TITLE
fix(authn): correct struct tag typo jsom -> json for Expiration in kubernetes auth claims

### DIFF
--- a/internal/server/authn/method/kubernetes/server.go
+++ b/internal/server/authn/method/kubernetes/server.go
@@ -29,7 +29,7 @@ type resource struct {
 }
 
 type claims struct {
-	Expiration int64    `jsom:"exp"`
+	Expiration int64    `json:"exp"`
 	Identity   identity `json:"kubernetes.io"`
 }
 

--- a/internal/server/authn/method/kubernetes/server_internal_test.go
+++ b/internal/server/authn/method/kubernetes/server_internal_test.go
@@ -116,6 +116,14 @@ func Test_Server_SkipsAuthentication(t *testing.T) {
 	assert.True(t, server.SkipsAuthentication(t.Context()))
 }
 
+func Test_Claims_Expiration(t *testing.T) {
+	var c claims
+	err := json.Unmarshal([]byte(`{"exp": 1234567890, "kubernetes.io": {"namespace": "test"}}`), &c)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1234567890), c.Expiration)
+	assert.Equal(t, "test", c.Identity.Namespace)
+}
+
 type mockTokenValidator map[string]claims
 
 func (m mockTokenValidator) Validate(_ context.Context, jwt string) (map[string]any, error) {


### PR DESCRIPTION
The Expiration field in the claims struct had a typo in its struct tag:
```go
jsom:"exp" → json:"exp"
```
This caused Go's encoding/json to never unmarshal the exp field from the Kubernetes service account JWT, leaving Expiration always as 0 (Unix epoch). Downstream this causes token expiry to be treated as January 1, 1970, effectively making all SA tokens immediately expired

Co-authored-by: Koren Ben Ezri <koren.ben-ezri@snyk.io>

closes #5906