### PR TITLE
feat(authn/oidc): support custom authorize parameters in OIDC provider config

### DIFF
--- a/config/flipt.schema.cue
+++ b/config/flipt.schema.cue
@@ -147,6 +147,7 @@ JsonPath: string
 			use_pkce?: bool
 			algorithms?: [...("RS256" | "RS384" | "RS512" | "ES256" | "ES384" | "ES512" | "PS256" | "PS384" | "PS512")] | *["RS256"]
 			fetch_extra_user_info?: bool
+			authorize_parameters?: [string]: string
 		}
 
 	}

--- a/config/flipt.schema.json
+++ b/config/flipt.schema.json
@@ -476,6 +476,13 @@
                         "fetch_extra_user_info": {
                           "type": "boolean",
                           "default": false
+                        },
+                        "authorize_parameters": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "default": {}
                         }
                       }
                     }

--- a/internal/config/authentication.go
+++ b/internal/config/authentication.go
@@ -526,15 +526,16 @@ func (a AuthenticationMethodOIDCConfig) validate() error {
 
 // AuthenticationOIDCProvider configures provider credentials
 type AuthenticationMethodOIDCProvider struct {
-	IssuerURL          string   `json:"issuerURL,omitempty" mapstructure:"issuer_url" yaml:"issuer_url,omitempty"`
-	ClientID           string   `json:"-" mapstructure:"client_id" yaml:"-"`
-	ClientSecret       string   `json:"-" mapstructure:"client_secret" yaml:"-"`
-	RedirectAddress    string   `json:"redirectAddress,omitempty" mapstructure:"redirect_address" yaml:"redirect_address,omitempty"`
-	Nonce              string   `json:"nonce,omitempty" mapstructure:"nonce" yaml:"nonce,omitempty"`
-	Scopes             []string `json:"scopes,omitempty" mapstructure:"scopes" yaml:"scopes,omitempty"`
-	UsePKCE            bool     `json:"usePKCE,omitempty" mapstructure:"use_pkce" yaml:"use_pkce,omitempty"`
-	Algorithms         []string `json:"algorithms,omitempty" mapstructure:"algorithms" yaml:"algorithms,omitempty"`
-	FetchExtraUserInfo bool     `json:"fetchExtraUserInfo,omitempty" mapstructure:"fetch_extra_user_info" yaml:"fetch_extra_user_info,omitempty"`
+	IssuerURL           string            `json:"issuerURL,omitempty" mapstructure:"issuer_url" yaml:"issuer_url,omitempty"`
+	ClientID            string            `json:"-" mapstructure:"client_id" yaml:"-"`
+	ClientSecret        string            `json:"-" mapstructure:"client_secret" yaml:"-"`
+	RedirectAddress     string            `json:"redirectAddress,omitempty" mapstructure:"redirect_address" yaml:"redirect_address,omitempty"`
+	Nonce               string            `json:"nonce,omitempty" mapstructure:"nonce" yaml:"nonce,omitempty"`
+	Scopes              []string          `json:"scopes,omitempty" mapstructure:"scopes" yaml:"scopes,omitempty"`
+	UsePKCE             bool              `json:"usePKCE,omitempty" mapstructure:"use_pkce" yaml:"use_pkce,omitempty"`
+	Algorithms          []string          `json:"algorithms,omitempty" mapstructure:"algorithms" yaml:"algorithms,omitempty"`
+	FetchExtraUserInfo  bool              `json:"fetchExtraUserInfo,omitempty" mapstructure:"fetch_extra_user_info" yaml:"fetch_extra_user_info,omitempty"`
+	AuthorizeParameters map[string]string `json:"authorizeParameters,omitempty" mapstructure:"authorize_parameters" yaml:"authorize_parameters,omitempty"`
 }
 
 func (a AuthenticationMethodOIDCProvider) setDefaults(defaults map[string]any) {

--- a/internal/server/authn/method/oidc/server.go
+++ b/internal/server/authn/method/oidc/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/url"
 	"strings"
 	"time"
 
@@ -117,6 +118,19 @@ func (s *Server) AuthorizeURL(ctx context.Context, req *auth.AuthorizeURLRequest
 	authURL, err := provider.AuthURL(context.Background(), oidcRequest)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(providerCfg.AuthorizeParameters) != 0 {
+		at, err := url.Parse(authURL)
+		if err != nil {
+			return nil, err
+		}
+		query := at.Query()
+		for k, v := range providerCfg.AuthorizeParameters {
+			query.Add(k, v)
+		}
+		at.RawQuery = query.Encode()
+		authURL = at.String()
 	}
 
 	return &auth.AuthorizeURLResponse{AuthorizeUrl: authURL}, nil
@@ -292,7 +306,8 @@ func (s *Server) providerFor(provider string, state string, nonce string) (*capo
 		oidcOpts = append(oidcOpts, capoidc.WithPKCE(PKCEVerifier))
 	}
 
-	req, err := capoidc.NewRequest(oauthChallengeTTL, callback,
+	req, err := capoidc.NewRequest(
+		oauthChallengeTTL, callback,
 		oidcOpts...,
 	)
 	if err != nil {

--- a/internal/server/authn/method/oidc/server_test.go
+++ b/internal/server/authn/method/oidc/server_test.go
@@ -332,6 +332,117 @@ func Test_Server_Nonce(t *testing.T) {
 	testOIDCFlow(t, ctx, tp.Addr(), clientAddress, client, server, nil)
 }
 
+func Test_Server_AuthorizeParameters(t *testing.T) {
+	var (
+		id, secret = "client_id", "client_secret"
+		nonce      = "static"
+
+		logger = zaptest.NewLogger(t)
+		ctx    = t.Context()
+	)
+
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
+	require.NoError(t, err)
+
+	type testCase struct {
+		name   string
+		params map[string]string
+		checks func(t *testing.T, q url.Values)
+	}
+
+	tests := []testCase{
+		{
+			name:   "custom authorize parameters",
+			params: map[string]string{"audience": "my-api", "prompt": "login"},
+			checks: func(t *testing.T, q url.Values) {
+				assert.Equal(t, "my-api", q.Get("audience"))
+				assert.Equal(t, "login", q.Get("prompt"))
+			},
+		},
+		{
+			name:   "no authorize parameters",
+			params: nil,
+			checks: func(t *testing.T, q url.Values) {
+				assert.NotEmpty(t, q.Get("response_type"))
+				assert.NotEmpty(t, q.Get("client_id"))
+				assert.Empty(t, q.Get("audience"))
+				assert.Empty(t, q.Get("prompt"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := chi.NewRouter()
+			httpServer := httptest.NewServer(router)
+			clientAddress := strings.Replace(httpServer.URL, "127.0.0.1", "localhost", 1)
+			t.Cleanup(httpServer.Close)
+
+			tp := oidc.StartTestProvider(t, oidc.WithNoTLS(), oidc.WithTestDefaults(&oidc.TestProviderDefaults{
+				CustomClaims: map[string]any{},
+				SubjectInfo: map[string]*oidc.TestSubject{
+					"mark": {
+						Password: "phelps",
+					},
+				},
+				SigningKey: &oidc.TestSigningKey{
+					PrivKey: priv,
+					PubKey:  priv.Public(),
+					Alg:     oidc.RS256,
+				},
+				AllowedRedirectURIs: []string{
+					fmt.Sprintf("%s/auth/v1/method/oidc/google/callback", clientAddress),
+				},
+				ClientID:      &id,
+				ClientSecret:  &secret,
+				ExpectedNonce: &nonce,
+			}))
+			t.Cleanup(tp.Stop)
+
+			authConfig := config.AuthenticationConfig{
+				Session: config.AuthenticationSessionConfig{
+					Domain:        "localhost",
+					Secure:        false,
+					TokenLifetime: 1 * time.Hour,
+					StateLifetime: 10 * time.Minute,
+				},
+				Methods: config.AuthenticationMethodsConfig{
+					OIDC: config.AuthenticationMethod[config.AuthenticationMethodOIDCConfig]{
+						Enabled: true,
+						Method: config.AuthenticationMethodOIDCConfig{
+							Providers: map[string]config.AuthenticationMethodOIDCProvider{
+								"google": {
+									IssuerURL:           tp.Addr(),
+									ClientID:            id,
+									ClientSecret:        secret,
+									RedirectAddress:     clientAddress,
+									Nonce:               nonce,
+									AuthorizeParameters: tt.params,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			grpcServer := oidctesting.StartGRPCServer(t, ctx, logger, authConfig)
+			t.Cleanup(func() { _ = grpcServer.Stop() })
+
+			resp, err := grpcServer.Client().AuthorizeURL(ctx, &auth.AuthorizeURLRequest{
+				Provider: "google",
+				State:    "random-state",
+			})
+			require.NoError(t, err)
+			require.NotEmpty(t, resp.AuthorizeUrl)
+
+			u, err := url.Parse(resp.AuthorizeUrl)
+			require.NoError(t, err)
+
+			tt.checks(t, u.Query())
+		})
+	}
+}
+
 func Test_Server_FetchExtraUserInfoClaims(t *testing.T) {
 	var (
 		id, secret = "client_id", "client_secret"


### PR DESCRIPTION
Add an optional `authorize_parameters` map to `AuthenticationMethodOIDCProvider`
that allows appending arbitrary query parameters to the OIDC authorize URL.
This enables providers that require additional parameters (e.g.
connection, domain_hint, idp) during the authorization flow.

closes #6124
