### PR TITLE
docs: correct typos in error type and authentication config comments

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -36,7 +36,7 @@ func NewErrorf[E StringError](format string, args ...any) error {
 // ErrNotFound represents a not found error
 type ErrNotFound string
 
-// ErrNotFoundf is a convience function for producing ErrNotFound.
+// ErrNotFoundf is a convenience function for producing ErrNotFound.
 var ErrNotFoundf = NewErrorf[ErrNotFound]
 
 func (e ErrNotFound) Error() string {
@@ -46,7 +46,7 @@ func (e ErrNotFound) Error() string {
 // ErrInvalid represents an invalid error
 type ErrInvalid string
 
-// ErrInvalidf is a convience function for producing ErrInvalid.
+// ErrInvalidf is a convenience function for producing ErrInvalid.
 var ErrInvalidf = NewErrorf[ErrInvalid]
 
 func (e ErrInvalid) Error() string {
@@ -66,7 +66,7 @@ func (e ErrValidation) Error() string {
 // ErrCanceled is returned when an operation has been prematurely canceled by the requester.
 type ErrCanceled string
 
-// ErrCanceledf is a convience function for producing ErrCanceled.
+// ErrCanceledf is a convenience function for producing ErrCanceled.
 var ErrCanceledf = NewErrorf[ErrCanceled]
 
 func (e ErrCanceled) Error() string {
@@ -87,7 +87,7 @@ func EmptyFieldError(field string) error {
 // client in an authenticated context.
 type ErrUnauthenticated string
 
-// ErrUnauthenticatedf is a convience function for producing ErrUnauthenticated.
+// ErrUnauthenticatedf is a convenience function for producing ErrUnauthenticated.
 var ErrUnauthenticatedf = NewErrorf[ErrUnauthenticated]
 
 // Error() returns the underlying string of the error.
@@ -107,7 +107,7 @@ func (e ErrUnauthorized) Error() string {
 // already exists
 type ErrAlreadyExists string
 
-// ErrAlreadyExistsf is a convience function for producing ErrAlreadyExists
+// ErrAlreadyExistsf is a convenience function for producing ErrAlreadyExists
 var ErrAlreadyExistsf = NewErrorf[ErrAlreadyExists]
 
 // Error returns the underlying string of the error
@@ -119,7 +119,7 @@ func (e ErrAlreadyExists) Error() string {
 // underlying storage revision has advanced since the operations was first attempted
 type ErrConflict string
 
-// ErrConflictf is a convience function for producing ErrConflict
+// ErrConflictf is a convenience function for producing ErrConflict
 var ErrConflictf = NewErrorf[ErrConflict]
 
 // Error returns the underlying string of the error
@@ -131,7 +131,7 @@ func (e ErrConflict) Error() string {
 // either because it is not yet implemented or because it has been disabled in Flipt
 type ErrNotImplemented string
 
-// ErrNotImplementedf is a convience function for producing ErrNotImplemented
+// ErrNotImplementedf is a convenience function for producing ErrNotImplemented
 var ErrNotImplementedf = NewErrorf[ErrNotImplemented]
 
 // Error returns the underlying string of the error
@@ -141,7 +141,7 @@ func (e ErrNotImplemented) Error() string {
 
 // ErrNotModified is returned when a request is made containing an If-None-Match header
 // which matches the current digest for the given requested resource
-// It us up to the client to reuse a previous response in this situation
+// It is up to the client to reuse a previous response in this situation
 type ErrNotModified string
 
 var ErrNotModifiedf = NewErrorf[ErrNotModified]

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -175,7 +175,7 @@ type AuthenticationSessionConfig struct {
 	TokenLifetime time.Duration `json:"tokenLifetime,omitempty" mapstructure:"token_lifetime" yaml:"token_lifetime,omitempty"`
 	// StateLifetime is the lifetime duration of the state cookie.
 	StateLifetime time.Duration `json:"stateLifetime,omitempty" mapstructure:"state_lifetime" yaml:"state_lifetime,omitempty"`
-	// CSRF configures CSRF provention mechanisms.
+	// CSRF configures CSRF prevention mechanisms.
 	CSRF AuthenticationSessionCSRFConfig `json:"csrf,omitempty" mapstructure:"csrf" yaml:"csrf,omitempty"`
 	// Storage configures the storage mechanism for the session.
 	Storage AuthenticationSessionStorageConfig `json:"storage,omitempty" mapstructure:"storage" yaml:"storage,omitempty"`


### PR DESCRIPTION
## Summary

- `errors/errors.go`: `convience` -> `convenience` (7 occurrences across all `Err*f` var comments), and `It us up to` -> `It is up to` in `ErrNotModified`
- `internal/config/authentication.go`: `provention` -> `prevention` in the CSRF field comment

## Changes

- `errors/errors.go`: fix spelling and grammar in godoc comments
- `internal/config/authentication.go`: fix spelling in struct field comment

## Backward Compatibility

Comment-only changes, zero functional impact.

## Additional Notes

Spotted while reading through the errors package. The `convience` typo was copy-pasted across all 7 error factory var comments, so fixing them all in one shot.