### PR TITLE
docs: tighten AGENTS.md files and add reviewer personas

### DIFF
--- a/.agents/personas/README.md
+++ b/.agents/personas/README.md
@@ -1,0 +1,39 @@
+# Agent Personas
+
+This directory contains reusable reviewer personas for agent workflows.
+
+They are written to be usable with Codex or any other AI agent that can read a
+Markdown prompt file and follow repository instructions from `AGENTS.md`.
+
+Unlike the procedural prompts in `.agents/commands/`, a persona defines a *role*
+(what to look for, how to flag findings, what output to produce) rather than a
+step-by-step task.
+
+## Usage
+
+Give your agent one of these files along with the code to review.
+
+Example:
+
+```text
+Use .agents/personas/go-reviewer.md to review the staged Go changes.
+```
+
+```text
+Use .agents/personas/go-reviewer.md to review internal/server/evaluation.
+```
+
+## Available personas
+
+- `go-reviewer.md` — senior Go reviewer; expands the "Go conventions" and
+  "Testing" sections of `AGENTS.md` into a full review checklist with examples.
+- `react-reviewer.md` — senior frontend reviewer for the UI; expands the
+  "Conventions" and "Testing" sections of `ui/AGENTS.md` into a full review
+  checklist with examples.
+
+## Conventions
+
+- Personas defer mechanical formatting and lint findings to `goimports` and
+  `golangci-lint`; they flag only what the linter won't catch.
+- Findings should cite `file:line` and separate blocking issues from
+  suggestions.

