### PR TITLE
docs(release): tag the squashed merge commit and verify reachability

### DIFF
--- a/.agents/commands/release.md
+++ b/.agents/commands/release.md
@@ -63,11 +63,31 @@ git commit -s -m "chore: release v<version>"
 - Tell the user to review and merge the PR.
 - Stop here and wait until the user confirms the PR has been merged.
 
-### 6. Create the annotated tag
+### 6. Create the annotated tag on the merged commit
 
-- Switch back to `v2`.
-- Pull the latest changes.
-- Create the annotated tag:
+The release PR is **squash-merged**, so the commit on `origin/v2` is a brand new
+commit (e.g. `chore: release v<version> (#NNNN)`) — not the commit from your local
+`release/v<version>` branch. The tag MUST point at the squashed commit on
+`origin/v2`. Tagging the local release-branch commit instead leaves the tag
+orphaned (not an ancestor of `v2`), which breaks goreleaser's changelog on the
+*next* release.
+
+- Sync your local `v2` to exactly match the remote merged commit:
+
+```text
+git fetch origin
+git checkout v2
+git reset --hard origin/v2
+```
+
+- Confirm `HEAD` is the squashed release commit (its subject should be
+  `chore: release v<version> (#NNNN)`):
+
+```text
+git log -1 --oneline
+```
+
+- Create the annotated tag on this commit:
 
 ```text
 git tag -a v<version> -m "Release v<version>"
@@ -76,9 +96,19 @@ git tag -a v<version> -m "Release v<version>"
 - Show the tag details to the user.
 - Stop and confirm before pushing the tag.
 
-### 7. Push the tag
+### 7. Verify reachability, then push the tag
 
-- Push the tag to `origin`.
+- Before pushing, verify the tag is an ancestor of `origin/v2`. If this check
+  fails, STOP — the tag is on the wrong commit and must be recreated (delete it
+  with `git tag -d v<version>` and redo step 6). Do not push an unreachable tag.
+
+```text
+git merge-base --is-ancestor v<version> origin/v2 \
+  && echo "OK: tag is reachable from origin/v2" \
+  || echo "FAIL: tag is NOT on origin/v2 — do not push"
+```
+
+- Only after the check prints `OK`, push the tag to `origin`.
 - Confirm the push succeeded.
 - Tell the user that CI should now build and publish the release artifacts.
 
@@ -86,5 +116,7 @@ git tag -a v<version> -m "Release v<version>"
 
 - Do not skip confirmation checkpoints.
 - Do not continue after the PR is opened until the user confirms it was merged.
+- Never push a tag that is not an ancestor of `origin/v2` (step 7). An orphaned
+  tag silently corrupts the changelog of the following release.
 - If repository policy conflicts with any step, surface the conflict before
   proceeding.


### PR DESCRIPTION
## Why

Follow-up to #6082. That PR added a safety net (`GORELEASER_PREVIOUS_TAG`) so a misplaced tag can't corrupt the changelog. This PR fixes the **root cause**: orphaned release tags.

### What goes wrong today

The release command (`.agents/commands/release.md`) squash-merges the `release/vX.Y.Z` PR into `v2`, which creates a **new commit SHA** on the branch (`chore: release vX.Y.Z (#NNNN)`). Step 6 then says "switch to v2, pull, tag" — but it never syncs local `v2` to the exact merged commit, and never verifies the tag is reachable. In practice the `v2.8.0` and `v2.9.0` tags ended up on the **pre-squash release-branch commits**, which are not ancestors of `v2`. goreleaser's previous-tag detection then walked past them to `v2.7.0`, producing the v2.10.0 notes that spanned three releases.

## What this changes

Tightens steps 6–7 of the release command:

- **Tag the squashed commit on `origin/v2`**, explicitly: `git fetch && git checkout v2 && git reset --hard origin/v2`, then confirm `HEAD` is the `chore: release vX.Y.Z (#NNNN)` commit before tagging.
- **Reachability gate before push**: `git merge-base --is-ancestor v<version> origin/v2` must pass; abort and recreate the tag if it fails.
- Adds an Agent Note: never push a tag that isn't an ancestor of `origin/v2`.

## Relationship to #6082

- #6082 — `GORELEASER_PREVIOUS_TAG` safety net (tolerates the problem). Merge first.
- This PR — fixes the tagging step so tags stay reachable (prevents the problem).

Together they're belt-and-suspenders.