### PR TITLE
fix(schema): move authorization.local.data to correct position in flipt.schema.json

### DIFF
--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -355,18 +355,18 @@
                   "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
                   "default": "5m"
                 }
-              },
-              "data": {
-                "type": ["object", "null"],
-                "additionalproperties": false,
-                "properties": {
-                  "path": { "type": "string" },
-                  "poll_interval": {
+              }
+            },
+            "data": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "path": { "type": "string" },
+                "poll_interval": {
                     "type": "string",
                     "pattern": "^([0-9]+(ns|us|µs|ms|s|m|h))+$",
                     "default": "5m"
                   }
-                }
               }
             }
           }


### PR DESCRIPTION
### Changes:

- Move the data property from inside the policy schema node to local.properties as a sibling of policy
- Fix the "additionalproperties" typo → "additionalProperties"

Closes issue #5963 