--- a/.agents/personas/go-reviewer.md
+++ b/.agents/personas/go-reviewer.md
@@ -1,0 +1,234 @@
+# Go Reviewer Persona
+
+You are a senior Go reviewer for the Flipt codebase. Review the provided Go
+changes (a diff, a file, or a package) against the conventions below and report
+concrete, actionable findings. Follow the repository's `AGENTS.md` for context;
+this file expands its concise "Go conventions" and "Testing" sections into a full
+review checklist.
+
+## How to review
+
+- Focus on the changed code unless asked to review more broadly.
+- Cite `file:line` for each finding and show the offending snippet.
+- Distinguish **blocking** issues (correctness, security, broken conventions)
+  from **suggestions** (style, readability).
+- Praise what is done well — don't only list problems.
+- Defer mechanical formatting/lint findings to `goimports` and `golangci-lint`;
+  flag style only where the linter won't catch it.
+
+## Foundation
+
+All Go follows the [Google Go Style Guide](https://google.github.io/styleguide/go/guide).
+Pay attention to: `gofmt`/`goimports` formatting, idiomatic naming, focused
+packages without circular dependencies, errors returned last and handled
+explicitly, and godoc on exported symbols. The rules below are Flipt-specific
+conventions layered on top.
+
+## Naming
+
+| Kind | Convention | Examples |
+|------|-----------|----------|
+| Public functions | PascalCase | `NewServer`, `ListFlags`, `RegisterGRPC` |
+| Private functions | camelCase | `getStore`, `buildConfig`, `handleError` |
+| Constructors | `New` prefix | `NewRepository`, `NewEnvironmentFactory` |
+| Variables | camelCase | `environmentKey`, `namespaceKey`, `startTime` |
+| Constants | PascalCase (exported) / camelCase (unexported) | |
+| Interfaces | descriptive nouns | `Store`, `EnvironmentStore`, `Validator` |
+
+## Variable declarations
+
+Prefer `:=` for single declarations; use a `var` block for related variables.
+
+```go
+result := SomeType{}
+
+var (
+    environmentKey = r.EnvironmentKey
+    namespaceKey   = r.NamespaceKey
+    startTime      = time.Now().UTC()
+)
+```
+
+## Constants over var/`:=`
+
+Use `const` for values that won't change — including in tests.
+
+❌ Bad
+
+```go
+var (
+    maxRetries     = 3
+    secretProvider = "vault"
+)
+// or
+maxRetries := 3
+secretProvider := "vault"
+```
+
+✅ Good
+
+```go
+const (
+    maxRetries     = 3
+    secretProvider = "vault"
+)
+```
+
+## Error handling
+
+Use the custom error types where they fit:
+
+```go
+// Preferred
+return nil, errs.ErrNotFoundf("flag %q not found", key)
+return nil, errs.ErrInvalidf("invalid configuration: %s", reason)
+
+// Fallback
+return nil, fmt.Errorf("failed to process: %w", err)
+```
+
+Prefer inline error declaration and checking when it reads well:
+
+❌ Bad
+
+```go
+err := doSomething()
+if err != nil {
+    // ...
+}
+```
+
+✅ Good
+
+```go
+if err := doSomething(); err != nil {
+    // ...
+}
+```
+
+## Imports
+
+Three groups: standard library, third-party, local.
+
+```go
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "github.com/go-git/go-git/v6"
+    "go.uber.org/zap"
+
+    "go.flipt.io/flipt/errors"
+    "go.flipt.io/flipt/internal/config"
+)
+```
+
+## Logging
+
+Structured logging with `zap`; `Debug` is the most common level. Be selective —
+don't over-log.
+
+```go
+s.logger.Debug("processing request",
+    zap.String("environment", envKey),
+    zap.String("namespace", nsKey),
+    zap.Int("count", len(items)))
+
+s.logger.Debug("debug info for development")  // most common
+s.logger.Info("important application events")
+s.logger.Warn("recoverable error conditions")
+s.logger.Error("error conditions that need attention")
+```
+
+## Comments & documentation
+
+Godoc on exported symbols starts with the symbol name; inline comments explain
+non-obvious logic.
+
+```go
+// ListFlags lists all flags in the specified environment and namespace.
+func (s *Server) ListFlags(ctx context.Context, r *flipt.ListFlagRequest) (*flipt.FlagList, error) {
+    // Check for X-Environment header for backward compatibility.
+    environmentKey := r.EnvironmentKey
+    if headerEnv, ok := common.FliptEnvironmentFromContext(ctx); ok && headerEnv != "" {
+        environmentKey = headerEnv
+    }
+}
+```
+
+## Project organization
+
+- `internal/` for private packages that shouldn't be imported externally.
+- Organize by domain (`server/`, `storage/`, `config/`, `analytics/`).
+- Interfaces in the domain root, implementations in subdirectories.
+- Co-locate tests (`*_test.go`); use `testdata/` for fixtures.
+
+## Testing
+
+Tests must verify **behavior, not just absence of error**.
+
+❌ Bad — only checks it ran
+
+```go
+func TestFeature(t *testing.T) {
+    result, err := service.DoSomething(input)
+    require.NoError(t, err)
+    assert.NotNil(t, result)
+}
+```
+
+✅ Good — verifies the logic and the data flowing through
+
+```go
+func TestFeature(t *testing.T) {
+    store.On("Method", mock.MatchedBy(func(ctx context.Context) bool {
+        value, ok := somePackage.ValueFromContext(ctx)
+        return ok && value == expectedValue
+    }), expectedArg).Return(expectedResult, nil)
+
+    result, err := service.DoSomething(input)
+    require.NoError(t, err)
+
+    assert.Equal(t, expectedOutput, result.ImportantField)
+    store.AssertExpectations(t)
+}
+```
+
+Principles:
+
+- **Verify behavior, not just success** — don't stop at no-error.
+- **Test the logic** — use `mock.MatchedBy` to assert correct data flows through.
+- **Test edge cases** — condition met vs. not met.
+- **Meaningful assertions** — assert on values that matter to the business logic.
+- **Mock verification** — `mock.AssertExpectations(t)` to confirm expected calls.
+
+Go unit tests use testcontainers for anything needing external tools.
+
+## Pre-commit checks the change must pass
+
+```bash
+mise run fmt          # goimports
+mise run lint         # golangci-lint (CI runs --timeout=10m)
+mise run go:modernize # modern Go idioms
+```
+
+Also enforced by CI: `go mod tidy` must leave a clean git tree, and generated
+code (protobuf output, mocks) must be regenerated rather than hand-edited.
+
+## Output format
+
+```text
+## Go Review
+
+**Verdict:** <one line>
+
+### Blocking
+1. `file.go:42` — <issue> — <why> — <suggested fix>
+
+### Suggestions
+1. `file.go:88` — <issue> — <suggested fix>
+
+### Done well
+- <notable good practice>
+```

--- a/.agents/personas/react-reviewer.md
+++ b/.agents/personas/react-reviewer.md
@@ -1,0 +1,129 @@
+# React Reviewer Persona
+
+You are a senior frontend reviewer for the Flipt UI (`ui/`). Review the provided
+React/TypeScript changes against the conventions below and report concrete,
+actionable findings. Follow `ui/AGENTS.md` for context; this expands its
+"Conventions" and "Testing" sections into a full checklist.
+
+## How to review
+
+- Focus on the changed code unless asked to review more broadly.
+- Cite `file:line` and show the snippet.
+- Separate **blocking** issues (bugs, broken conventions, missing error/loading
+  states, accessibility gaps) from **suggestions** (style, readability).
+- Praise what is done well.
+- Defer mechanical formatting/lint to ESLint + Prettier; flag only what they miss.
+
+## Component structure
+
+Functional components with typed props; handle loading and error states explicitly.
+
+```tsx
+export default function FlagList({ namespace }: FlagListProps) {
+  const { data, isLoading, error } = useListFlagsQuery({ namespace });
+
+  if (isLoading) return <Loading />;
+  if (error) return <ErrorMessage error={error} />;
+
+  return (
+    <div className="space-y-4">
+      {data?.flags.map((flag) => (
+        <FlagCard key={flag.key} flag={flag} />
+      ))}
+    </div>
+  );
+}
+```
+
+## State & data fetching
+
+RTK Query slices are **co-located per feature** under `src/app/<feature>/<feature>Api.ts`
+(not in `src/data/`). Use `~/` to import from `src/`. Invalidate cache tags after mutations.
+
+```typescript
+// src/app/flags/flagsApi.ts
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+export const flagsApi = createApi({
+  reducerPath: 'flagsApi',
+  baseQuery: /* shared base query with x-csrf-token */,
+  tagTypes: ['Flag'],
+  endpoints: (builder) => ({
+    listFlags: builder.query<FlagList, ListFlagsRequest>({
+      query: ({ environmentKey, namespaceKey }) =>
+        `${environmentKey}/namespaces/${namespaceKey}/flags`,
+      providesTags: ['Flag'],
+    }),
+  }),
+});
+```
+
+Shared constants, `APIError`, and fetch helpers live in `src/data/api.ts`. The
+backend is v2-first (`api/v2/environments`, `auth/v1`, `evaluate/v1`, `internal/v2`,
+`meta/info`). Real-time updates use SSE (`EventSource`), not WebSocket.
+
+## TypeScript
+
+- Type all props and API responses; avoid `any`.
+- Export types from their domain modules under `src/types/`.
+
+## Styling (Tailwind v4)
+
+Utility classes; config is CSS-first in `src/index.css` (no `tailwind.config.js`).
+Respect dark mode (driven by the Redux `preferencesSlice` theme) — use theme-aware
+classes, not hardcoded colors. Build on Radix UI primitives for interactive components.
+
+```tsx
+<div className="flex items-center justify-between rounded-lg p-4 shadow">
+  <h2 className="text-lg font-semibold">Flag Name</h2>
+  <Switch enabled={enabled} onChange={handleToggle} />
+</div>
+```
+
+## File naming
+
+| Kind | Convention | Example |
+|------|-----------|---------|
+| Components | PascalCase | `FlagList.tsx` |
+| Hooks | `use` prefix | `useChangesStream.ts` |
+| API slices | `Api` suffix | `flagsApi.ts` |
+| Types | PascalCase | `Flag.ts` |
+| Utils | camelCase | `formatters.ts` |
+
+## Accessibility
+
+- ARIA labels on interactive elements; keyboard navigation works.
+- Sufficient color contrast in both light and dark themes.
+
+## Testing
+
+- Unit tests with Jest (`npm run test`); co-locate `*.test.ts(x)`.
+- E2E with Playwright in `ui/tests/` (`npx playwright test`, needs a backend).
+- Test behavior users observe (rendered output, interactions), not implementation details.
+- Cover loading, error, and empty states.
+
+## Before the change lands
+
+```bash
+mise run ui:fmt && mise run ui:lint   # CI enforces both
+npm run knip                          # no new unused files/exports/deps
+```
+
+`npm run build` runs `tsc` — type errors must be clean.
+
+## Output format
+
+```text
+## React Review
+
+**Verdict:** <one line>
+
+### Blocking
+1. `file.tsx:42` — <issue> — <why> — <suggested fix>
+
+### Suggestions
+1. `file.tsx:88` — <issue> — <suggested fix>
+
+### Done well
+- <notable good practice>
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,580 +1,87 @@
 # AGENTS
 
-This file provides guidance to AI Agents when working with code in this repository.
+Guidance for AI agents working in this repository. Full docs live at <https://docs.flipt.io> — weigh **v2** docs over v1.
 
-All of our documentation is at <https://docs.flipt.io>. Weigh the v2 docs heavily when answering questions over the v1 docs.
+Flipt v2 is a Git-native feature management platform (Go server + React UI) in a monorepo.
 
-## Reusable Agent Commands
+## Branch model (read first)
 
-Portable agent prompts live in `.agents/commands/`.
+- **v2 code** lives on the `v2` branch — the **default** branch. Most work happens here.
+- **v1 code** lives on `main`.
+- Base PRs on the matching branch and apply the matching label (`v2` or `v1`).
+- License: Fair Core License (server), MIT (client code).
 
-- Use these files for Codex or any other repo-aware AI agent.
-- Current commands:
-  - `.agents/commands/changelog.md`
-  - `.agents/commands/release.md`
+## Tooling
 
-## Project Overview
-
-Flipt v2 is a Git-native feature management platform with a monorepo structure. This is the v2 version with a Git-native architecture.
-
-- **v1 code**: Located on `main` branch
-- **v2 code**: Located on current (`v2`) branch. This is the default branch in the repository.
-- **License**: Fair Core License for server, MIT for client code
-- **Requirements**: Go 1.25+ and Node.js 18+
-
-## Project Architecture & Structure
-
-### Repository Structure
-
-- `cmd/flipt/` - Main application entry point
-- `core/` - Core validation and business logic
-- `errors/` - Shared error definitions
-- `internal/` - Core application logic (not importable)
-  - `cmd/` - Internal command utilities and code generation tools
-  - `common/` - Shared types and utilities across internal packages
-  - `config/` - Configuration management
-  - `containers/` - Container test utilities
-  - `coss/` - Commercial open source features (license management, enterprise storage, secrets)
-  - `secrets/` - Secret management system with provider interface (OSS file provider, Pro Vault provider)
-  - `credentials/` - Credential management for cloud storage and Git authentication
-  - `ext/` - Import/export functionality for flags and segments
-  - `gateway/` - HTTP gateway implementation
-  - `info/` - Version and build information
-  - `migrations/` - Database migration files (ClickHouse for analytics)
-  - `otel/` - OpenTelemetry integration (logs, metrics, traces)
-  - `product/` - Product metadata and feature flags
-  - `release/` - Release version checking
-  - `server/` - gRPC and HTTP server implementations
-    - `analytics/` - Analytics collection server (Prometheus, ClickHouse)
-    - `authn/` - Authentication server and middleware
-    - `authz/` - Authorization server with Rego engine
-    - `environments/` - Environment management server
-    - `evaluation/` - Flag evaluation server with OFREP support
-    - `metadata/` - Metadata API server
-  - `storage/` - Storage abstractions and implementations
-    - `analytics/` - Analytics data storage
-    - `authn/` - Authentication storage (Redis, memory, static)
-    - `environments/` - Environment-aware storage with Git support
-    - `fs/` - File system abstraction layer
-    - `git/` - Git repository management
-  - `telemetry/` - Usage telemetry collection
-- `rpc/` - Protocol buffer definitions and generated code
-  - `flipt/` - Main Flipt API (v1)
-  - `v2/` - V2 APIs (environments, analytics, evaluation)
-- `sdk/` - Client SDKs (Go SDK included)
-- `ui/` - React/TypeScript frontend
-
-### Key Components
-
-#### Storage Layer
-
-Multi-backend storage supporting:
-
-- Git repositories (primary for v2)
-- File system (local development)
-- Cloud storage (S3, GCS, Azure Blob) - Flipt config only
-
-#### Environments System
-
-- Environment-per-branch: Map Git branches to environments
-- Environment-per-directory: Organize by microservice/team
-- Environment-per-repository: Separate repos for products
-
-#### APIs
-
-- gRPC API (port 9000) - Primary interface
-- REST API (port 8080) - HTTP gateway over gRPC
-- OpenFeature compatible evaluation
-
-##### Key Endpoints
-
-- **Evaluation API**: `/api/v1/evaluate` - Evaluate feature flags
-- **Management API**: Full CRUD operations on flags, segments, rules
-- **Analytics API**: `/api/v2/analytics` - Flag evaluation metrics
-- **Environments API**: `/api/v2/environments` - Environment management
-- **OFREP API**: `/ofrep/v1` - OpenFeature Remote Evaluation Protocol
-
-#### UI Architecture
-
-- React 19 with TypeScript
-- Redux Toolkit for state management
-- Tailwind CSS for styling
-- Vite for build tooling
-- React Router for navigation
-
-## Development Setup & Commands
-
-### Initial Setup
-
-Tool versions (Go, Node) are defined in `.mise.toml`. Install [mise](https://mise.jdx.dev/) and run:
+Tool versions are pinned in `.mise.toml` (**Go 1.26**, **Node 20**). Install [mise](https://mise.jdx.dev/), then:
 
 ```bash
-# Install tool versions and development dependencies
-mise install
-mise run bootstrap
+mise install        # install pinned Go/Node
+mise run bootstrap  # install dev dependencies
 ```
 
-### Development Workflow
+All common tasks run through mise (`mise tasks` to list). Key ones:
 
-1. **Setup**: Run `mise install` then `mise run bootstrap` to install tools
-2. **Backend Development**:
-   - Use `mise run dev` for server
-   - Server runs on port 8080 (HTTP) and 9000 (gRPC)
-3. **Frontend Development**:
-   - Run `mise run ui:dev` for UI dev server on port 5173
-   - UI proxies API requests to backend on port 8080
-4. **Full Development**: Run both servers simultaneously
+| Task | Does |
+|------|------|
+| `mise run dev` | Run Go server (HTTP :8080, gRPC :9000) with local config |
+| `mise run ui:dev` | Run UI dev server on :5173 (proxies API to :8080) |
+| `mise run build` | Release-style build (Go + bundled UI assets) |
+| `mise run test` | Go unit tests (`go test -v {path} -run {name}` for one) |
+| `mise run lint` / `mise run fmt` | golangci-lint / goimports |
+| `mise run go:modernize` | Apply modern Go idioms |
+| `mise run proto` | Regenerate protobuf + gRPC stubs |
+| `mise run go:mockery` | Regenerate mocks (config in `.mockery.yml`) |
 
-### Build & Run Commands
+Portable agent prompts for Codex and other tools live in `.agents/`: commands in `.agents/commands/` (`changelog.md`, `release.md`) and reviewer personas in `.agents/personas/` (`go-reviewer.md`).
 
-- `mise run build` - Builds the project similar to a release build
-- `mise run go:build` - Builds Go server for development without bundling assets
-- `mise run dev` - Runs Go server in development mode with local config
-- `./bin/flipt server --config config/local.yml` - Run built binary with local config
+## Detailed rules — read the relevant file before working in that area
 
-### UI Development Commands
+- **UI / React / TypeScript** (components, Redux, Tailwind, API slices) → read `ui/AGENTS.md`
+- **Integration tests & the Dagger build pipeline** → read `build/CLAUDE.md`
 
-- `mise run ui:deps` - Install UI dependencies
-- `mise run ui:dev` - Run UI in development mode (port 5173)
-- `mise run ui:build` - Build UI assets for release
-- `cd ui && npm run dev` - Alternative way to run UI dev server
+## Architecture (the non-obvious parts)
 
-### Testing Commands
+- **gRPC-first**: gRPC (:9000) is the primary interface; the REST API (:8080) is an HTTP gateway generated over it. Add/change RPCs in `rpc/`, run `mise run proto`.
+- `cmd/flipt/` is the entry point. `internal/` holds private app logic (server, storage, config); `core/` holds validation/business logic; `errors/` holds shared error types.
+- **OSS vs Pro boundary**: `internal/coss/` and the Pro-tier providers (e.g. `internal/secrets/` Vault provider) are commercial features gated by license — keep them isolated from OSS paths.
+- **Storage** (`internal/storage/`) is multi-backend: Git repos are primary for v2; filesystem for local dev; cloud (S3/GCS/Azure) is for Flipt config only. Environments map to Git branches/directories/repos.
+- **APIs**: Management CRUD, Evaluation (`/api/v1/evaluate`, OpenFeature/OFREP at `/ofrep/v1`), Analytics (`/api/v2/analytics`), Environments (`/api/v2/environments`).
 
-- `mise run test` - Run all Go unit tests (alias for `go:test`)
-- `go test -v {path} -run {test}` - Run a specific Go test
-- `mise run bench` - Run Go benchmarking tests (alias for `go:bench`)
-- `mise run go:cover` - Run tests and generate coverage report
-- `cd ui && npm run test` - Run UI unit tests (Jest)
+## Go conventions
 
-### Code Quality Commands
+Follow the [Google Go Style Guide](https://google.github.io/styleguide/go/guide); `goimports` and `golangci-lint` enforce the mechanical parts. The concise project-specific rules below are the always-on essentials; for a full review checklist with examples, use `.agents/personas/go-reviewer.md`.
 
-- `mise run lint` - Run Go linters (alias for `go:lint`)
-- `mise run fmt` - Format Go code with goimports (alias for `go:fmt`)
-- `mise run ui:lint` - Run UI linters (ESLint)
-- `mise run ui:fmt` - Format UI code (Prettier)
+- **Use the custom error types** where they fit: `errs.ErrNotFoundf("flag %q not found", key)`, `errs.ErrInvalidf(...)`. Fall back to `fmt.Errorf("...: %w", err)` otherwise.
+- **Prefer `const` over `var`/`:=`** for values that won't change — including in tests.
+- Prefer inline error checks: `if err := doSomething(); err != nil { ... }`.
+- Imports in three groups: stdlib, third-party, local (`go.flipt.io/flipt/...`).
+- Structured logging with `zap`; `Debug` is the common level. Be selective.
+- Keep interfaces in the domain root, implementations in subdirectories; co-locate `*_test.go` and use `testdata/` for fixtures.
 
-### Code Generation Commands
+## Testing
 
-- `mise run proto` - Generate protobuf files and gRPC stubs (alias for `go:proto`)
-- `mise run go:mockery` - Generate mocks
-- `mise run go:generate` - Generate both mocks and proto files
+Tests must verify **behavior, not just absence of error**. Don't stop at `require.NoError`; assert the values that matter and verify data flowing through mocks with `mock.MatchedBy`, then `mock.AssertExpectations(t)`. Go tests use testcontainers for anything needing external tools.
 
-### Cleanup Commands
+## Before you commit
 
-- `mise run clean` - Clean built files and tidy go.mod
-- `mise run prep` - Prepare project for building (clean + ui:build)
-
-### Build Process Notes
-
-- Protocol buffers generate Go and gateway code
-- Mockery generates Go test mocks. See .mockery.yml
-- UI has no code generation
-
-## Code Style Guidelines
-
-### Go Code Style
-
-#### Foundation: Google Go Style Guide
-
-**All Go code should follow the [Google Go Style Guide](https://google.github.io/styleguide/go/guide) as the base style guide.**
-
-The guidelines below are Flipt-specific conventions that build upon the Google style guide. When in doubt, refer to the Google guide first, then apply these project-specific patterns.
-
-Key areas from the Google guide to pay special attention to:
-
-- **Formatting**: Use `gofmt` (we use `goimports` which includes `gofmt`)
-- **Naming**: Follow Go naming conventions for packages, types, functions, and variables
-- **Package organization**: Keep packages focused and avoid circular dependencies
-- **Error handling**: Return errors as the last return value, handle errors explicitly
-- **Documentation**: Write clear godoc comments for exported types and functions
-
-#### Naming Conventions
-
-- **Public functions**: Use PascalCase (`NewServer`, `ListFlags`, `RegisterGRPC`)
-- **Private functions**: Use camelCase (`getStore`, `buildConfig`, `handleError`)
-- **Factory functions**: Use `New` prefix for constructors (`NewRepository`, `NewEnvironmentFactory`)
-- **Variables**: Use camelCase (`environmentKey`, `namespaceKey`, `startTime`)
-- **Constants**: Use PascalCase for exported, camelCase for unexported
-- **Interfaces**: Use descriptive names (`Store`, `EnvironmentStore`, `Validator`)
-
-#### Variable Declarations
-
-```go
-// Prefer := for single variable declarations
-result := SomeType{}
-
-// Use var blocks for multiple related variables
-var (
-    environmentKey = r.EnvironmentKey
-    namespaceKey   = r.NamespaceKey
-    startTime      = time.Now().UTC()
-)
-```
-
-#### Constants
-
-Use constants when appropriate for values that are unlikely to change. Even in tests.
-
-**❌ Bad Examples**
-
-```go
-var (
-    maxRetries = 3
-    secretProvider = "vault"
-)
-```
-
-```go
-  maxRetries := 3
-  secretProvider := "vault"
-```
-
-**✅ Good Example**
-
-```go
-const (
-    maxRetries = 3
-    secretProvider = "vault"
-)
-```
-
-#### Error Handling
-
-##### Error Types
-
-Use the custom error types when possible:
-
-```go
-// Preferred - use custom error types
-return nil, errs.ErrNotFoundf("flag %q not found", key)
-return nil, errs.ErrInvalidf("invalid configuration: %s", reason)
-
-// Fallback - standard error handling
-return nil, fmt.Errorf("failed to process: %w", err)
-```
-
-##### Inline Errors
-
-Prefer inline error declarations and checking when it makes sense.
-
-**❌ Bad Example**
-
-```go
-err := doSomething()
-if err != nil {
-    // ...
-}
-```
-
-**✅ Good Example**
-
-```go
-if err := doSomething(); err != nil {
-    // ...
-}
-```
-
-#### Imports
-
-Follow the three-group import pattern (extends Google guide):
-
-```go
-import (
-    // Standard library
-    "context"
-    "fmt"
-    "time"
-
-    // Third-party packages
-    "github.com/go-git/go-git/v6"
-    "go.uber.org/zap"
-
-    // Local packages
-    "go.flipt.io/flipt/errors"
-    "go.flipt.io/flipt/internal/config"
-)
-```
-
-#### Logging
-
-Use structured logging with zap:
-
-```go
-// Preferred - structured logging with context
-s.logger.Debug("processing request",
-    zap.String("environment", envKey),
-    zap.String("namespace", nsKey),
-    zap.Int("count", len(items)))
-
-// Use appropriate log levels
-s.logger.Debug("debug info for development")  // Most common
-s.logger.Info("important application events")
-s.logger.Warn("recoverable error conditions")
-s.logger.Error("error conditions that need attention")
-
-// Avoid overusing log statements - be selective about what to log
-```
-
-#### Comments and Documentation
-
-```go
-// Public functions need godoc comments starting with function name
-// ListFlags lists all flags in the specified environment and namespace
-func (s *Server) ListFlags(ctx context.Context, r *flipt.ListFlagRequest) (*flipt.FlagList, error) {
-    // Inline comments explain complex logic
-    // Check for X-Environment header for backward compatibility
-    environmentKey := r.EnvironmentKey
-    if headerEnv, ok := common.FliptEnvironmentFromContext(ctx); ok && headerEnv != "" {
-        environmentKey = headerEnv
-    }
-}
-```
-
-#### Project Organization
-
-- Use `internal/` for private packages that shouldn't be imported externally
-- Organize by domain (`server/`, `storage/`, `config/`, `analytics/`)
-- Keep interfaces in domain root, implementations in subdirectories
-- Co-locate tests with implementation (`*_test.go`)
-- Use `testdata/` directories for test fixtures
-
-#### Pre-commit Quality Checks (Go)
-
-**Always run these commands when adding or editing Go code:**
+Run the relevant checks — CI enforces all of these:
 
 ```bash
-# Format Go code
-mise run fmt
-
-# Lint Go code
-mise run lint
-
-# Run modernize to update code to 1.24+ style
-mise run go:modernize
+mise run fmt && mise run lint && mise run go:modernize   # Go
+mise run ui:fmt && mise run ui:lint                      # UI
+npx prettier -w <file>.md                                # Markdown
 ```
 
-### UI/React/TypeScript Code Style
+Hard constraints (CI will fail otherwise):
 
-#### File Naming and Organization
+- `go mod tidy` must leave a clean git tree — tidy and commit `go.mod`/`go.sum` changes.
+- Shell scripts must pass shellcheck.
+- Never hand-edit generated code (protobuf output, mocks) — regenerate it.
 
-- **Components**: Use PascalCase for `.tsx` files (`FlagForm.tsx`, `FlagTable.tsx`)
-- **API files**: Use camelCase with suffix (`flagsApi.ts`, `authApi.ts`)
-- **Types**: Use PascalCase for `.ts` files (`Flag.ts`, `Analytics.ts`)
-- **Utilities**: Use descriptive lowercase names (`helpers.ts`)
+## Commits & PRs
 
-#### Component Structure
-
-- Use functional components with hooks
-- Organize components by domain in directories
-- Keep reusable UI components in `ui/` directory
-- Co-locate component tests with implementation
-
-#### State Management
-
-- Use Redux Toolkit for application state
-- Create API slices for domain-specific data (`flagsApi.ts`)
-- Use TypeScript for type safety throughout
-
-#### Pre-commit Quality Checks (UI)
-
-**Always run these commands when adding or editing UI code:**
-
-```bash
-# Format UI code (TypeScript/React)
-mise run ui:fmt
-
-# Lint UI code (ESLint)
-mise run ui:lint
-```
-
-### General Pre-commit Checks
-
-```bash
-# Format specific markdown files (replace with actual filename)
-npx prettier -w README.md
-```
-
-## Configuration
-
-### Configuration Files
-
-- `config/local.yml` - Local development config
-- `config/dev.yml` - Alternative dev config
-- User config at `{{ USER_CONFIG_DIR }}/flipt/config.yml`
-
-### Debugging Tips
-
-- Use `FLIPT_LOG_LEVEL=debug` for verbose logging
-- Check `/metrics` endpoint for Prometheus metrics
-- View OpenTelemetry traces for request flow
-- Git sync issues: Check repository access and credentials
-- Authentication issues: Verify redirect URLs and client configurations
-
-## Testing Guidelines
-
-### Test Structure
-
-- Go tests use testcontainers for unit tests that depend on external tools
-- UI tests use Jest for unit tests and Playwright for E2E
-
-### Writing Effective Tests
-
-When writing tests, ensure they actually verify the functionality being tested:
-
-**❌ Bad Example - Test doesn't verify actual behavior:**
-
-```go
-// This test only verifies the method runs without error, not that the logic works
-func TestFeature(t *testing.T) {
-    result, err := service.DoSomething(input)
-    require.NoError(t, err)
-    assert.NotNil(t, result)
-}
-```
-
-**✅ Good Example - Test verifies specific behavior:**
-
-```go
-// This test verifies the actual logic and behavior
-func TestFeature(t *testing.T) {
-    // Use mock.MatchedBy to verify the correct data is passed through
-    store.On("Method", mock.MatchedBy(func(ctx context.Context) bool {
-        // Verify the context contains the expected values
-        value, ok := somePackage.ValueFromContext(ctx)
-        return ok && value == expectedValue
-    }), expectedArg).Return(expectedResult, nil)
-
-    result, err := service.DoSomething(input)
-    require.NoError(t, err)
-
-    // Verify the actual business logic worked correctly
-    assert.Equal(t, expectedOutput, result.ImportantField)
-    store.AssertExpectations(t) // Ensures mocks were called as expected
-}
-```
-
-**Key Testing Principles:**
-
-- **Verify behavior, not just success**: Don't just check that methods return without error
-- **Test the logic**: Use `mock.MatchedBy` to verify correct data flows through the system
-- **Test edge cases**: Include tests for when conditions are met vs. not met
-- **Use meaningful assertions**: Assert on the specific values that matter to the business logic
-- **Mock verification**: Use `mock.AssertExpectations(t)` to ensure mocks were called with expected parameters
-
-### Integration Tests
-
-Integration tests are defined in `build/testing/` and run as Mage targets. For details on available integration test targets, helpers, and how to add new integration tests, see the files in that directory:
-
-- `build/testing/integration.go` - Integration test targets and configuration
-- `build/testing/integration/` - Individual integration test suites
-- `build/testing/helpers.go` - Shared test helpers
-- `build/testing/test.go` - Core test utilities
-
-## Git Workflow & Commits
-
-### Creating Effective Commits
-
-#### Commit Message Format
-
-Follow conventional commit format:
-
-```
-type(scope): brief description
-
-Longer description if needed explaining the why, not the what.
-
-- List specific changes if helpful
-- Include any breaking changes
-- Reference issues (e.g., "Fixes #123")
-```
-
-#### Commit Types
-
-- `feat:` - New features
-- `fix:` - Bug fixes
-- `docs:` - Documentation changes
-- `style:` - Code style changes (formatting, etc.)
-- `refactor:` - Code refactoring without functional changes
-- `test:` - Adding or modifying tests
-- `chore:` - Build process or auxiliary tool changes
-
-#### Examples
-
-```bash
-# Good commit messages
-git commit -s -m "feat: add X-Environment header support to ListFlags endpoint
-
-The v1 ListFlags endpoint now checks for X-Environment header
-for backward compatibility. When present, the header value
-takes precedence over the request environment parameter.
-
-- Modified ListFlags method to check context for environment header
-- Added ForwardFliptEnvironment middleware to v1 API gateway
-- Added comprehensive test coverage
-
-Fixes #4411"
-
-git commit -s -m "fix: resolve race condition in flag evaluation cache"
-
-git commit -s -m "test: improve X-Environment header test coverage
-
-- Use mock.MatchedBy to verify context contains correct environment
-- Add test for when header is not present
-- Ensure tests actually validate the header precedence logic"
-```
-
-### Pull Request Guidelines
-
-#### PR Title Format
-
-Use the same conventional commit format for PR titles:
-
-```
-type(scope): brief description
-```
-
-#### PR Description Template
-
-```markdown
-## Summary
-
-Brief description of what this PR does and why.
-
-## Changes
-
-- **Modified `file1.go`**: Specific change description
-- **Added `file2_test.go`**: Test coverage description
-- **Updated `config.yml`**: Configuration change description
-
-## Backward Compatibility
-
-Describe any backward compatibility or breaking change considerations.
-
-## Additional Notes
-
-Any other context, screenshots, or related issues.
-```
-
-#### PR Best Practices
-
-- **Keep PRs focused**: One logical change per PR
-- **Write descriptive titles**: Use conventional commit format
-- **Provide context**: Explain the "why" behind changes
-- **Include tests**: Always add tests for new functionality
-- **Run quality checks**: Format and lint before creating PR
-- **Reference issues**: Use "Fixes #123" to auto-close issues
-- **Review your own PR**: Look through the diff before requesting review
-- **Base PRs on the correct branch**: Base PRs on the correct branch (e.g. `v2` for v2 changes, `main` for v1 changes)
-- **Label PRs correctly**: When creating a feature based off of the v2 branch, label the PR with the `v2` label. Similarly for a v1 (main) feature, use the `v1` label.
-
-#### Quality Checklist
-
-Before creating a PR, ensure:
-
-- [ ] Code follows style guidelines
-- [ ] Tests are added and passing
-- [ ] Linting passes (`mise run lint` / `mise run ui:lint`)
-- [ ] Code is formatted (`mise run fmt` / `mise run ui:fmt`)
-- [ ] Commit messages are clear and descriptive
-- [ ] PR description explains the change and its purpose
+- Conventional commits: `type(scope): description` (`feat`, `fix`, `docs`, `refactor`, `test`, `chore`, …).
+- **Always sign commits with `-s`.**
+- Keep PRs focused; explain the *why*; reference issues with `Fixes #123`.
+- Base on the correct branch and label `v2`/`v1` (see Branch model above).

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -1,255 +1,58 @@
-# AGENTS - UI Directory
+# AGENTS — UI
 
-This file provides guidance to AI Agents when working with the Flipt UI application.
+The Flipt UI: a React 19 + TypeScript single-page app that is **embedded into the Flipt server binary** for production. Follow the root `AGENTS.md` for repo-wide rules; this file covers the `ui/` package.
 
-## UI Overview
+## Stack
 
-The Flipt UI is a React-based single-page application that provides a web interface for managing feature flags. It's built with modern technologies and gets embedded into the main Flipt server binary.
+React 19 · TypeScript · Redux Toolkit + RTK Query · React Router v7 (hash router) · Tailwind CSS **v4** · Radix UI primitives · Vite 6 · Jest (unit) + Playwright (e2e) · ESLint + Prettier.
 
-## Technology Stack
+## Commands
 
-- **Framework**: React 19 with TypeScript
-- **State Management**: Redux Toolkit with RTK Query
-- **Styling**: Tailwind CSS
-- **Build Tool**: Vite
-- **Testing**: Jest (unit), Playwright (E2E)
-- **Code Quality**: ESLint, Prettier
-- **UI Components**: Custom components with Radix UI
-
-## Project Structure
-
-```
-ui/
-├── src/
-│   ├── app/              # Redux store and root configuration
-│   │   ├── hooks.ts      # Typed Redux hooks
-│   │   └── store.ts      # Store configuration
-│   ├── components/       # Reusable React components
-│   │   ├── common/       # Shared UI components
-│   │   ├── flags/        # Flag-specific components
-│   │   ├── segments/     # Segment-specific components
-│   │   └── rules/        # Rule-specific components
-│   ├── data/            # API integration and data layer
-│   │   └── api/         # RTK Query API slices
-│   ├── types/           # TypeScript type definitions
-│   ├── utils/           # Utility functions and helpers
-│   ├── App.tsx          # Root application component
-│   └── main.tsx         # Application entry point
-├── public/              # Static assets
-├── tests/               # Test files
-├── package.json         # Dependencies and scripts
-├── tsconfig.json        # TypeScript configuration
-├── vite.config.ts       # Vite build configuration
-└── tailwind.config.js   # Tailwind CSS configuration
-```
-
-## Development Workflow
-
-### Running the UI
+Node 20 (pinned in root `.mise.toml`). From the repo root:
 
 ```bash
-# From repository root
-mise run ui:dev
-
-# Or from ui directory
-npm run dev
+mise run ui:dev    # dev server on :5173, proxies API to backend :8080
+mise run ui:build  # production build (embedded into the server binary)
+mise run ui:fmt    # prettier
+mise run ui:lint   # eslint
 ```
 
-The development server runs on port 5173 and proxies API requests to the backend on port 8080.
+Or from `ui/`: `npm run dev | build | lint | format | test | knip`.
+`npm run build` runs `tsc` first, so **type errors fail the build**.
 
-### Building for Production
+## Architecture (the non-obvious parts)
 
-```bash
-# From repository root
-mise run ui:build
+- **`src/app/<feature>/`** = feature/route modules — pages, layouts, and the feature's **co-located RTK Query slice** (`flagsApi.ts`, `authApi.ts`, `environmentsApi.ts`, …). This is where most logic lives.
+- **`src/components/`** = shared, reusable components (built on Radix UI primitives).
+- **`src/data/`** = cross-cutting data layer: `api.ts` (shared base URLs, `APIError`, fetch/browser helpers, session) and `hooks/` (shared hooks like `useChangesStream`).
+- **`src/store.ts`** = Redux store (`configureStore`); `src/types/`, `src/utils/`, `src/hooks/`.
+- **Routing**: `createHashRouter` from `react-router` (hash-based URLs).
+- **Path alias**: `~/` maps to `src/` (e.g. `import { FlagType } from '~/types/Flag'`).
+- **Backend API is v2-first**: base paths `api/v2/environments`, `auth/v1`, `evaluate/v1`, `internal/v2`, `meta/info`. Requests carry an `x-csrf-token` header.
+- **Real-time** flag changes use **SSE** (`EventSource` in `useChangesStream`), not WebSocket.
+- **Styling**: Tailwind **v4** — config is CSS-first in `src/index.css`; there is **no `tailwind.config.js`**. Dark mode is driven by the Redux `preferencesSlice` theme.
 
-# Or from ui directory
-npm run build
-```
+## Conventions
 
-Production builds are embedded into the server binary during the main build process.
+Concise essentials below; for a full review checklist with examples use `.agents/personas/react-reviewer.md`.
 
-## Code Style Guidelines
-
-### Component Structure
-
-```tsx
-// Use functional components with TypeScript
-export default function FlagList({ namespace }: FlagListProps) {
-  const { data, isLoading, error } = useListFlagsQuery({ namespace });
-
-  if (isLoading) return <Loading />;
-  if (error) return <ErrorMessage error={error} />;
-
-  return (
-    <div className="space-y-4">
-      {data?.flags.map((flag) => (
-        <FlagCard key={flag.key} flag={flag} />
-      ))}
-    </div>
-  );
-}
-```
-
-### State Management
-
-Use Redux Toolkit with RTK Query for API calls:
-
-```typescript
-// data/api/flagsApi.ts
-export const flagsApi = createApi({
-  reducerPath: 'flagsApi',
-  baseQuery: fetchBaseQuery({ baseUrl: '/api/v1' }),
-  tagTypes: ['Flag'],
-  endpoints: (builder) => ({
-    listFlags: builder.query<FlagList, ListFlagsRequest>({
-      query: ({ namespace }) => `namespaces/${namespace}/flags`,
-      providesTags: ['Flag']
-    })
-  })
-});
-```
-
-### TypeScript Best Practices
-
-- Define interfaces for all props and API responses
-- Use strict typing throughout the application
-- Avoid `any` types unless absolutely necessary
-- Export types from their domain modules
-
-### Styling with Tailwind
-
-```tsx
-// Use Tailwind utility classes
-<div className="flex items-center justify-between p-4 bg-white rounded-lg shadow">
-  <h2 className="text-lg font-semibold text-gray-900">Flag Name</h2>
-  <Switch enabled={enabled} onChange={handleToggle} />
-</div>
-```
-
-### File Naming Conventions
-
-- **Components**: PascalCase (`FlagList.tsx`, `SegmentEditor.tsx`)
-- **Hooks**: camelCase with 'use' prefix (`useAuth.ts`, `useFlags.ts`)
-- **Utils**: camelCase (`formatters.ts`, `validators.ts`)
-- **API slices**: camelCase with 'Api' suffix (`flagsApi.ts`)
-- **Types**: PascalCase (`Flag.ts`, `Segment.ts`)
-
-## API Integration
-
-### API Structure
-
-The UI communicates with the backend through:
-
-- **REST API**: Primary interface on `/api/v1` and `/api/v2`
-- **WebSocket**: Real-time updates for flag changes (when enabled)
-
-### Authentication
-
-The UI supports multiple authentication methods:
-
-- Basic authentication
-- OIDC (OpenID Connect)
-- Token-based authentication
-
-Authentication state is managed in Redux and tokens are stored securely.
+- Functional components with hooks; strict TypeScript, avoid `any`; type all props and API responses.
+- RTK Query slices co-located per feature under `src/app/<feature>/<feature>Api.ts`; invalidate cache tags after mutations.
+- Every API call handles loading and error states.
+- File naming: Components `PascalCase.tsx`, hooks `useThing.ts`, API slices `thingApi.ts`, types `Thing.ts`, utils `camelCase.ts`.
+- Accessibility: ARIA labels and keyboard navigation.
 
 ## Testing
 
-### Unit Tests
+- Unit (Jest): `cd ui && npm run test` (config in `jest.config.ts`).
+- E2E (Playwright): specs in `ui/tests/*.spec.ts`, run with `npx playwright test` (requires a running backend).
+- `npm run knip` finds unused files/exports/deps.
 
-```bash
-# Run unit tests
-npm run test
+## Before you commit
 
-# Run with coverage
-npm run test:coverage
-```
+`mise run ui:fmt && mise run ui:lint` — both are enforced by CI (the UI lint job runs eslint + prettier check).
 
-### E2E Tests
+## Notes
 
-```bash
-# Run E2E tests (requires backend running)
-npm run test:e2e
-```
-
-## Common Development Tasks
-
-### Adding a New Feature
-
-1. Create TypeScript types in `types/`
-2. Add API endpoints in `data/api/`
-3. Build React components in `components/`
-4. Add routing if needed in `App.tsx`
-5. Write tests for new functionality
-
-### Modifying API Calls
-
-1. Update the RTK Query slice in `data/api/`
-2. Regenerate TypeScript types if needed
-3. Update components using the API
-4. Test with both mock and real backend
-
-### Updating Styles
-
-1. Use Tailwind classes for styling
-2. Add custom styles sparingly in component files
-3. Update `tailwind.config.js` for theme changes
-4. Keep dark mode support in mind
-
-## Build and Deployment
-
-### Production Build Process
-
-1. Vite bundles the application
-2. Assets are optimized and minified
-3. Build output goes to `dist/` directory
-4. Server embeds the built assets
-
-### Environment Variables
-
-- `VITE_API_URL`: Backend API URL (defaults to proxy in dev)
-- `VITE_ENABLE_TELEMETRY`: Enable usage telemetry
-- `VITE_SENTRY_DSN`: Sentry error reporting DSN
-
-## Performance Considerations
-
-- Use React.memo for expensive components
-- Implement virtualization for long lists
-- Lazy load routes and heavy components
-- Optimize bundle size with code splitting
-
-## Debugging Tips
-
-- Use React DevTools for component inspection
-- Redux DevTools for state debugging
-- Network tab for API call inspection
-- Console for development logs
-- Source maps are available in development
-
-## Common Issues and Solutions
-
-### CORS Issues
-
-- Ensure proxy configuration in `vite.config.ts` is correct
-- Check backend CORS settings if running separately
-
-### State Management
-
-- Clear Redux store on logout
-- Handle optimistic updates carefully
-- Invalidate cache tags after mutations
-
-### Build Issues
-
-- Clear `node_modules` and reinstall
-- Check Node.js version (18+)
-- Verify all dependencies are installed
-
-## Important Notes
-
-- The UI is embedded in the server binary for production
-- Development runs as a separate process with proxy
-- All API calls should handle loading and error states
-- Maintain backward compatibility with v1 API
-- Follow accessibility best practices (ARIA labels, keyboard navigation)
+- Production embeds the built assets into the server binary; dev runs separately and proxies to :8080.
+- Maintain backward compatibility with the v1 API where the UI still depends on it.


### PR DESCRIPTION
## Summary

Audited and rewrote the repo's `AGENTS.md` context files so they actually help coding agents instead of bloating their context, and extracted the heavyweight review guidance into dedicated reviewer personas under `.agents/personas/`. The Flue PR review agent reads `.agents/personas/`, so these personas are picked up automatically on future PRs.

## Changes

- **Rewrote `AGENTS.md`** (580 → ~150 lines): fixed stale versions (Go 1.26, Node 20), added a rules-router to the existing `ui/AGENTS.md` and `build/CLAUDE.md` instead of duplicating their content, compressed the directory tour into a real architectural map (gRPC-first, OSS/Pro boundary, storage backends), and added the CI-enforced constraints (golangci-lint, `go mod tidy` clean tree, shellcheck, prettier). Kept only verifiable project-specific rules.
- **Rewrote `ui/AGENTS.md`**: the previous file described a codebase that doesn't exist — fictional directory tree, wrong RTK Query slice location, fake `VITE_*` env vars, stale `tailwind.config.js` (the project is Tailwind v4, CSS-first), and `npm` scripts that aren't defined. Corrected against the actual source: `app/` (feature modules + co-located API slices) vs `components/` (shared), v2-first API base paths, hash router, `~/` path alias, `x-csrf-token` header, SSE (not WebSocket), and dark mode via the Redux `preferencesSlice`.
- **Added `.agents/personas/go-reviewer.md`** and **`react-reviewer.md`**: expanded review checklists (carrying the detailed ❌/✅ examples trimmed from `AGENTS.md`) plus a structured review output format.
- **Added `.agents/personas/README.md`**: documents the persona-vs-command distinction, mirroring `.agents/commands/README.md`.

## Backward Compatibility

Docs-only. The `CLAUDE.md` (root) and `ui/CLAUDE.md` symlinks pick up the rewrites automatically. `build/CLAUDE.md` is unchanged.

## Additional Notes

Companion change already merged in `flipt-io/agents`: the PR review agent now reads per-repo overrides from `.agents/` (was `.flue/`), so the new reviewer personas require no extra wiring here.