### PR TITLE
fix(stream): don't suppress digest reverts in snapshot stream

### DIFF
--- a/internal/server/evaluation/client/server.go
+++ b/internal/server/evaluation/client/server.go
@@ -162,8 +162,11 @@ func (s *Server) EvaluationSnapshotNamespaceStream(r *rpcevaluation.EvaluationNa
 				continue
 			}
 
-			// Skip sending data the client already has (digest unchanged).
-			if r.GetDigest() == snap.GetDigest() {
+			// Skip the initial snapshot if the client already has it. Once we have
+			// sent at least one update (lastDigest != nil), rely solely on the
+			// hash-based dedup below so that a revert to the original digest is
+			// still delivered.
+			if lastDigest == nil && r.GetDigest() == snap.GetDigest() {
 				continue
 			}
 

--- a/internal/server/evaluation/client/server.go
+++ b/internal/server/evaluation/client/server.go
@@ -1,11 +1,8 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"time"
-
-	"crypto/sha1" //nolint:gosec
 
 	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/server/environments"
@@ -102,17 +99,18 @@ func (s *Server) EvaluationSnapshotNamespaceStream(r *rpcevaluation.EvaluationNa
 		ctx        = stream.Context()
 	)
 
+	if d := len(r.GetDigest()); d > 0 && d != 40 {
+		return errors.InvalidFieldError("digest", "must be a 40-character string")
+	}
+
 	env, err := s.getCurrentEnvironment(ctx, r.EnvironmentKey)
 	if err != nil {
 		return err
 	}
 
 	var (
-		//nolint:gosec // this is a hash for a stream
-		hash = sha1.New()
-		// lastDigest is the digest of the last snapshot we sent
-		// this includes all namespaces
-		lastDigest []byte
+		// lastDigest tracks the digest of the last snapshot we sent
+		lastDigest = r.GetDigest()
 
 		environmentKey = env.Key()
 		namespaceKey   = r.Key
@@ -162,28 +160,16 @@ func (s *Server) EvaluationSnapshotNamespaceStream(r *rpcevaluation.EvaluationNa
 				continue
 			}
 
-			// Skip the initial snapshot if the client already has it. Once we have
-			// sent at least one update (lastDigest != nil), rely solely on the
-			// hash-based dedup below so that a revert to the original digest is
-			// still delivered.
-			if lastDigest == nil && r.GetDigest() == snap.GetDigest() {
-				continue
-			}
-
-			hash.Write([]byte(snap.Digest))
-
 			// only send the snapshot if we have a new digest
-			if digest := hash.Sum(nil); !bytes.Equal(lastDigest, digest) {
+			if snap.Digest != lastDigest {
 				if err := stream.Send(snap); err != nil {
 					metrics.EvaluationsStreamErrorsTotal.Add(ctx, 1, metric.WithAttributeSet(attrSet))
 					s.logger.Error("error sending evaluation namespace snapshot", zap.Error(err), zap.String("namespace", namespaceKey), zap.String("environment", environmentKey))
 					return err
 				}
 				metrics.EvaluationsStreamMessagesTotal.Add(ctx, 1, metric.WithAttributeSet(attrSet))
-				lastDigest = digest
+				lastDigest = snap.Digest
 			}
-
-			hash.Reset()
 		}
 	}
 }

--- a/internal/server/evaluation/client/server_test.go
+++ b/internal/server/evaluation/client/server_test.go
@@ -356,6 +356,47 @@ func TestServer_EvaluationSnapshotNamespaceStream(t *testing.T) {
 		assert.Equal(t, "d1", stream.sent[0].Digest)
 	})
 
