### PR TITLE
feat(stream): skip sending snapshot when client digest matches

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,7 @@ linters:
         - G404
         - G602
         - G115
+        - G124
     staticcheck:
       checks:
         - "-SA1019"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,8 @@
 [tools]
 go = "1.26"
 node = "20"
-golangci-lint = "2.11.2"
-buf = "1.66.0"
+golangci-lint = "2.12.2"
+buf = "1.70.0"
 dagger = "0.20.3"
 mockery = "3.7.0"
 

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"runtime/debug"
+	"slices"
 	"sync"
 
 	prom "github.com/prometheus/client_golang/prometheus"
@@ -303,7 +304,8 @@ func NewGRPCServer(
 			tracingProvider.RegisterSpanProcessor(
 				tracesdk.NewBatchSpanProcessor(
 					analyticsExporter,
-					tracesdk.WithBatchTimeout(cfg.Analytics.Buffer.FlushPeriod)),
+					tracesdk.WithBatchTimeout(cfg.Analytics.Buffer.FlushPeriod),
+				),
 			)
 			server.onShutdown(func(ctx context.Context) error {
 				return analyticsExporter.Shutdown(ctx)
@@ -339,15 +341,19 @@ func NewGRPCServer(
 	))
 
 	// add auth interceptors to the server
-	unaryInterceptors = append(unaryInterceptors,
-		append(authUnaryInterceptors,
+	unaryInterceptors = append(
+		unaryInterceptors,
+		append(
+			authUnaryInterceptors,
 			middlewaregrpc.FliptHeadersUnaryInterceptor(logger),
 			middlewaregrpc.EvaluationUnaryInterceptor(),
 		)...,
 	)
 
-	streamInterceptors = append(streamInterceptors,
-		append(authStreamInterceptors,
+	streamInterceptors = append(
+		streamInterceptors,
+		append(
+			authStreamInterceptors,
 			middlewaregrpc.FliptHeadersStreamInterceptor(logger),
 		)...,
 	)
@@ -441,8 +447,8 @@ func (s *GRPCServer) Shutdown(ctx context.Context) error {
 	s.logger.Info("shutting down GRPC server...")
 
 	// call in reverse order to emulate pop semantics of a stack
-	for i := len(s.shutdownFuncs) - 1; i >= 0; i-- {
-		if fn := s.shutdownFuncs[i]; fn != nil {
+	for _, fn := range slices.Backward(s.shutdownFuncs) {
+		if fn != nil {
 			if err := fn(ctx); err != nil {
 				return err
 			}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -89,6 +89,8 @@ func (m *eventSourceMarshaler) Marshal(v any) ([]byte, error) {
 			converted[k] = v
 		}
 		return m.marshalEventSourceMap(converted)
+	case *status.Status:
+		return m.marshalStatus(val)
 	default:
 		return nil, fmt.Errorf("unsupported event-stream payload %T", v)
 	}
@@ -116,19 +118,23 @@ func (m *eventSourceMarshaler) marshalEventSourceMap(val map[string]any) ([]byte
 	}
 
 	if errStatus, ok := val["error"].(*status.Status); ok {
-		if codes.Code(errStatus.Code) == codes.Canceled {
-			return nil, nil
-		}
-		b, err := m.JSONPb.Marshal(map[string]any{
-			"type":    "error",
-			"code":    errStatus.Code,
-			"message": errStatus.Message,
-		})
-		if err != nil {
-			return nil, err
-		}
-		return fmt.Appendf(nil, "data: %s\n\n", b), nil
+		return m.marshalStatus(errStatus)
 	}
 
 	return nil, fmt.Errorf("unsupported event-stream payload map: %T", val)
+}
+
+func (m *eventSourceMarshaler) marshalStatus(errStatus *status.Status) ([]byte, error) {
+	if codes.Code(errStatus.Code) == codes.Canceled {
+		return nil, nil
+	}
+	b, err := m.JSONPb.Marshal(map[string]any{
+		"type":    "error",
+		"code":    errStatus.Code,
+		"message": errStatus.Message,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return fmt.Appendf(nil, "data: %s\n\n", b), nil
 }

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -74,6 +74,33 @@ func TestEventSourceMarshalerError(t *testing.T) {
 	require.Equal(t, "boom", got["message"])
 }
 
+func TestEventSourceMarshalerStatus(t *testing.T) {
+	m := &eventSourceMarshaler{JSONPb: runtime.JSONPb{}}
+	errStatus := grpcstatus.New(codes.Internal, "boom").Proto()
+
+	buf, err := m.Marshal(errStatus)
+	require.NoError(t, err)
+
+	payload, ok := extractEventPayload(t, buf)
+	require.True(t, ok)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(payload, &got))
+
+	require.Equal(t, "error", got["type"])
+	require.InDelta(t, float64(codes.Internal), got["code"], 0)
+	require.Equal(t, "boom", got["message"])
+}
+
+func TestEventSourceMarshalerCanceledStatus(t *testing.T) {
+	m := &eventSourceMarshaler{JSONPb: runtime.JSONPb{}}
+	errStatus := grpcstatus.New(codes.Canceled, "disconnected").Proto()
+
+	buf, err := m.Marshal(errStatus)
+	require.NoError(t, err)
+	require.Nil(t, buf)
+}
+
 func TestEventSourceMarshalerCanceledErrorIsIgnored(t *testing.T) {
 	m := &eventSourceMarshaler{JSONPb: runtime.JSONPb{}}
 	errStatus := grpcstatus.New(codes.Canceled, "client disconnected").Proto()

--- a/internal/server/evaluation/client/server.go
+++ b/internal/server/evaluation/client/server.go
@@ -162,6 +162,11 @@ func (s *Server) EvaluationSnapshotNamespaceStream(r *rpcevaluation.EvaluationNa
 				continue
 			}
 
+			// Skip sending data the client already has (digest unchanged).
+			if r.GetDigest() == snap.GetDigest() {
+				continue
+			}
+
 			hash.Write([]byte(snap.Digest))
 
 			// only send the snapshot if we have a new digest

--- a/internal/server/evaluation/client/server_test.go
+++ b/internal/server/evaluation/client/server_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -157,99 +158,277 @@ type fakeCloser struct{}
 
 func (f *fakeCloser) Close() error { return nil }
 
-func TestServer_EvaluationSnapshotNamespaceStream_Success(t *testing.T) {
-	var (
-		logger   = zaptest.NewLogger(t)
-		mockEnv  = environments.NewMockEnvironment(t)
-		envStore = evaluation.NewMockEnvironmentStore(t)
-	)
+func TestServer_EvaluationSnapshotNamespaceStream(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
 
-	mockEnv.On("Key").Return("env-key")
-	envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
 
-	mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
-		&fakeCloser{}, nil,
-	).Run(func(args mock.Arguments) {
-		ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
-		go func() {
-			ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
-			ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d2"}
-			close(ch)
-		}()
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
+			&fakeCloser{}, nil,
+		).Run(func(args mock.Arguments) {
+			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
+			go func() {
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d2"}
+				close(ch)
+			}()
+		})
+
+		stream := &mockStream{ctx: t.Context()}
+		stream.On("Send", mock.Anything).Return(nil)
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.NoError(t, err)
+		assert.Len(t, stream.sent, 2)
+		assert.Equal(t, "d1", stream.sent[0].Digest)
+		assert.Equal(t, "d2", stream.sent[1].Digest)
 	})
 
-	stream := &mockStream{ctx: t.Context()}
-	stream.On("Send", mock.Anything).Return(nil)
-	s := NewServer(logger, envStore)
-	req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+	t.Run("subscribe error", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
 
-	err := s.EvaluationSnapshotNamespaceStream(req, stream)
-	require.NoError(t, err)
-	assert.Len(t, stream.sent, 2)
-	assert.Equal(t, "d1", stream.sent[0].Digest)
-	assert.Equal(t, "d2", stream.sent[1].Digest)
-}
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
 
-func TestServer_EvaluationSnapshotNamespaceStream_SubscribeError(t *testing.T) {
-	var (
-		logger   = zaptest.NewLogger(t)
-		mockEnv  = environments.NewMockEnvironment(t)
-		envStore = evaluation.NewMockEnvironmentStore(t)
-	)
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(nil, errors.New("subscribe error"))
 
-	mockEnv.On("Key").Return("env-key")
-	envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+		stream := &mockStream{ctx: t.Context()}
+		stream.On("Send", mock.Anything).Return(nil)
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
 
-	mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(nil, errors.New("subscribe error"))
-
-	stream := &mockStream{ctx: t.Context()}
-	stream.On("Send", mock.Anything).Return(nil)
-	s := NewServer(logger, envStore)
-	req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
-
-	err := s.EvaluationSnapshotNamespaceStream(req, stream)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "subscribe error")
-}
-
-func TestServer_EvaluationSnapshotNamespaceStream_ContextCancel(t *testing.T) {
-	var (
-		logger   = zaptest.NewLogger(t)
-		mockEnv  = environments.NewMockEnvironment(t)
-		envStore = evaluation.NewMockEnvironmentStore(t)
-	)
-
-	mockEnv.On("Key").Return("env-key")
-	envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
-
-	wait := make(chan struct{})
-	t.Cleanup(func() { close(wait) })
-
-	mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
-		&fakeCloser{}, nil,
-	).Run(func(args mock.Arguments) {
-		ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
-		go func() {
-			ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
-			// wait for Send to be called before closing
-			<-wait
-			close(ch)
-		}()
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "subscribe error")
 	})
 
-	ctx, cancel := context.WithCancel(t.Context())
-	t.Cleanup(cancel)
-	stream := &mockStream{ctx: ctx}
-	stream.On("Send", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		// signal that Send was called, then cancel context
-		wait <- struct{}{}
-		cancel()
-	})
-	s := NewServer(logger, envStore)
-	req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+	t.Run("context cancel", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
 
-	err := s.EvaluationSnapshotNamespaceStream(req, stream)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(stream.sent), 1)
-	assert.Equal(t, "d1", stream.sent[0].Digest)
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+
+		var (
+			wait = make(chan struct{})
+			once sync.Once
+		)
+
+		closeWait := func() { once.Do(func() { close(wait) }) }
+
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
+			&fakeCloser{}, nil,
+		).Run(func(args mock.Arguments) {
+			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
+			go func() {
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
+				<-wait
+				close(ch)
+			}()
+		})
+
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(func() { closeWait(); cancel() })
+		stream := &mockStream{ctx: ctx}
+		stream.On("Send", mock.Anything).Return(nil).Run(func(_ mock.Arguments) {
+			closeWait()
+			cancel()
+		})
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(stream.sent), 1)
+		assert.Equal(t, "d1", stream.sent[0].Digest)
+	})
+
+	t.Run("nil snapshot", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
+
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
+			&fakeCloser{}, nil,
+		).Run(func(args mock.Arguments) {
+			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
+			go func() {
+				ch <- nil
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
+				close(ch)
+			}()
+		})
+
+		stream := &mockStream{ctx: t.Context()}
+		stream.On("Send", mock.Anything).Return(nil)
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.NoError(t, err)
+		require.Len(t, stream.sent, 1)
+		assert.Equal(t, "d1", stream.sent[0].Digest)
+	})
+
+	t.Run("request digest match", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
+
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
+			&fakeCloser{}, nil,
+		).Run(func(args mock.Arguments) {
+			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
+			go func() {
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
+				close(ch)
+			}()
+		})
+
+		stream := &mockStream{ctx: t.Context()}
+		stream.On("Send", mock.Anything).Return(nil)
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{
+			EnvironmentKey: "env-key",
+			Key:            "ns-key",
+			Digest:         new("d1"),
+		}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.NoError(t, err)
+		require.Empty(t, stream.sent)
+	})
+
+	t.Run("same digest dedup", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
+
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
+			&fakeCloser{}, nil,
+		).Run(func(args mock.Arguments) {
+			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
+			go func() {
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
+				close(ch)
+			}()
+		})
+
+		stream := &mockStream{ctx: t.Context()}
+		stream.On("Send", mock.Anything).Return(nil)
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.NoError(t, err)
+		require.Len(t, stream.sent, 1)
+		assert.Equal(t, "d1", stream.sent[0].Digest)
+	})
+
+	t.Run("channel closed", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
+
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
+			&fakeCloser{}, nil,
+		).Run(func(args mock.Arguments) {
+			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
+			go func() {
+				close(ch)
+			}()
+		})
+
+		stream := &mockStream{ctx: t.Context()}
+		stream.On("Send", mock.Anything).Return(nil)
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.NoError(t, err)
+		require.Empty(t, stream.sent)
+	})
+
+	t.Run("send error", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
+
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
+			&fakeCloser{}, nil,
+		).Run(func(args mock.Arguments) {
+			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
+			go func() {
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
+				close(ch)
+			}()
+		})
+
+		stream := &mockStream{ctx: t.Context()}
+		stream.On("Send", mock.Anything).Return(errors.New("send error"))
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "send error")
+	})
+
+	t.Run("env not found", func(t *testing.T) {
+		var (
+			logger   = zaptest.NewLogger(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
+
+		envStore.On("Get", mock.Anything, "env-key").Return(nil, errors.New("not found"))
+		envStore.On("GetFromContext", mock.Anything).Return(nil, errors.New("not found from context"))
+
+		stream := &mockStream{ctx: t.Context()}
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{EnvironmentKey: "env-key", Key: "ns-key"}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.Error(t, err)
+	})
 }

--- a/internal/server/evaluation/ofrep_bridge.go
+++ b/internal/server/evaluation/ofrep_bridge.go
@@ -70,7 +70,8 @@ func (s *Server) OFREPFlagEvaluation(ctx context.Context, r *ofrep.EvaluateFlagR
 		}
 
 		if s.tracingEnabled {
-			s.addEvaluationEvent(ctx, env, namespaceKey, r.Key, entityId, "",
+			s.addEvaluationEvent(
+				ctx, env, namespaceKey, r.Key, entityId, "",
 				tracing.AttributeMatch.Bool(resp.Match),
 				tracing.AttributeVariant.String(resp.VariantKey),
 				tracing.AttributeReason.String(tracing.ReasonToValue(resp.Reason)),
@@ -110,7 +111,8 @@ func (s *Server) OFREPFlagEvaluation(ctx context.Context, r *ofrep.EvaluateFlagR
 		}
 
 		if s.tracingEnabled {
-			s.addEvaluationEvent(ctx, env, namespaceKey, r.Key, entityId, "",
+			s.addEvaluationEvent(
+				ctx, env, namespaceKey, r.Key, entityId, "",
 				tracing.AttributeVariant.Bool(resp.Enabled),
 				tracing.AttributeReason.String(tracing.ReasonToValue(resp.Reason)),
 				tracing.AttributeSegments.StringSlice(resp.SegmentKeys),
@@ -146,10 +148,15 @@ func (s *Server) OFREPFlagEvaluationBulk(ctx context.Context, r *ofrep.EvaluateB
 	}
 
 	var (
-		namespaceKey = getNamespace(ctx)
-		flagKeys, ok = r.Context["flags"]
-		keys         = strings.Split(flagKeys, ",")
+		namespaceKey   = getNamespace(ctx)
+		flagKeys, ok   = r.Context["flags"]
+		keys           = strings.Split(flagKeys, ",")
+		snapshotDigest string
 	)
+
+	if sn, err := env.EvaluationNamespaceSnapshot(ctx, namespaceKey); err == nil {
+		snapshotDigest = sn.GetDigest()
+	}
 
 	if !ok {
 		flags, err := store.ListFlags(ctx, storage.ListWithOptions(storage.NewNamespace(namespaceKey)))
@@ -204,7 +211,7 @@ func (s *Server) OFREPFlagEvaluationBulk(ctx context.Context, r *ofrep.EvaluateB
 		EventStreams: []*ofrep.EventStream{{
 			Type: "sse",
 			Endpoint: &ofrep.EventStreamEndpoint{
-				RequestUri: fmt.Sprintf("/client/v2/environments/%s/namespaces/%s/stream", env.Key(), namespaceKey),
+				RequestUri: fmt.Sprintf("/client/v2/environments/%s/namespaces/%s/stream?digest=%s", env.Key(), namespaceKey, snapshotDigest),
 			},
 		}},
 	}, err

--- a/internal/server/evaluation/ofrep_bridge_test.go
+++ b/internal/server/evaluation/ofrep_bridge_test.go
@@ -12,6 +12,7 @@ import (
 	"go.flipt.io/flipt/internal/storage"
 	"go.flipt.io/flipt/rpc/flipt/core"
 	"go.flipt.io/flipt/rpc/flipt/ofrep"
+	rpcevaluationv2 "go.flipt.io/flipt/rpc/v2/evaluation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/zap/zaptest"
@@ -457,11 +458,13 @@ func TestOFREPFlagEvaluationBulkWithEtag(t *testing.T) {
 				store          = storage.NewMockReadOnlyStore(t)
 				logger         = zaptest.NewLogger(t)
 				s              = New(logger, envStore)
+				namespaceKey   = "test-namespace"
 			)
 
 			environment.On("Key").Return(environmentKey)
 			envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 			environment.On("EvaluationStore").Return(store, nil)
+			environment.EXPECT().EvaluationNamespaceSnapshot(mock.Anything, namespaceKey).Return(&rpcevaluationv2.EvaluationNamespaceSnapshot{Digest: "abcdefg"}, nil).Maybe()
 
 			for _, flag := range tt.flags {
 				if flag.Key == "" {
@@ -523,6 +526,7 @@ func TestOFREPFlagEvaluationBulk(t *testing.T) {
 
 	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
+	environment.EXPECT().EvaluationNamespaceSnapshot(mock.Anything, namespaceKey).Return(&rpcevaluationv2.EvaluationNamespaceSnapshot{Digest: "abcdefg"}, nil).Maybe()
 
 	store.On("GetFlag", mock.Anything, mock.Anything).Return(flag, nil)
 
@@ -582,6 +586,6 @@ func TestOFREPFlagEvaluationBulk(t *testing.T) {
 	stream := result.EventStreams[0]
 	assert.Equal(t, "sse", stream.Type)
 	assert.NotNil(t, stream.Endpoint)
-	assert.Equal(t, "/client/v2/environments/test-environment/namespaces/test-namespace/stream", stream.Endpoint.GetRequestUri())
+	assert.Equal(t, "/client/v2/environments/test-environment/namespaces/test-namespace/stream?digest=abcdefg", stream.Endpoint.GetRequestUri())
 	assert.Empty(t, stream.Endpoint.GetOrigin())
 }

--- a/rpc/v2/evaluation/evaluationv2.pb.go
+++ b/rpc/v2/evaluation/evaluationv2.pb.go
@@ -1124,12 +1124,19 @@ func (x *EvaluationNamespaceSnapshotRequest) GetEnvironmentKey() string {
 	return ""
 }
 
+// Subscribes to a stream of namespace snapshots. The server sends the latest
+// snapshot whenever flag data changes, or immediately if the client's digest
+// is stale. Skips sending when the client is already up to date.
 type EvaluationNamespaceSnapshotStreamRequest struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	Key            string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	EnvironmentKey string                 `protobuf:"bytes,2,opt,name=environment_key,json=environmentKey,proto3" json:"environment_key,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Namespace key to stream.
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Environment key to stream.
+	EnvironmentKey string `protobuf:"bytes,2,opt,name=environment_key,json=environmentKey,proto3" json:"environment_key,omitempty"`
+	// Last snapshot digest the client has. Stream skips sending snapshots with a matching digest.
+	Digest        *string `protobuf:"bytes,3,opt,name=digest,proto3,oneof" json:"digest,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *EvaluationNamespaceSnapshotStreamRequest) Reset() {
@@ -1172,6 +1179,13 @@ func (x *EvaluationNamespaceSnapshotStreamRequest) GetKey() string {
 func (x *EvaluationNamespaceSnapshotStreamRequest) GetEnvironmentKey() string {
 	if x != nil {
 		return x.EnvironmentKey
+	}
+	return ""
+}
+
+func (x *EvaluationNamespaceSnapshotStreamRequest) GetDigest() string {
+	if x != nil && x.Digest != nil {
+		return *x.Digest
 	}
 	return ""
 }
@@ -1299,10 +1313,12 @@ const file_evaluation_evaluationv2_proto_rawDesc = "" +
 	"\"EvaluationNamespaceSnapshotRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x1c\n" +
 	"\treference\x18\x02 \x01(\tR\treference\x12'\n" +
-	"\x0fenvironment_key\x18\x03 \x01(\tR\x0eenvironmentKey\"e\n" +
+	"\x0fenvironment_key\x18\x03 \x01(\tR\x0eenvironmentKey\"\x8d\x01\n" +
 	"(EvaluationNamespaceSnapshotStreamRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12'\n" +
-	"\x0fenvironment_key\x18\x02 \x01(\tR\x0eenvironmentKey\"\xcc\x01\n" +
+	"\x0fenvironment_key\x18\x02 \x01(\tR\x0eenvironmentKey\x12\x1b\n" +
+	"\x06digest\x18\x03 \x01(\tH\x00R\x06digest\x88\x01\x01B\t\n" +
+	"\a_digest\"\xcc\x01\n" +
 	"\x12EvaluationSnapshot\x12N\n" +
 	"\n" +
 	"namespaces\x18\x01 \x03(\v2..evaluation.EvaluationSnapshot.NamespacesEntryR\n" +
@@ -1416,6 +1432,7 @@ func file_evaluation_evaluationv2_proto_init() {
 		(*EvaluationRollout_Threshold)(nil),
 	}
 	file_evaluation_evaluationv2_proto_msgTypes[6].OneofWrappers = []any{}
+	file_evaluation_evaluationv2_proto_msgTypes[12].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/rpc/v2/evaluation/evaluationv2.pb.gw.go
+++ b/rpc/v2/evaluation/evaluationv2.pb.gw.go
@@ -157,6 +157,8 @@ func local_request_ClientEvaluationService_EvaluationSnapshotNamespace_1(ctx con
 	return msg, metadata, err
 }
 
+var filter_ClientEvaluationService_EvaluationSnapshotNamespaceStream_0 = &utilities.DoubleArray{Encoding: map[string]int{"environment_key": 0, "key": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+
 func request_ClientEvaluationService_EvaluationSnapshotNamespaceStream_0(ctx context.Context, marshaler runtime.Marshaler, client ClientEvaluationServiceClient, req *http.Request, pathParams map[string]string) (ClientEvaluationService_EvaluationSnapshotNamespaceStreamClient, runtime.ServerMetadata, error) {
 	var (
 		protoReq EvaluationNamespaceSnapshotStreamRequest
@@ -181,6 +183,12 @@ func request_ClientEvaluationService_EvaluationSnapshotNamespaceStream_0(ctx con
 	protoReq.Key, err = runtime.String(val)
 	if err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "key", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_ClientEvaluationService_EvaluationSnapshotNamespaceStream_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	stream, err := client.EvaluationSnapshotNamespaceStream(ctx, &protoReq)
 	if err != nil {

--- a/rpc/v2/evaluation/evaluationv2.proto
+++ b/rpc/v2/evaluation/evaluationv2.proto
@@ -128,9 +128,16 @@ message EvaluationNamespaceSnapshotRequest {
   string environment_key = 3;
 }
 
+// Subscribes to a stream of namespace snapshots. The server sends the latest
+// snapshot whenever flag data changes, or immediately if the client's digest
+// is stale. Skips sending when the client is already up to date.
 message EvaluationNamespaceSnapshotStreamRequest {
+  // Namespace key to stream.
   string key = 1;
+  // Environment key to stream.
   string environment_key = 2;
+  // Last snapshot digest the client has. Stream skips sending snapshots with a matching digest.
+  optional string digest = 3;
 }
 
 message EvaluationSnapshot {

--- a/rpc/v2/evaluation/openapi.yaml
+++ b/rpc/v2/evaluation/openapi.yaml
@@ -41,12 +41,19 @@ paths:
             parameters:
                 - name: environmentKey
                   in: path
+                  description: Environment key to stream.
                   required: true
                   schema:
                     type: string
                 - name: key
                   in: path
+                  description: Namespace key to stream.
                   required: true
+                  schema:
+                    type: string
+                - name: digest
+                  in: query
+                  description: Last snapshot digest the client has. Stream skips sending snapshots with a matching digest.
                   schema:
                     type: string
             responses:


### PR DESCRIPTION
Short-circuit stream send when client's last digest matches snapshot,
reducing redundant data transfer for OFREP clients
