### PR TITLE
ci: pin goreleaser previous tag to semver predecessor

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,17 @@ jobs:
       - name: Prep Build
         run: mise run prep
 
+      # Nightly builds run from the v2 branch rather than a release tag, so use the
+      # latest v2 semver tag as the changelog baseline instead of letting goreleaser
+      # infer it from git ancestry. This matches the release workflow safety net for
+      # orphaned release tags.
+      - name: Determine previous release tag
+        id: prev_tag
+        run: |
+          prev=$(git tag -l 'v2.*' --sort=-v:refname | head -n 1)
+          echo "Previous tag: ${prev:-<none>}"
+          echo "previous_tag=${prev}" >> "$GITHUB_OUTPUT"
+
       - name: GoReleaser (Nightly) Build
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -51,6 +62,7 @@ jobs:
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_PREVIOUS_TAG: ${{ steps.prev_tag.outputs.previous_tag }}
           ANALYTICS_WRITE_KEY: ${{ secrets.ANALYTICS_WRITE_KEY }}
           ANALYTICS_WRITE_ENDPOINT: ${{ secrets.ANALYTICS_WRITE_ENDPOINT }}
           QUILL_SIGN_P12: ${{ secrets.QUILL_SIGN_P12 }}
@@ -106,6 +118,17 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
+      # Nightly releases run from the v2 branch rather than a release tag, so use the
+      # latest v2 semver tag as the changelog baseline instead of letting goreleaser
+      # infer it from git ancestry. This matches the release workflow safety net for
+      # orphaned release tags.
+      - name: Determine previous release tag
+        id: prev_tag
+        run: |
+          prev=$(git tag -l 'v2.*' --sort=-v:refname | head -n 1)
+          echo "Previous tag: ${prev:-<none>}"
+          echo "previous_tag=${prev}" >> "$GITHUB_OUTPUT"
+
       - name: GoReleaser (Nightly) Release
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -115,3 +138,4 @@ jobs:
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_PREVIOUS_TAG: ${{ steps.prev_tag.outputs.previous_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,22 @@ jobs:
           private-key: ${{ secrets.FLIPT_RELEASE_BOT_APP_PEM }}
           owner: ${{ github.repository_owner }}
 
+      # Determine the previous release tag by semver order rather than letting
+      # goreleaser infer it from git ancestry. Release PRs are squash-merged into
+      # v2, which can leave annotated tags pointing at orphaned commits that are not
+      # ancestors of the current tag. When that happens goreleaser's `git describe`
+      # walk skips the orphaned tags and falls back to a much older tag, producing a
+      # changelog that spans several releases. Pinning GORELEASER_PREVIOUS_TAG to the
+      # immediate semver predecessor keeps the changelog scoped to a single release.
+      - name: Determine previous release tag
+        id: prev_tag
+        run: |
+          prev=$(git tag -l 'v2.*' --sort=-v:refname \
+            | awk -v c="${GITHUB_REF_NAME}" 'found { print; exit } $0 == c { found = 1 }')
+          echo "Current tag:  ${GITHUB_REF_NAME}"
+          echo "Previous tag: ${prev:-<none>}"
+          echo "previous_tag=${prev}" >> "$GITHUB_OUTPUT"
+
       - name: GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -131,6 +147,7 @@ jobs:
         env:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GORELEASER_PREVIOUS_TAG: ${{ steps.prev_tag.outputs.previous_tag }}
           DISCORD_WEBHOOK_ID: ${{ secrets.DISCORD_WEBHOOK_ID }}
           DISCORD_WEBHOOK_TOKEN: ${{ secrets.DISCORD_WEBHOOK_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Why

The [v2.10.0 release notes](https://github.com/flipt-io/flipt/releases/tag/v2.10.0) contained commits from **three releases** (252 commits) instead of just the new ones (88).

### Root cause

Release PRs (`release/vX.Y.Z`) are **squash-merged** into `v2`, which rewrites the release commit into a new SHA on the branch (e.g. `chore: release v2.9.0 (#5770)`). The annotated tags `v2.8.0` and `v2.9.0`, however, point at the **original release-branch commits**, which the squash leaves **orphaned** — they are not ancestors of `v2`.

goreleaser determines the changelog's previous tag with `git describe --tags --abbrev=0 <tag>^`, which only considers tags reachable from the current commit. With `v2.8.0`/`v2.9.0` orphaned, it walked back to the last reachable tag — **`v2.7.0`** — and emitted a changelog spanning `v2.7.0..v2.10.0`.

(The v2.10.0 release notes themselves have since been corrected.)

## What this does

Adds a step that computes the previous release tag by **semver order** (`git tag --sort=-v:refname`, immediate predecessor) and passes it to goreleaser via `GORELEASER_PREVIOUS_TAG`. This keeps the changelog scoped to a single release even if a tag is orphaned by a squash-merge.

- `v2.10.0` → `v2.9.0`, `v2.9.0` → `v2.8.0`, … (verified against existing tags)
- First release → empty, so goreleaser falls back to its default behavior.

## Follow-ups (not in this PR)

This is the robust safety net. Worth considering separately:
- Ensure release tags are created on `origin/v2` HEAD after merge (or stop squash-merging release PRs) so tags stay reachable.
- A pre-release guard that fails if a tag isn't an ancestor of `origin/v2`.