### PR TITLE
fix(config): disable profiling diagnostics by default

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -186,7 +186,7 @@ JsonPath: string
 
 	#diagnostics: {
 		profiling?: {
-			enabled?: bool | *true
+			enabled?: bool | *false
 		}
 	}
 

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -768,7 +768,7 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": true
+              "default": false
             }
           }
         }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -603,7 +603,7 @@ func Default() *Config {
 
 		Diagnostics: DiagnosticConfig{
 			Profiling: ProfilingDiagnosticConfig{
-				Enabled: true,
+				Enabled: false,
 			},
 		},
 

--- a/internal/config/diagnostics.go
+++ b/internal/config/diagnostics.go
@@ -13,6 +13,6 @@ type ProfilingDiagnosticConfig struct {
 }
 
 func (c *DiagnosticConfig) setDefaults(v *viper.Viper) error {
-	v.SetDefault("diagnostics.profiling.enabled", true)
+	v.SetDefault("diagnostics.profiling.enabled", false)
 	return nil
 }

--- a/internal/config/testdata/marshal/yaml/default.yml
+++ b/internal/config/testdata/marshal/yaml/default.yml
@@ -31,10 +31,6 @@ metrics:
   enabled: true
   exporter: prometheus
 
-diagnostics:
-  profiling:
-    enabled: true
-
 meta:
   check_for_updates: true
   telemetry_enabled: true


### PR DESCRIPTION
The profiling diagnostics feature exposes pprof endpoints on the HTTP
server. Having it enabled by default was a security concern since it
leaks runtime internals. Change the default to false so operators
must consciously opt in.
