### PR TITLE
fix(evaluation): refactor number constraint evaluation to use nil checks consistently

### DIFF
--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -674,13 +674,13 @@ func matchesString(c storage.EvaluationConstraint, v string) (bool, error) {
 		return strings.HasSuffix(strings.TrimSpace(v), value), nil
 	case flipt.OpIsOneOf:
 		if c.StringSet == nil {
-			return false, fmt.Errorf("constraint %q not prepared for evaluation", c.Property)
+			return false, errs.ErrInvalidf("constraint %q not prepared for evaluation", c.Property)
 		}
 		_, ok := c.StringSet[v]
 		return ok, nil
 	case flipt.OpIsNotOneOf:
 		if c.StringSet == nil {
-			return false, fmt.Errorf("constraint %q not prepared for evaluation", c.Property)
+			return false, errs.ErrInvalidf("constraint %q not prepared for evaluation", c.Property)
 		}
 		_, ok := c.StringSet[v]
 		return !ok, nil
@@ -714,19 +714,19 @@ func matchesNumber(c storage.EvaluationConstraint, v string) (bool, error) {
 	switch c.Operator {
 	case flipt.OpIsOneOf:
 		if c.NumberSet == nil {
-			return false, fmt.Errorf("constraint %q not prepared for evaluation", c.Property)
+			return false, errs.ErrInvalidf("constraint %q not prepared for evaluation", c.Property)
 		}
 		_, ok := c.NumberSet[n]
 		return ok, nil
 	case flipt.OpIsNotOneOf:
 		if c.NumberSet == nil {
-			return false, fmt.Errorf("constraint %q not prepared for evaluation", c.Property)
+			return false, errs.ErrInvalidf("constraint %q not prepared for evaluation", c.Property)
 		}
 		_, ok := c.NumberSet[n]
 		return !ok, nil
 	case flipt.OpEQ, flipt.OpNEQ, flipt.OpLT, flipt.OpLTE, flipt.OpGT, flipt.OpGTE:
 		if c.Number == nil {
-			return false, fmt.Errorf("constraint %q not prepared for evaluation", c.Property)
+			return false, errs.ErrInvalidf("constraint %q not prepared for evaluation", c.Property)
 		}
 		value := *c.Number
 		switch c.Operator {

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -724,27 +724,25 @@ func matchesNumber(c storage.EvaluationConstraint, v string) (bool, error) {
 		}
 		_, ok := c.NumberSet[n]
 		return !ok, nil
-	}
-
-	if c.Value == "" {
-		return false, errs.ErrInvalidf("parsing number from %q", c.Value)
-	}
-
-	value := c.Number
-
-	switch c.Operator {
-	case flipt.OpEQ:
-		return value == n, nil
-	case flipt.OpNEQ:
-		return value != n, nil
-	case flipt.OpLT:
-		return n < value, nil
-	case flipt.OpLTE:
-		return n <= value, nil
-	case flipt.OpGT:
-		return n > value, nil
-	case flipt.OpGTE:
-		return n >= value, nil
+	case flipt.OpEQ, flipt.OpNEQ, flipt.OpLT, flipt.OpLTE, flipt.OpGT, flipt.OpGTE:
+		if c.Number == nil {
+			return false, fmt.Errorf("constraint %q not prepared for evaluation", c.Property)
+		}
+		value := *c.Number
+		switch c.Operator {
+		case flipt.OpEQ:
+			return value == n, nil
+		case flipt.OpNEQ:
+			return value != n, nil
+		case flipt.OpLT:
+			return n < value, nil
+		case flipt.OpLTE:
+			return n <= value, nil
+		case flipt.OpGT:
+			return n > value, nil
+		case flipt.OpGTE:
+			return n >= value, nil
+		}
 	}
 
 	return false, nil

--- a/internal/server/evaluation/evaluation_test.go
+++ b/internal/server/evaluation/evaluation_test.go
@@ -1728,15 +1728,41 @@ func Test_matchesString_ErrorsWithoutPrepare(t *testing.T) {
 }
 
 func Test_matchesNumber_ErrorsWithoutPrepare(t *testing.T) {
-	c := storage.EvaluationConstraint{
-		Property: "count",
-		Operator: "isnotoneof",
-		Type:     core.ComparisonType_NUMBER_COMPARISON_TYPE,
-		Value:    `[1,2,3]`,
-	}
-	match, err := matchesNumber(c, "1")
-	require.ErrorContains(t, err, `constraint "count" not prepared for evaluation`)
-	assert.False(t, match)
+	t.Run("is not one of", func(t *testing.T) {
+		c := storage.EvaluationConstraint{
+			Property: "count",
+			Operator: "isnotoneof",
+			Type:     core.ComparisonType_NUMBER_COMPARISON_TYPE,
+			Value:    `[1,2,3]`,
+		}
+		match, err := matchesNumber(c, "1")
+		require.ErrorContains(t, err, `constraint "count" not prepared for evaluation`)
+		assert.False(t, match)
+	})
+
+	t.Run("scalar eq", func(t *testing.T) {
+		c := storage.EvaluationConstraint{
+			Property: "count",
+			Operator: "eq",
+			Type:     core.ComparisonType_NUMBER_COMPARISON_TYPE,
+			Value:    "5",
+		}
+		match, err := matchesNumber(c, "1")
+		require.ErrorContains(t, err, `constraint "count" not prepared for evaluation`)
+		assert.False(t, match)
+	})
+
+	t.Run("scalar lt", func(t *testing.T) {
+		c := storage.EvaluationConstraint{
+			Property: "count",
+			Operator: "lt",
+			Type:     core.ComparisonType_NUMBER_COMPARISON_TYPE,
+			Value:    "5",
+		}
+		match, err := matchesNumber(c, "1")
+		require.ErrorContains(t, err, `constraint "count" not prepared for evaluation`)
+		assert.False(t, match)
+	})
 }
 
 func Test_matchesNumberWithPreparedSets(t *testing.T) {

--- a/internal/server/evaluation/evaluation_test.go
+++ b/internal/server/evaluation/evaluation_test.go
@@ -1723,7 +1723,9 @@ func Test_matchesString_ErrorsWithoutPrepare(t *testing.T) {
 		Value:    `["a","b"]`,
 	}
 	match, err := matchesString(c, "a")
-	require.ErrorContains(t, err, `constraint "tenant" not prepared for evaluation`)
+	require.Error(t, err)
+	var ierr errs.ErrInvalid
+	require.ErrorAs(t, err, &ierr)
 	assert.False(t, match)
 }
 
@@ -1736,7 +1738,9 @@ func Test_matchesNumber_ErrorsWithoutPrepare(t *testing.T) {
 			Value:    `[1,2,3]`,
 		}
 		match, err := matchesNumber(c, "1")
-		require.ErrorContains(t, err, `constraint "count" not prepared for evaluation`)
+		require.Error(t, err)
+		var ierr errs.ErrInvalid
+		require.ErrorAs(t, err, &ierr)
 		assert.False(t, match)
 	})
 
@@ -1748,7 +1752,9 @@ func Test_matchesNumber_ErrorsWithoutPrepare(t *testing.T) {
 			Value:    "5",
 		}
 		match, err := matchesNumber(c, "1")
-		require.ErrorContains(t, err, `constraint "count" not prepared for evaluation`)
+		require.Error(t, err)
+		var ierr errs.ErrInvalid
+		require.ErrorAs(t, err, &ierr)
 		assert.False(t, match)
 	})
 
