### PR TITLE
fix(streaming): deprecate name and description in evaluation snapshot

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -212,6 +212,7 @@ run = """
 set -euo pipefail
 echo " > Formatting..."
 golangci-lint fmt
+buf format --write
 """
 
 [tasks."go:lint"]

--- a/internal/storage/fs/snapshot.go
+++ b/internal/storage/fs/snapshot.go
@@ -287,10 +287,8 @@ func (s *Snapshot) addDoc(doc *ext.Document) error {
 				MatchType:   core.MatchType(matchType),
 			}
 			evalSnapSegment = &evaluation.EvaluationSegment{
-				Key:         s.Key,
-				Name:        s.Name,
-				Description: s.Description,
-				MatchType:   toEvaluationSegmentMatchType(core.MatchType(matchType)),
+				Key:       s.Key,
+				MatchType: toEvaluationSegmentMatchType(core.MatchType(matchType)),
 			}
 		)
 
@@ -330,13 +328,11 @@ func (s *Snapshot) addDoc(doc *ext.Document) error {
 			// evaluation snapshot
 
 			evalSnapFlag = &evaluation.EvaluationFlag{
-				Key:         f.Key,
-				Name:        f.Name,
-				Description: f.Description,
-				Enabled:     f.Enabled,
-				Type:        toEvaluationFlagType(f.Type),
-				CreatedAt:   s.now,
-				UpdatedAt:   s.now,
+				Key:       f.Key,
+				Enabled:   f.Enabled,
+				Type:      toEvaluationFlagType(f.Type),
+				CreatedAt: s.now,
+				UpdatedAt: s.now,
 			}
 		)
 

