### PR TITLE
ci: add issue health workflow

### DIFF
--- a/.agents/issue-health/prompts/flipt-issue-health.md
+++ b/.agents/issue-health/prompts/flipt-issue-health.md
@@ -1,0 +1,32 @@
+# Flipt Issue Health
+
+Flipt is a Git-native feature management platform (Go server + React UI).
+Analyze newly opened issues for actionability and routing, not code review.
+
+## Versions
+
+Flipt v2 is the current focus and lives on the `v2` (default) branch; v1 is in
+maintenance on `main`. Apply `v2` or `v1` when the issue clearly concerns one
+version (e.g. mentions Git-native environments, v2 config, or a specific
+version string); default to `v2` when unstated. Point reporters at
+<https://docs.flipt.io>, preferring v2 docs.
+
+## Routing
+
+If `targetRepoLabels` contains a matching label, suggest it:
+
+- `bug` for defect reports. Ask for missing reproduction steps, Flipt version,
+  and deployment/storage backend, and suggest `needs more info` when a bug
+  report lacks them.
+- `enhancement` for feature requests, and `proposal` for open-ended ideas or
+  design discussions.
+- `ui` for the React UI, `go` for the Go server/API, and `dx` for developer
+  experience or tooling.
+- `needs docs` when the request implies documentation updates.
+
+Do not suggest `good first issue` or `help wanted` — maintainers triage those.
+
+## Support
+
+Direct usage questions and general help to the Discord community at
+<https://flipt.io/discord> rather than the issue tracker.

--- a/.github/workflows/issue-health.yml
+++ b/.github/workflows/issue-health.yml
@@ -1,0 +1,41 @@
+name: Issue Health Check
+
+# AI health check for newly opened issues.
+#
+# The central issue-health action fetches the issue, asks the model for structured
+# actionability data, renders a comment, and applies only labels that already
+# exist in this repository. It does not create labels, close issues, assign
+# maintainers, or edit issue bodies.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-health-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  issue-health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: flipt-io/agents/actions/issue-health@main # pin to a tag/SHA to freeze the checker
+        env:
+          # pi-ai's cloudflare-workers-ai provider reads these directly from
+          # process.env — passed through the composite action's inherited env.
+          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          # Isolated from .agents/pr-review consumers (personas/commands) so the
+          # two fleet agents don't read each other's config.
+          local-config-dir: .agents/issue-health
+          # Kimi K2.6 on Cloudflare Workers AI — matches the PR reviewer setup.
+          model: cloudflare-workers-ai/@cf/moonshotai/kimi-k2.6


### PR DESCRIPTION
## Summary
- Add an Issue Health Check workflow for newly opened issues, mirroring [flipt-client-sdks#1816](https://github.com/flipt-io/flipt-client-sdks/pull/1816).
- Use the central `flipt-io/agents/actions/issue-health@main` action with the same Cloudflare Workers AI / Kimi K2.6 provider setup as our PR reviewer.
- Add issue-health-specific guidance (`.agents/issue-health/prompts/flipt-issue-health.md`) for v1/v2 routing, area labels, and Discord support.

## Notes
- The action only comments and applies labels that **already exist** in this repo (`label-mode: existing-only`). It does not create labels, close issues, assign maintainers, or edit issue bodies.
- Config is isolated under `.agents/issue-health` so it stays separate from the `.agents/personas` and `.agents/commands` consumed by PR review and Codex — `pr-review.yml` is left untouched.
- Reuses the existing `CLOUDFLARE_API_KEY` / `CLOUDFLARE_ACCOUNT_ID` repo secrets already wired up for PR review.