### PR TITLE
ci: pin azure-sdk-for-go/sdk/security/keyvault/azsecrets to v1.4.0

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -300,6 +300,15 @@ grep -rl --include='*_test.go' 'func Fuzz' . | while read -r file; do
 done
 """
 
+[tasks."dagger:integration"]
+alias = "di"
+description = "Run a Dagger integration test by name (e.g. mise di signing/azure)"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+dagger call test --source . integration --cases="$*"
+"""
+
 [tasks."go:generate"]
 description = "Generate mocks and proto files"
 depends = ["go:mockery", "go:proto"]

--- a/build/testing/integration.go
+++ b/build/testing/integration.go
@@ -714,12 +714,13 @@ permit_slice(allowed, requested) if {
 }
 `
 
-		return fn(ctx, client, base, flipt.
-			WithEnvVariable("FLIPT_AUTHORIZATION_BACKEND", "local").
-			WithEnvVariable("FLIPT_AUTHORIZATION_LOCAL_POLICY_PATH", policyPath).
-			WithNewFile(policyPath, string(policy)).
-			WithEnvVariable("FLIPT_AUTHORIZATION_LOCAL_DATA_PATH", policyData).
-			WithNewFile(policyData, string(data)),
+		return fn(
+			ctx, client, base, flipt.
+				WithEnvVariable("FLIPT_AUTHORIZATION_BACKEND", "local").
+				WithEnvVariable("FLIPT_AUTHORIZATION_LOCAL_POLICY_PATH", policyPath).
+				WithNewFile(policyPath, string(policy)).
+				WithEnvVariable("FLIPT_AUTHORIZATION_LOCAL_DATA_PATH", policyData).
+				WithNewFile(policyData, string(data)),
 			conf,
 		)
 	}
@@ -1073,7 +1074,7 @@ func main() {
 	fmt.Println("Secret stored successfully in Lowkey Vault")
 }
 GOEOF
-				cd /tmp/setup && go mod init setup && go mod tidy && go run main.go
+				cd /tmp/setup && go mod init setup && go get github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets@v1.4.0 && go mod tidy && go run main.go
 			`,
 			}).Sync(ctx)
 		if err != nil {


### PR DESCRIPTION
Azure has released a new version of the go sdk that fails to work
with lowkey-vault