--- a/internal/storage/fs/snapshot_test.go
+++ b/internal/storage/fs/snapshot_test.go
@@ -680,8 +680,8 @@ func TestSnapshot_EvaluationNamespaceSnapshot(t *testing.T) {
 				Flags: []*evaluation.EvaluationFlag{
 					{
 						Key:         "flag_boolean_2",
-						Name:        "FLAG_BOOLEAN",
-						Description: "Boolean Flag Description",
+						Name:        "",
+						Description: "",
 						Enabled:     false,
 						Type:        evaluation.EvaluationFlagType_BOOLEAN_FLAG_TYPE,
 						Rollouts: []*evaluation.EvaluationRollout{
@@ -694,8 +694,8 @@ func TestSnapshot_EvaluationNamespaceSnapshot(t *testing.T) {
 										Segments: []*evaluation.EvaluationSegment{
 											{
 												Key:         "segment2",
-												Name:        "segment2",
-												Description: "description",
+												Name:        "",
+												Description: "",
 												MatchType:   evaluation.EvaluationSegmentMatchType_ANY_SEGMENT_MATCH_TYPE,
 												Constraints: []*evaluation.EvaluationConstraint{
 													{
@@ -730,8 +730,8 @@ func TestSnapshot_EvaluationNamespaceSnapshot(t *testing.T) {
 					},
 					{
 						Key:         "prod-flag-1",
-						Name:        "Prod Flag 1",
-						Description: "description",
+						Name:        "",
+						Description: "",
 						Enabled:     true,
 						Type:        evaluation.EvaluationFlagType_VARIANT_FLAG_TYPE,
 						DefaultVariant: &evaluation.EvaluationVariant{
@@ -743,8 +743,8 @@ func TestSnapshot_EvaluationNamespaceSnapshot(t *testing.T) {
 								Segments: []*evaluation.EvaluationSegment{
 									{
 										Key:         "segment2",
-										Name:        "segment2",
-										Description: "description",
+										Name:        "",
+										Description: "",
 										MatchType:   evaluation.EvaluationSegmentMatchType_ANY_SEGMENT_MATCH_TYPE,
 										Constraints: []*evaluation.EvaluationConstraint{
 											{

--- a/rpc/v2/evaluation/evaluationv2.pb.go
+++ b/rpc/v2/evaluation/evaluationv2.pb.go
@@ -549,9 +549,15 @@ func (x *EvaluationRolloutSegment) GetSegments() []*EvaluationSegment {
 }
 
 type EvaluationSegment struct {
-	state         protoimpl.MessageState     `protogen:"open.v1"`
-	Key           string                     `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	Name          string                     `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Key   string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// name will be empty to avoid exposing internal information.
+	//
+	// Deprecated: Marked as deprecated in evaluation/evaluationv2.proto.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// description will be empty to avoid exposing internal information.
+	//
+	// Deprecated: Marked as deprecated in evaluation/evaluationv2.proto.
 	Description   string                     `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	MatchType     EvaluationSegmentMatchType `protobuf:"varint,4,opt,name=match_type,json=matchType,proto3,enum=evaluation.EvaluationSegmentMatchType" json:"match_type,omitempty"`
 	CreatedAt     *timestamppb.Timestamp     `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
@@ -598,6 +604,7 @@ func (x *EvaluationSegment) GetKey() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in evaluation/evaluationv2.proto.
 func (x *EvaluationSegment) GetName() string {
 	if x != nil {
 		return x.Name
@@ -605,6 +612,7 @@ func (x *EvaluationSegment) GetName() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in evaluation/evaluationv2.proto.
 func (x *EvaluationSegment) GetDescription() string {
 	if x != nil {
 		return x.Description
@@ -701,9 +709,15 @@ func (x *EvaluationVariant) GetAttachment() string {
 }
 
 type EvaluationFlag struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	Key            string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
-	Name           string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Key   string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// name will be empty to avoid exposing internal information.
+	//
+	// Deprecated: Marked as deprecated in evaluation/evaluationv2.proto.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// description will be empty to avoid exposing internal information.
+	//
+	// Deprecated: Marked as deprecated in evaluation/evaluationv2.proto.
 	Description    string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	Enabled        bool                   `protobuf:"varint,4,opt,name=enabled,proto3" json:"enabled,omitempty"`
 	Type           EvaluationFlagType     `protobuf:"varint,5,opt,name=type,proto3,enum=evaluation.EvaluationFlagType" json:"type,omitempty"`
@@ -753,6 +767,7 @@ func (x *EvaluationFlag) GetKey() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in evaluation/evaluationv2.proto.
 func (x *EvaluationFlag) GetName() string {
 	if x != nil {
 		return x.Name
@@ -760,6 +775,7 @@ func (x *EvaluationFlag) GetName() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in evaluation/evaluationv2.proto.
 func (x *EvaluationFlag) GetDescription() string {
 	if x != nil {
 		return x.Description
@@ -1260,11 +1276,11 @@ const file_evaluation_evaluationv2_proto_rawDesc = "" +
 	"\x18EvaluationRolloutSegment\x12\x14\n" +
 	"\x05value\x18\x01 \x01(\bR\x05value\x12P\n" +
 	"\x10segment_operator\x18\x02 \x01(\x0e2%.evaluation.EvaluationSegmentOperatorR\x0fsegmentOperator\x129\n" +
-	"\bsegments\x18\x03 \x03(\v2\x1d.evaluation.EvaluationSegmentR\bsegments\"\xdc\x02\n" +
+	"\bsegments\x18\x03 \x03(\v2\x1d.evaluation.EvaluationSegmentR\bsegments\"\xe4\x02\n" +
 	"\x11EvaluationSegment\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
-	"\vdescription\x18\x03 \x01(\tR\vdescription\x12E\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x16\n" +
+	"\x04name\x18\x02 \x01(\tB\x02\x18\x01R\x04name\x12$\n" +
+	"\vdescription\x18\x03 \x01(\tB\x02\x18\x01R\vdescription\x12E\n" +
 	"\n" +
 	"match_type\x18\x04 \x01(\x0e2&.evaluation.EvaluationSegmentMatchTypeR\tmatchType\x129\n" +
 	"\n" +
@@ -1277,11 +1293,11 @@ const file_evaluation_evaluationv2_proto_rawDesc = "" +
 	"\x03key\x18\x02 \x01(\tR\x03key\x12\x1e\n" +
 	"\n" +
 	"attachment\x18\x03 \x01(\tR\n" +
-	"attachment\"\xea\x03\n" +
+	"attachment\"\xf2\x03\n" +
 	"\x0eEvaluationFlag\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
-	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x18\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x16\n" +
+	"\x04name\x18\x02 \x01(\tB\x02\x18\x01R\x04name\x12$\n" +
+	"\vdescription\x18\x03 \x01(\tB\x02\x18\x01R\vdescription\x12\x18\n" +
 	"\aenabled\x18\x04 \x01(\bR\aenabled\x122\n" +
 	"\x04type\x18\x05 \x01(\x0e2\x1e.evaluation.EvaluationFlagTypeR\x04type\x129\n" +
 	"\n" +

--- a/rpc/v2/evaluation/evaluationv2.proto
+++ b/rpc/v2/evaluation/evaluationv2.proto
@@ -55,8 +55,10 @@ enum EvaluationSegmentMatchType {
 
 message EvaluationSegment {
   string key = 1;
-  string name = 2;
-  string description = 3;
+  // name will be empty to avoid exposing internal information.
+  string name = 2 [deprecated = true];
+  // description will be empty to avoid exposing internal information.
+  string description = 3 [deprecated = true];
   EvaluationSegmentMatchType match_type = 4;
   google.protobuf.Timestamp created_at = 5;
   google.protobuf.Timestamp updated_at = 6;
@@ -76,8 +78,10 @@ enum EvaluationFlagType {
 
 message EvaluationFlag {
   string key = 1;
-  string name = 2;
-  string description = 3;
+  // name will be empty to avoid exposing internal information.
+  string name = 2 [deprecated = true];
+  // description will be empty to avoid exposing internal information.
+  string description = 3 [deprecated = true];
   bool enabled = 4;
   EvaluationFlagType type = 5;
   google.protobuf.Timestamp created_at = 6;

--- a/rpc/v2/evaluation/openapi.yaml
+++ b/rpc/v2/evaluation/openapi.yaml
@@ -129,8 +129,10 @@ components:
                     type: string
                 name:
                     type: string
+                    description: name will be empty to avoid exposing internal information.
                 description:
                     type: string
+                    description: description will be empty to avoid exposing internal information.
                 enabled:
                     type: boolean
                 type:
@@ -240,8 +242,10 @@ components:
                     type: string
                 name:
                     type: string
+                    description: name will be empty to avoid exposing internal information.
                 description:
                     type: string
+                    description: description will be empty to avoid exposing internal information.
                 matchType:
                     enum:
                         - ALL_SEGMENT_MATCH_TYPE


### PR DESCRIPTION
Stop populating name and description fields on EvaluationFlag and EvaluationSegment in evaluation snapshot responses. These fields are marked deprecated in the protobuf schema and are no longer set by the
snapshot builder, reducing the surface of internal information exposed to evaluation clients.

Backward compatible: deprecated fields remain in the wire format but will always be empty strings.

closes: #5989 
