### PR TITLE
chore(deps): upgrade build tooling to Node 24

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.26"
-node = "20"
+node = "24"
 golangci-lint = "2.12.2"
 buf = "1.70.0"
 dagger = "0.21.0"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Flipt v2 is a Git-native feature management platform (Go server + React UI) in a
 
 ## Tooling
 
-Tool versions are pinned in `.mise.toml` (**Go 1.26**, **Node 20**). Install [mise](https://mise.jdx.dev/), then:
+Tool versions are pinned in `.mise.toml` (**Go 1.26**, **Node 24**). Install [mise](https://mise.jdx.dev/), then:
 
 ```bash
 mise install        # install pinned Go/Node

--- a/build/internal/ui.go
+++ b/build/internal/ui.go
@@ -16,13 +16,13 @@ func UI(ctx context.Context, client *dagger.Client, source *dagger.Directory, re
 		nodeBase = client.Container().From(nodeBaseRef)
 		if _, err := nodeBase.Sync(ctx); err != nil {
 			// Build fresh Node.js base and cache it
-			nodeBase = client.Container().From("node:22-bullseye-slim")
+			nodeBase = client.Container().From("node:24-bullseye-slim")
 			// Cache this Node.js base layer
 			nodeBase.Publish(ctx, nodeBaseRef)
 		}
 	} else {
 		// No cache - use regular build
-		nodeBase = client.Container().From("node:22-bullseye-slim")
+		nodeBase = client.Container().From("node:24-bullseye-slim")
 	}
 
 	// Use cache volume for dependencies (more reliable than registry caching for npm)

--- a/build/testing/ui.go
+++ b/build/testing/ui.go
@@ -91,7 +91,7 @@ func UI(ctx context.Context, client *dagger.Client, base, flipt *dagger.Containe
 func buildUI(ctx context.Context, client *dagger.Client, flipt *dagger.Container, source *dagger.Directory) (_ *dagger.Container, err error) {
 	cache := client.CacheVolume("node-modules-cache")
 
-	ui, err := client.Container().From("node:22-bullseye-slim").
+	ui, err := client.Container().From("node:24-bullseye-slim").
 		// initially mount only the package json
 		WithMountedDirectory("/src", client.Directory().
 			WithFile("package.json", source.File("package.json")).

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -8,7 +8,7 @@ React 19 · TypeScript · Redux Toolkit + RTK Query · React Router v7 (hash rou
 
 ## Commands
 
-Node 20 (pinned in root `.mise.toml`). From the repo root:
+Node 24 (pinned in root `.mise.toml`). From the repo root:
 
 ```bash
 mise run ui:dev    # dev server on :5173, proxies API to backend :8080

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:24-alpine
 
 WORKDIR /ui
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -58,7 +58,7 @@
         "@tailwindcss/vite": "^4.3.1",
         "@trivago/prettier-plugin-sort-imports": "^5.2.2",
         "@types/jest": "^29.5.14",
-        "@types/node": "^20.19.0",
+        "@types/node": "^24.13.2",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@types/react-redux": "^7.1.34",
@@ -7220,13 +7220,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -15826,9 +15826,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -64,7 +64,7 @@
     "@tailwindcss/forms": "^0.5.11",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
     "@types/jest": "^29.5.14",
-    "@types/node": "^20.19.0",
+    "@types/node": "^24.13.2",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@types/react-redux": "^7.1.34",


### PR DESCRIPTION
## Why

Flipt v2 had Node version drift across its build tooling: local dev + CI lint/test jobs ran **Node 20** (via the `.mise.toml` pin), while release and integration builds ran **Node 22** (Dagger container images), and `@types/node` was still `^20`. Node 20 is now past EOL. This PR converges everything on **Node 24** (current Active LTS, supported to April 2028).

Node here is **build-time only** — production ships a single Go binary with the UI bundled as static assets, so there is no Node runtime to upgrade. This is purely build-tooling alignment.

## Changes

- `.mise.toml`: `node = "20"` → `node = "24"` (drives local dev + CI lint/test via mise)
- `ui/Dockerfile`: `node:22-alpine` → `node:24-alpine`
- `build/internal/ui.go`: `node:22-bullseye-slim` → `node:24-bullseye-slim` (release build, both refs)
- `build/testing/ui.go`: `node:22-bullseye-slim` → `node:24-bullseye-slim` (integration build)
- `ui/package.json`: `@types/node` `^20.19.0` → `^24.13.2` (lockfile regenerated — diff limited to `@types/node` + transitive `undici-types`)
- `AGENTS.md` / `ui/AGENTS.md`: doc prose updated to Node 24

## Verification

Local (Node 24.17.0):
- `npm ci` · `npm run lint` · `npm run test` (26/26) · `npm run build` (tsc clean — no type errors from the `@types/node` major bump)
- `mise run build`: produced `bin/flipt` with bundled UI assets; `go mod tidy` left a clean tree

Dagger on `node:24-bullseye-slim`:
- `dagger call test --source=. ui` (integration UI build) ✔
- `dagger call build --source=.` (release build) ✔