@@ -1760,7 +1766,9 @@ func Test_matchesNumber_ErrorsWithoutPrepare(t *testing.T) {
 			Value:    "5",
 		}
 		match, err := matchesNumber(c, "1")
-		require.ErrorContains(t, err, `constraint "count" not prepared for evaluation`)
+		require.Error(t, err)
+		var ierr errs.ErrInvalid
+		require.ErrorAs(t, err, &ierr)
 		assert.False(t, match)
 	})
 }

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -88,7 +88,7 @@ type EvaluationConstraint struct {
 	// Pre-parsed fields populated by PrepareForEvaluation, excluded from JSON serialization.
 	StringSet map[string]struct{}  `json:"-"` // populated for string/entity-id isoneof/isnotoneof constraints; used by matchesStringSet.
 	NumberSet map[float64]struct{} `json:"-"` // populated for number isoneof/isnotoneof constraints; used by matchesNumberSet.
-	Number    float64              `json:"-"` // populated for scalar number comparisons (eq, neq, lt, lte, gt, gte); used by matchesNumber.
+	Number    *float64             `json:"-"` // populated for scalar number comparisons (eq, neq, lt, lte, gt, gte); used by matchesNumber.
 	Datetime  time.Time            `json:"-"` // populated for scalar datetime comparisons (eq, neq, lt, lte, gt, gte); used by matchesDatetime.
 }
 
@@ -123,7 +123,7 @@ func (c *EvaluationConstraint) PrepareForEvaluation() error {
 			if err != nil {
 				return fmt.Errorf("constraint %q: parsing number: %w", c.Property, err)
 			}
-			c.Number = n
+			c.Number = &n
 		case c.Type == core.ComparisonType_DATETIME_COMPARISON_TYPE && c.Value != "":
 			d, err := parseDatetime(c.Value)
 			if err != nil {


### PR DESCRIPTION
- change Number field to *float64 to allow nil values
- move nil check into main operator switch for scalar operators
- add test coverage for scalar operators using sub-tests
- improve consistency with string constraint evaluation pattern

some cleanup for #6017 
