### PR TITLE
ci: switch PR Review to Kimi K2.6 on Cloudflare Workers AI

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,10 +3,10 @@ name: PR Review
 # AI code review for PRs targeting v2, including PRs from forks.
 #
 # Uses `pull_request_target` (not `pull_request`) on purpose: a `pull_request`
-# event from a fork gets a read-only token with no secrets or GitHub Models
-# access, so the reviewer couldn't call the model or post a review. With
+# event from a fork gets a read-only token with no repo secrets, so the
+# reviewer couldn't reach Cloudflare Workers AI or post a review. With
 # `pull_request_target` the job runs in the base-repo context with a writable
-# token + `models: read`.
+# token and access to CLOUDFLARE_* secrets.
 #
 # SECURITY: this is safe ONLY because the reviewer never checks out or executes
 # the PR's code — it reads the diff via the `gh` API. Do NOT add
@@ -21,7 +21,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  models: read
 
 concurrency:
   group: pr-review-${{ github.event.pull_request.number }}
@@ -38,5 +37,13 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: flipt-io/agents/actions/pr-review@main # pin to a tag/SHA to freeze the reviewer
+        env:
+          # pi-ai's cloudflare-workers-ai provider reads these directly from
+          # process.env — passed through the composite action's inherited env.
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         with:
           pr-number: ${{ github.event.pull_request.number }}
+          # Kimi K2.6 on Cloudflare Workers AI — 262k context, reasoning,
+          # vision, tool calling. Big enough for non-trivial diffs.
+          model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6


### PR DESCRIPTION
## What

Switches the PR Review workflow from the agents-repo default model (`github/openai/gpt-4.1`) to `cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6`.

## Why

The default model on `flipt-io/agents` is `github/openai/gpt-4.1` via GitHub Models. On a free plan that caps requests at ~8k input tokens — too small for most v2 PR diffs (system prompt + skill + diff overflow it quickly). Kimi K2.6 on Cloudflare Workers AI gives a 262k context window, reasoning, vision, and tool calling at $0.95/$4.00 per M input/output tokens. The Flue framework already supports this model through its built-in `cloudflare-workers-ai` catalog (no `app.ts` change needed); the agents action was updated to inherit provider creds from the caller's env in flipt-io/agents#9.

## Changes

- Add `env:` block on the `uses:` step exposing `CLOUDFLARE_API_KEY` and `CLOUDFLARE_ACCOUNT_ID` (already configured as repo secrets).
- Set `model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6`.
- Drop `models: read` from `permissions` — no longer needed once we're off GitHub Models.
- Update the `pull_request_target` security comment to reference Cloudflare secrets instead of GitHub Models.

## Safety

`pull_request_target` is still required so the job can reach the Cloudflare secrets and post a review on fork PRs. The reviewer continues to read the diff via `gh` — no checkout of the PR head, no build steps from PR code.