+	t.Run("request digest revert", func(t *testing.T) {
+		// Regression test: after the stream sends d2 to the client (who started with d1),
+		// a snapshot reverting to d1 must still be sent. The initial-request digest
+		// should only suppress the very first snapshot, not subsequent ones.
+		var (
+			logger   = zaptest.NewLogger(t)
+			mockEnv  = environments.NewMockEnvironment(t)
+			envStore = evaluation.NewMockEnvironmentStore(t)
+		)
+
+		mockEnv.On("Key").Return("env-key")
+		envStore.On("Get", mock.Anything, "env-key").Return(mockEnv, nil)
+
+		mockEnv.On("EvaluationNamespaceSnapshotSubscribe", mock.Anything, "ns-key", mock.Anything).Return(
+			&fakeCloser{}, nil,
+		).Run(func(args mock.Arguments) {
+			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
+			go func() {
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"} // skipped: client already has d1
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d2"} // sent: new state
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"} // must be sent: client has d2, not d1
+				close(ch)
+			}()
+		})
+
+		stream := &mockStream{ctx: t.Context()}
+		stream.On("Send", mock.Anything).Return(nil)
+		s := NewServer(logger, envStore)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{
+			EnvironmentKey: "env-key",
+			Key:            "ns-key",
+			Digest:         new("d1"),
+		}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		require.NoError(t, err)
+		require.Len(t, stream.sent, 2)
+		assert.Equal(t, "d2", stream.sent[0].Digest)
+		assert.Equal(t, "d1", stream.sent[1].Digest)
+	})
+
 	t.Run("channel closed", func(t *testing.T) {
 		var (
 			logger   = zaptest.NewLogger(t)

--- a/internal/server/evaluation/client/server_test.go
+++ b/internal/server/evaluation/client/server_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	errs "go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/server/environments"
 	"go.flipt.io/flipt/internal/server/evaluation"
 	rpcevaluation "go.flipt.io/flipt/rpc/v2/evaluation"
@@ -159,6 +160,27 @@ type fakeCloser struct{}
 func (f *fakeCloser) Close() error { return nil }
 
 func TestServer_EvaluationSnapshotNamespaceStream(t *testing.T) {
+	const (
+		d1 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		d2 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	t.Run("invalid request digest length", func(t *testing.T) {
+		logger := zaptest.NewLogger(t)
+		stream := &mockStream{ctx: t.Context()}
+		s := NewServer(logger, nil)
+		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{
+			EnvironmentKey: "env-key",
+			Key:            "ns-key",
+			Digest:         new("too-short"),
+		}
+
+		err := s.EvaluationSnapshotNamespaceStream(req, stream)
+		var target errs.ErrValidation
+		require.ErrorAs(t, err, &target)
+		assert.Equal(t, "invalid field digest: must be a 40-character string", target.Error())
+	})
+
 	t.Run("success", func(t *testing.T) {
 		var (
 			logger   = zaptest.NewLogger(t)
@@ -305,7 +327,7 @@ func TestServer_EvaluationSnapshotNamespaceStream(t *testing.T) {
 		).Run(func(args mock.Arguments) {
 			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
 			go func() {
-				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"}
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: d1}
 				close(ch)
 			}()
 		})
@@ -316,7 +338,7 @@ func TestServer_EvaluationSnapshotNamespaceStream(t *testing.T) {
 		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{
 			EnvironmentKey: "env-key",
 			Key:            "ns-key",
-			Digest:         new("d1"),
+			Digest:         new(d1),
 		}
 
 		err := s.EvaluationSnapshotNamespaceStream(req, stream)
@@ -374,9 +396,9 @@ func TestServer_EvaluationSnapshotNamespaceStream(t *testing.T) {
 		).Run(func(args mock.Arguments) {
 			ch := args.Get(2).(chan<- *rpcevaluation.EvaluationNamespaceSnapshot)
 			go func() {
-				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"} // skipped: client already has d1
-				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d2"} // sent: new state
-				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: "d1"} // must be sent: client has d2, not d1
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: d1} // skipped: client already has d1
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: d2} // sent: new state
+				ch <- &rpcevaluation.EvaluationNamespaceSnapshot{Digest: d1} // must be sent: client has d2, not d1
 				close(ch)
 			}()
 		})
@@ -387,14 +409,14 @@ func TestServer_EvaluationSnapshotNamespaceStream(t *testing.T) {
 		req := &rpcevaluation.EvaluationNamespaceSnapshotStreamRequest{
 			EnvironmentKey: "env-key",
 			Key:            "ns-key",
-			Digest:         new("d1"),
+			Digest:         new(d1),
 		}
 
 		err := s.EvaluationSnapshotNamespaceStream(req, stream)
 		require.NoError(t, err)
 		require.Len(t, stream.sent, 2)
-		assert.Equal(t, "d2", stream.sent[0].Digest)
-		assert.Equal(t, "d1", stream.sent[1].Digest)
+		assert.Equal(t, d2, stream.sent[0].Digest)
+		assert.Equal(t, d1, stream.sent[1].Digest)
 	})
 
 	t.Run("channel closed", func(t *testing.T) {


### PR DESCRIPTION
## What

`EvaluationSnapshotNamespaceStream` uses `r.GetDigest() == snap.GetDigest()` to skip sending a snapshot the client already has. Good idea, but that check fires on every future snapshot with the same digest - not just the initial one.

## The bug

Say client connects with digest `d1`. Stream goes:
- `d1` -> skipped (correct, client has it)
- `d2` -> sent (client now has d2)
- `d1` (git rollback) -> skipped! (but client has d2 now, not d1)

Client is stuck on stale state and won't recover until the digest changes again.

## How to reproduce

Run the new test:

```
go test ./internal/server/evaluation/client/... -run TestServer_EvaluationSnapshotNamespaceStream/request_digest_revert
```

It fails without the fix.

## Fix

Guard the check with `lastDigest == nil` so it only suppresses the first snapshot (before anything has been sent). After that, the existing hash-based dedup handles everything, including reverts.

```go
// before
if r.GetDigest() == snap.GetDigest() {

// after
if lastDigest == nil && r.GetDigest() == snap.GetDigest() {
```

Regression introduced in #5909.