### PR TITLE
fix(ofrep): new SSE event stream endpoint and conditional request support

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -180,6 +180,7 @@ JsonPath: string
 			"X-Flipt-Accept-Server-Version",
 			"X-Flipt-Environment",
 			"X-Flipt-Namespace",
+			"If-None-Match",
 		]
 	}
 

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -751,7 +751,8 @@
             "X-CSRF-Token",
             "X-Flipt-Accept-Server-Version",
             "X-Flipt-Environment",
-            "X-Flipt-Namespace"
+            "X-Flipt-Namespace",
+            "If-None-Match"
           ]
         }
       }

--- a/internal/cmd/grpc.go
+++ b/internal/cmd/grpc.go
@@ -262,7 +262,7 @@ func NewGRPCServer(
 		return nil, fmt.Errorf("building environments server: %w", err)
 	}
 
-	clientevalsrv := serverclientevaluation.NewServer(logger, environmentStore)
+	clientevalsrv := serverclientevaluation.NewServer(logger, environmentStore, serverclientevaluation.WithSkipOFREPAuthn(cfg.Authentication.Exclude.OFREP))
 
 	var (
 		// authnOpts is a slice of options that will be passed to the authentication service.

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -19,6 +19,7 @@ import (
 	"go.flipt.io/flipt/internal/gateway"
 	"go.flipt.io/flipt/internal/info"
 	"go.flipt.io/flipt/internal/server/authn/method"
+	"go.flipt.io/flipt/internal/server/common"
 	ofrep_middleware "go.flipt.io/flipt/internal/server/evaluation/ofrep"
 	grpc_middleware "go.flipt.io/flipt/internal/server/middleware/grpc"
 	http_middleware "go.flipt.io/flipt/internal/server/middleware/http"
@@ -83,14 +84,17 @@ func NewHTTPServer(
 		evaluateAPI = gateway.NewGatewayServeMux(logger,
 			runtime.WithMetadata(grpc_middleware.ForwardFliptEnvironment))
 
-		clientEvaluationAPI = gateway.NewGatewayServeMux(logger,
+		clientEvaluationAPI = gateway.NewGatewayServeMux(
+			logger,
+			runtime.WithMetadata(grpc_middleware.ForwardOFREPStreamMarker),
 			runtime.WithMetadata(grpc_middleware.ForwardFliptEnvironment),
 			runtime.WithForwardResponseOption(http_middleware.HttpResponseModifier),
 		)
 
 		analyticsAPI = gateway.NewGatewayServeMux(logger, runtime.WithMetadata(grpc_middleware.ForwardFliptEnvironment))
 
-		ofrepAPI = gateway.NewGatewayServeMux(logger,
+		ofrepAPI = gateway.NewGatewayServeMux(
+			logger,
 			runtime.WithMetadata(grpc_middleware.ForwardFliptEnvironment),
 			runtime.WithMetadata(grpc_middleware.ForwardFliptNamespace),
 			runtime.WithForwardResponseOption(http_middleware.HttpResponseModifier),
@@ -190,6 +194,11 @@ func NewHTTPServer(
 
 		r.Mount("/api/v1", api)
 		r.Mount("/evaluate/v1", evaluateAPI)
+
+		// OFREP stream alias: must be registered before the /ofrep mount so the
+		// specific route takes precedence over the OFREP gateway catch-all.
+		r.Get("/ofrep/v1/_stream/{environmentKey}/{namespaceKey}/events", ofrepStreamHandler(clientEvaluationAPI))
+
 		r.Mount("/ofrep", ofrepAPI)
 		r.Mount("/internal/v1", clientEvaluationAPI) // for backwards compatibility
 
@@ -300,4 +309,36 @@ func removeTrailingSlash(h http.Handler) http.Handler {
 		r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")
 		h.ServeHTTP(w, r)
 	})
+}
+
+// ofrepStreamHandler returns an http.HandlerFunc that rewrites OFREP stream
+// requests to the existing client evaluation stream endpoint.
+//
+// Only SSE (text/event-stream) requests are accepted; all others receive 406.
+// An internal context marker is set so the downstream gateway metadata callback
+// can forward it as gRPC metadata, conditionally skipping authentication
+// when authentication.exclude.ofrep is enabled.
+func ofrepStreamHandler(next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Only accept SSE (text/event-stream) requests for the stream endpoint.
+		if !strings.HasPrefix(r.Header.Get("Accept"), "text/event-stream") {
+			http.Error(w, "text/event-stream is the only supported content type for this endpoint", http.StatusNotAcceptable)
+			return
+		}
+
+		// Set context marker to identify this as an OFREP stream alias request.
+		r = r.WithContext(common.WithOFREPStream(r.Context()))
+
+		// Override Accept to text/event-stream so grpc-gateway selects the
+		// eventSourceMarshaler instead of the wildcard JSON marshaler,
+		// preventing full snapshot proto responses.
+		r.Header.Set("Accept", "text/event-stream")
+
+		environmentKey := chi.URLParam(r, "environmentKey")
+		namespaceKey := chi.URLParam(r, "namespaceKey")
+
+		r.URL.Path = fmt.Sprintf("/client/v2/environments/%s/namespaces/%s/stream", environmentKey, namespaceKey)
+
+		next.ServeHTTP(w, r)
+	}
 }

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -47,6 +47,18 @@ type HTTPServer struct {
 	listenAndServe func() error
 }
 
+// newCORSHandler creates the CORS middleware handler from config.
+func newCORSHandler(cfg *config.Config) func(http.Handler) http.Handler {
+	return cors.New(cors.Options{
+		AllowedOrigins:   cfg.Cors.AllowedOrigins,
+		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
+		AllowedHeaders:   cfg.Cors.AllowedHeaders,
+		ExposedHeaders:   []string{"Link", "Etag"},
+		AllowCredentials: true,
+		MaxAge:           300,
+	}).Handler
+}
+
 // NewHTTPServer constructs and configures the HTTPServer instance.
 // The HTTPServer depends upon a running gRPC server instance which is why
 // it explicitly requires and established gRPC connection as an argument.
@@ -121,16 +133,7 @@ func NewHTTPServer(
 	}
 
 	if cfg.Cors.Enabled {
-		cors := cors.New(cors.Options{
-			AllowedOrigins:   cfg.Cors.AllowedOrigins,
-			AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodOptions},
-			AllowedHeaders:   cfg.Cors.AllowedHeaders,
-			ExposedHeaders:   []string{"Link"},
-			AllowCredentials: true,
-			MaxAge:           300,
-		})
-
-		r.Use(cors.Handler)
+		r.Use(newCORSHandler(cfg))
 		logger.Debug("CORS enabled", zap.Strings("allowed_origins", cfg.Cors.AllowedOrigins))
 	}
 

--- a/internal/cmd/http_test.go
+++ b/internal/cmd/http_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/config"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -59,6 +60,34 @@ func TestTrailingSlashMiddleware(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, res.StatusCode)
 	res.Body.Close()
+}
+
+func TestCORSExposedHeaders(t *testing.T) {
+	r := chi.NewRouter()
+	r.Use(newCORSHandler(&config.Config{
+		Cors: config.CorsConfig{
+			Enabled:        true,
+			AllowedOrigins: []string{"*"},
+			AllowedHeaders: []string{"*"},
+		},
+	}))
+	r.Get("/test", func(w http.ResponseWriter, r *http.Request) {})
+
+	s := httptest.NewServer(r)
+	t.Cleanup(s.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.URL+"/test", nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "http://localhost:5173")
+
+	res, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	exposed := res.Header.Get("Access-Control-Expose-Headers")
+	require.NotEmpty(t, exposed, "Access-Control-Expose-Headers must be present")
+	assert.Contains(t, exposed, "Etag", "Access-Control-Expose-Headers must include Etag for client-side conditional requests")
+	assert.Contains(t, exposed, "Link", "Access-Control-Expose-Headers must include Link")
 }
 
 func TestCrossOriginProtection(t *testing.T) {

--- a/internal/cmd/http_test.go
+++ b/internal/cmd/http_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/flipt/internal/config"
+	"go.flipt.io/flipt/internal/server/common"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -113,6 +114,49 @@ func TestCrossOriginProtection(t *testing.T) {
 			res := httptest.NewRecorder()
 			h.ServeHTTP(res, req)
 			assert.Equal(t, tt.expectedCode, res.Code)
+		})
+	}
+}
+
+func TestOFREPStreamAlias_AcceptsOnlySSE(t *testing.T) {
+	tests := []struct {
+		name         string
+		accept       string
+		expectedCode int
+	}{
+		{name: "no accept header", expectedCode: http.StatusNotAcceptable},
+		{name: "application/json", accept: "application/json", expectedCode: http.StatusNotAcceptable},
+		{name: "wildcard", accept: "*/*", expectedCode: http.StatusNotAcceptable},
+		{name: "compound", accept: "text/event-stream, */*", expectedCode: http.StatusOK},
+		{name: "exact sse", accept: "text/event-stream", expectedCode: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called bool
+			r := chi.NewRouter()
+			r.Get("/ofrep/v1/_stream/{environmentKey}/{namespaceKey}/events", ofrepStreamHandler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				called = true
+				assert.True(t, common.IsOFREPStream(r.Context()))
+				assert.Equal(t, "text/event-stream", r.Header.Get("Accept"))
+				assert.Equal(t, "/client/v2/environments/env/namespaces/ns/stream", r.URL.Path)
+			})))
+
+			s := httptest.NewServer(r)
+			t.Cleanup(s.Close)
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.URL+"/ofrep/v1/_stream/env/ns/events", nil)
+			require.NoError(t, err)
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+
+			res, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			res.Body.Close()
+
+			assert.Equal(t, tt.expectedCode, res.StatusCode)
+			assert.Equal(t, tt.expectedCode == http.StatusOK, called)
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,7 +131,7 @@ func Load(ctx context.Context, path string) (*Result, error) {
 		// tries to restore the original case of the keys in allowed_teams if they match any of the allowed_organizations.
 		if v.IsSet("authentication.methods.github.allowed_teams") && v.IsSet("authentication.methods.github.allowed_organizations") {
 			allowedTeams := v.GetStringMapStringSlice("authentication.methods.github.allowed_teams")
-			orgs := (v.GetStringSlice("authentication.methods.github.allowed_organizations"))
+			orgs := v.GetStringSlice("authentication.methods.github.allowed_organizations")
 			for org, teams := range allowedTeams {
 				if slices.Contains(orgs, org) {
 					continue
@@ -597,6 +597,7 @@ func Default() *Config {
 				"X-Flipt-Accept-Server-Version",
 				"X-Flipt-Environment",
 				"X-Flipt-Namespace",
+				"If-None-Match",
 			},
 		},
 

--- a/internal/config/cors.go
+++ b/internal/config/cors.go
@@ -26,6 +26,7 @@ func (c *CorsConfig) setDefaults(v *viper.Viper) error {
 		"X-Flipt-Accept-Server-Version",
 		common.HeaderFliptEnvironment,
 		common.HeaderFliptNamespace,
+		"If-None-Match",
 	})
 	return nil
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"go.flipt.io/flipt/internal/server/common"
 	"go.flipt.io/flipt/rpc/v2/evaluation"
 	"go.uber.org/zap"
 	"google.golang.org/genproto/googleapis/rpc/status"
@@ -58,6 +60,10 @@ func NewGatewayServeMux(logger *zap.Logger, opts ...runtime.ServeMuxOption) *run
 			runtime.WithIncomingHeaderMatcher(func(key string) (string, bool) {
 				if h := http.CanonicalHeaderKey(key); slices.Contains([]string{"Traceparent", "Tracestate", "Baggage"}, h) {
 					return h, true
+				}
+				// Prevent clients from spoofing the internal OFREP stream marker.
+				if isOFREPReservedHeader(key) {
+					return "", false
 				}
 				return runtime.DefaultHeaderMatcher(key)
 			}),
@@ -122,6 +128,24 @@ func (m *eventSourceMarshaler) marshalEventSourceMap(val map[string]any) ([]byte
 	}
 
 	return nil, fmt.Errorf("unsupported event-stream payload map: %T", val)
+}
+
+// isOFREPReservedHeader checks whether the given HTTP header key is reserved for
+// internal use and must not be forwarded as gRPC metadata from client requests.
+func isOFREPReservedHeader(key string) bool {
+	canonicalKey := http.CanonicalHeaderKey(key)
+	reservedCanonical := http.CanonicalHeaderKey(common.HeaderFliptOFREPStream)
+	if canonicalKey == reservedCanonical {
+		return true
+	}
+	// Also check the Grpc-Metadata-* prefixed form which DefaultHeaderMatcher
+	// would forward after stripping the prefix.
+	if trimmed, ok := strings.CutPrefix(key, "Grpc-Metadata-"); ok {
+		if http.CanonicalHeaderKey(trimmed) == reservedCanonical {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *eventSourceMarshaler) marshalStatus(errStatus *status.Status) ([]byte, error) {

--- a/internal/server/common/common.go
+++ b/internal/server/common/common.go
@@ -1,6 +1,25 @@
 package common
 
+import "context"
+
+// ContextKey is a type for context keys used across Flipt packages.
+type ContextKey string
+
 const (
-	HeaderFliptEnvironment = "X-Flipt-Environment"
-	HeaderFliptNamespace   = "X-Flipt-Namespace"
+	HeaderFliptEnvironment            = "X-Flipt-Environment"
+	HeaderFliptNamespace              = "X-Flipt-Namespace"
+	HeaderFliptOFREPStream            = "x-flipt-ofrep-stream"
+	ContextKeyOFREPStream  ContextKey = "ofrep-stream"
 )
+
+// WithOFREPStream sets the OFREP stream marker on the context.
+func WithOFREPStream(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ContextKeyOFREPStream, true)
+}
+
+// IsOFREPStream reports whether the context has the OFREP stream marker set.
+func IsOFREPStream(ctx context.Context) bool {
+	v := ctx.Value(ContextKeyOFREPStream)
+	ok, _ := v.(bool)
+	return ok
+}

--- a/internal/server/evaluation/client/server.go
+++ b/internal/server/evaluation/client/server.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"go.flipt.io/flipt/errors"
+	"go.flipt.io/flipt/internal/server/common"
 	"go.flipt.io/flipt/internal/server/environments"
 	"go.flipt.io/flipt/internal/server/evaluation"
 	"go.flipt.io/flipt/internal/server/metrics"
@@ -14,6 +15,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 // getEnvironmentFromContext retrieves the environment by key. If environment isn't found by key, it falls back to retrieving it from the context.
@@ -34,10 +36,24 @@ type Server struct {
 	envs   evaluation.EnvironmentStore
 
 	rpcevaluation.UnimplementedClientEvaluationServiceServer
+
+	skipOFREPAuthn bool
 }
 
-func NewServer(logger *zap.Logger, envs evaluation.EnvironmentStore) *Server {
-	return &Server{logger: logger, envs: envs}
+type Option func(*Server)
+
+func WithSkipOFREPAuthn(skip bool) Option {
+	return func(s *Server) {
+		s.skipOFREPAuthn = skip
+	}
+}
+
+func NewServer(logger *zap.Logger, envs evaluation.EnvironmentStore, opts ...Option) *Server {
+	s := &Server{logger: logger, envs: envs}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // RegisterGRPC registers the *Server onto the provided grpc Server.
@@ -175,5 +191,27 @@ func (s *Server) EvaluationSnapshotNamespaceStream(r *rpcevaluation.EvaluationNa
 }
 
 func (s *Server) SkipsAuthorization(ctx context.Context) bool {
+	return true
+}
+
+func (s *Server) SkipsAuthentication(ctx context.Context) bool {
+	if !s.skipOFREPAuthn {
+		return false
+	}
+
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+
+	if vals := md.Get(common.HeaderFliptOFREPStream); len(vals) == 0 || vals[0] != "true" {
+		return false
+	}
+
+	p, ok := peer.FromContext(ctx)
+	if !ok || p.Addr.Network() != "inproc" {
+		return false
+	}
+
 	return true
 }

--- a/internal/server/evaluation/client/server_test.go
+++ b/internal/server/evaluation/client/server_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 	"testing"
 
@@ -10,12 +11,14 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	errs "go.flipt.io/flipt/errors"
+	"go.flipt.io/flipt/internal/server/common"
 	"go.flipt.io/flipt/internal/server/environments"
 	"go.flipt.io/flipt/internal/server/evaluation"
 	rpcevaluation "go.flipt.io/flipt/rpc/v2/evaluation"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 )
 
 type mockStream struct {
@@ -43,6 +46,63 @@ func TestNewServerAndSkipsAuthorization(t *testing.T) {
 
 	assert.NotNil(t, s)
 	assert.True(t, s.SkipsAuthorization(t.Context()))
+}
+
+type testInprocAddr struct{}
+
+func (testInprocAddr) Network() string { return "inproc" }
+func (testInprocAddr) String() string  { return "0" }
+
+func TestServer_SkipsAuthentication(t *testing.T) {
+	tests := []struct {
+		name      string
+		skipOFREP bool
+		md        metadata.MD
+		peer      *peer.Peer
+		expected  bool
+	}{
+		{
+			name:      "ofrep exclusion disabled",
+			skipOFREP: false,
+			expected:  false,
+		},
+		{
+			name:      "no ofrep stream marker",
+			skipOFREP: true,
+			expected:  false,
+		},
+		{
+			name:      "marker present but not inproc peer",
+			skipOFREP: true,
+			md:        metadata.Pairs(common.HeaderFliptOFREPStream, "true"),
+			peer:      &peer.Peer{Addr: &net.TCPAddr{IP: net.IPv4(1, 2, 3, 4), Port: 9000}},
+			expected:  false,
+		},
+		{
+			name:      "marker present and inproc peer",
+			skipOFREP: true,
+			md:        metadata.Pairs(common.HeaderFliptOFREPStream, "true"),
+			peer:      &peer.Peer{Addr: testInprocAddr{}},
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zaptest.NewLogger(t)
+			s := NewServer(logger, nil, WithSkipOFREPAuthn(tt.skipOFREP))
+
+			ctx := t.Context()
+			if tt.md != nil {
+				ctx = metadata.NewIncomingContext(ctx, tt.md)
+			}
+			if tt.peer != nil {
+				ctx = peer.NewContext(ctx, tt.peer)
+			}
+
+			assert.Equal(t, tt.expected, s.SkipsAuthentication(ctx))
+		})
+	}
 }
 
 func TestServer_EvaluationSnapshotNamespace_Success(t *testing.T) {

--- a/internal/server/evaluation/ofrep_bridge.go
+++ b/internal/server/evaluation/ofrep_bridge.go
@@ -148,15 +148,10 @@ func (s *Server) OFREPFlagEvaluationBulk(ctx context.Context, r *ofrep.EvaluateB
 	}
 
 	var (
-		namespaceKey   = getNamespace(ctx)
-		flagKeys, ok   = r.Context["flags"]
-		keys           = strings.Split(flagKeys, ",")
-		snapshotDigest string
+		namespaceKey = getNamespace(ctx)
+		flagKeys, ok = r.Context["flags"]
+		keys         = strings.Split(flagKeys, ",")
 	)
-
-	if sn, err := env.EvaluationNamespaceSnapshot(ctx, namespaceKey); err == nil {
-		snapshotDigest = sn.GetDigest()
-	}
 
 	if !ok {
 		flags, err := store.ListFlags(ctx, storage.ListWithOptions(storage.NewNamespace(namespaceKey)))
@@ -195,7 +190,7 @@ func (s *Server) OFREPFlagEvaluationBulk(ctx context.Context, r *ofrep.EvaluateB
 		_, _ = hmac.WriteString(resp.Variant)
 	}
 
-	etag := fmt.Sprintf("%08x", hmac.Sum64())
+	etag := fmt.Sprintf("W/\"%08x\"", hmac.Sum64())
 	_ = grpc.SetHeader(ctx, metadata.Pairs("x-etag", etag))
 	err = nil
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
@@ -211,7 +206,7 @@ func (s *Server) OFREPFlagEvaluationBulk(ctx context.Context, r *ofrep.EvaluateB
 		EventStreams: []*ofrep.EventStream{{
 			Type: "sse",
 			Endpoint: &ofrep.EventStreamEndpoint{
-				RequestUri: fmt.Sprintf("/client/v2/environments/%s/namespaces/%s/stream?digest=%s", env.Key(), namespaceKey, snapshotDigest),
+				RequestUri: fmt.Sprintf("/client/v2/environments/%s/namespaces/%s/stream", env.Key(), namespaceKey),
 			},
 		}},
 	}, err

--- a/internal/server/evaluation/ofrep_bridge.go
+++ b/internal/server/evaluation/ofrep_bridge.go
@@ -206,7 +206,7 @@ func (s *Server) OFREPFlagEvaluationBulk(ctx context.Context, r *ofrep.EvaluateB
 		EventStreams: []*ofrep.EventStream{{
 			Type: "sse",
 			Endpoint: &ofrep.EventStreamEndpoint{
-				RequestUri: fmt.Sprintf("/client/v2/environments/%s/namespaces/%s/stream", env.Key(), namespaceKey),
+				RequestUri: fmt.Sprintf("/ofrep/v1/_stream/%s/%s/events", env.Key(), namespaceKey),
 			},
 		}},
 	}, err

--- a/internal/server/evaluation/ofrep_bridge_test.go
+++ b/internal/server/evaluation/ofrep_bridge_test.go
@@ -12,7 +12,6 @@ import (
 	"go.flipt.io/flipt/internal/storage"
 	"go.flipt.io/flipt/rpc/flipt/core"
 	"go.flipt.io/flipt/rpc/flipt/ofrep"
-	rpcevaluationv2 "go.flipt.io/flipt/rpc/v2/evaluation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/zap/zaptest"
@@ -377,7 +376,7 @@ func TestOFREPFlagEvaluationBulkWithEtag(t *testing.T) {
 			metadata: map[string]string{
 				"x-flipt-environment":       "test-environment",
 				"x-flipt-namespace":         "test-namespace",
-				"GrpcGateway-If-None-Match": "7e427de9ffaef7ba",
+				"GrpcGateway-If-None-Match": `W/"7e427de9ffaef7ba"`,
 			},
 			flags: []*core.Flag{{
 				Key:     "test-flag",
@@ -458,14 +457,11 @@ func TestOFREPFlagEvaluationBulkWithEtag(t *testing.T) {
 				store          = storage.NewMockReadOnlyStore(t)
 				logger         = zaptest.NewLogger(t)
 				s              = New(logger, envStore)
-				namespaceKey   = "test-namespace"
 			)
 
 			environment.On("Key").Return(environmentKey)
 			envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 			environment.On("EvaluationStore").Return(store, nil)
-			environment.EXPECT().EvaluationNamespaceSnapshot(mock.Anything, namespaceKey).Return(&rpcevaluationv2.EvaluationNamespaceSnapshot{Digest: "abcdefg"}, nil).Maybe()
-
 			for _, flag := range tt.flags {
 				if flag.Key == "" {
 					continue
@@ -526,8 +522,6 @@ func TestOFREPFlagEvaluationBulk(t *testing.T) {
 
 	envStore.On("GetFromContext", mock.Anything).Return(environment, nil)
 	environment.On("EvaluationStore").Return(store, nil)
-	environment.EXPECT().EvaluationNamespaceSnapshot(mock.Anything, namespaceKey).Return(&rpcevaluationv2.EvaluationNamespaceSnapshot{Digest: "abcdefg"}, nil).Maybe()
-
 	store.On("GetFlag", mock.Anything, mock.Anything).Return(flag, nil)
 
 	store.On("ListFlags", mock.Anything, mock.Anything).Return(storage.ResultSet[*core.Flag]{
@@ -586,6 +580,5 @@ func TestOFREPFlagEvaluationBulk(t *testing.T) {
 	stream := result.EventStreams[0]
 	assert.Equal(t, "sse", stream.Type)
 	assert.NotNil(t, stream.Endpoint)
-	assert.Equal(t, "/client/v2/environments/test-environment/namespaces/test-namespace/stream?digest=abcdefg", stream.Endpoint.GetRequestUri())
-	assert.Empty(t, stream.Endpoint.GetOrigin())
+	assert.Equal(t, "/client/v2/environments/test-environment/namespaces/test-namespace/stream", stream.Endpoint.GetRequestUri())
 }

--- a/internal/server/evaluation/ofrep_bridge_test.go
+++ b/internal/server/evaluation/ofrep_bridge_test.go
@@ -580,5 +580,5 @@ func TestOFREPFlagEvaluationBulk(t *testing.T) {
 	stream := result.EventStreams[0]
 	assert.Equal(t, "sse", stream.Type)
 	assert.NotNil(t, stream.Endpoint)
-	assert.Equal(t, "/client/v2/environments/test-environment/namespaces/test-namespace/stream", stream.Endpoint.GetRequestUri())
+	assert.Equal(t, "/ofrep/v1/_stream/test-environment/test-namespace/events", stream.Endpoint.GetRequestUri())
 }

--- a/internal/server/middleware/grpc/middleware.go
+++ b/internal/server/middleware/grpc/middleware.go
@@ -233,6 +233,18 @@ func forwardHeader(ctx context.Context, req *http.Request, headerKey string) met
 	return md
 }
 
+// ForwardOFREPStreamMarker is a grpc-gateway WithMetadata callback that
+// forwards the OFREP stream marker to gRPC metadata when the request context
+// carries the OFREP stream marker. Unlike an HTTP-header-based approach,
+// this cannot be spoofed by external clients because only ofrepStreamHandler
+// can set the context value.
+func ForwardOFREPStreamMarker(ctx context.Context, _ *http.Request) metadata.MD {
+	if common.IsOFREPStream(ctx) {
+		return metadata.Pairs(common.HeaderFliptOFREPStream, "true")
+	}
+	return nil
+}
+
 // ZapInterceptorLogger wraps a zap.Logger to conform to the grpclogging.Logger interface.
 // It translates grpclogging log levels to zap log levels and properly formats log fields.
 func ZapInterceptorLogger(l *zap.Logger) grpclogging.Logger {

--- a/rpc/flipt/ofrep/ofrep.pb.go
+++ b/rpc/flipt/ofrep/ofrep.pb.go
@@ -254,7 +254,7 @@ type EventStreamEndpoint struct {
 	// The path + query portion of the endpoint URL. Must start with `/`.
 	RequestUri string `protobuf:"bytes,1,opt,name=request_uri,json=requestUri,proto3" json:"request_uri,omitempty"`
 	// The scheme + host + optional port portion of the endpoint URL.
-	Origin        string `protobuf:"bytes,2,opt,name=origin,proto3" json:"origin,omitempty"`
+	Origin        *string `protobuf:"bytes,2,opt,name=origin,proto3,oneof" json:"origin,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -297,8 +297,8 @@ func (x *EventStreamEndpoint) GetRequestUri() string {
 }
 
 func (x *EventStreamEndpoint) GetOrigin() string {
-	if x != nil {
-		return x.Origin
+	if x != nil && x.Origin != nil {
+		return *x.Origin
 	}
 	return ""
 }
@@ -432,11 +432,12 @@ const file_ofrep_ofrep_proto_rawDesc = "" +
 	"\acontext\x18\x02 \x03(\v2-.flipt.ofrep.EvaluateBulkRequest.ContextEntryR\acontext\x1a:\n" +
 	"\fContextEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"X\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"h\n" +
 	"\x13EventStreamEndpoint\x12$\n" +
 	"\vrequest_uri\x18\x01 \x01(\tB\x03\xe0A\x02R\n" +
-	"requestUri\x12\x1b\n" +
-	"\x06origin\x18\x02 \x01(\tB\x03\xe0A\x01R\x06origin\"i\n" +
+	"requestUri\x12 \n" +
+	"\x06origin\x18\x02 \x01(\tB\x03\xe0A\x01H\x00R\x06origin\x88\x01\x01B\t\n" +
+	"\a_origin\"i\n" +
 	"\vEventStream\x12\x17\n" +
 	"\x04type\x18\x01 \x01(\tB\x03\xe0A\x05R\x04type\x12A\n" +
 	"\bendpoint\x18\x02 \x01(\v2 .flipt.ofrep.EventStreamEndpointB\x03\xe0A\x02R\bendpoint\"\x98\x01\n" +
@@ -504,6 +505,7 @@ func file_ofrep_ofrep_proto_init() {
 	if File_ofrep_ofrep_proto != nil {
 		return
 	}
+	file_ofrep_ofrep_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/rpc/flipt/ofrep/ofrep.proto
+++ b/rpc/flipt/ofrep/ofrep.proto
@@ -38,7 +38,7 @@ message EventStreamEndpoint {
   // The path + query portion of the endpoint URL. Must start with `/`.
   string request_uri = 1 [(google.api.field_behavior) = REQUIRED];
   // The scheme + host + optional port portion of the endpoint URL.
-  string origin = 2 [(google.api.field_behavior) = OPTIONAL];
+  optional string origin = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // A real-time change notification connection endpoint


### PR DESCRIPTION
- The origin field was marked as optional in grpc and it was always returned as an empty string, which breaks the ofrep-web JS client logic for constructing the streaming URL.
- The snapshotDigest was removed to align with current implementation details in the ofrep-web JS client. Removing it causes an extra re-evaluation fetch to the bulk endpoint on each (re)connect. Ideally, it should be avoided but I don't see a good solution at the moment.
- Include Etag in CORS exposed headers for cross-origin reads. The Access-Control-Expose-Headers response header only listed Link, preventing browser JS from reading the Etag header cross-origin. This broke conditional request caching via If-None-Match. Added Etag to the exposed headers list.
- Move SSE stream endpoint to /ofrep/v1/_stream/{env}/{ns}/events to support skip authentication for in-process OFREP stream requests


related #5669 61aa322bc
