### PR TITLE
fix(redis): route go-redis internal logs through zap

### DIFF
--- a/internal/cmd/authn.go
+++ b/internal/cmd/authn.go
@@ -50,6 +50,7 @@ func getAuthStore(
 			return nil, fmt.Errorf("failed to create redis client: %w", err)
 		}
 
+		storageauthredis.SetGlobalRedisLogger(logger)
 		store = storageauthredis.NewStore(rdb, logger, storageauthredis.WithCleanupGracePeriod(cleanupGracePeriod), storageauthredis.WithPrefix(prefix))
 	}
 

--- a/internal/storage/authn/redis/logger.go
+++ b/internal/storage/authn/redis/logger.go
@@ -1,0 +1,24 @@
+package redis
+
+import (
+	"context"
+
+	goredis "github.com/redis/go-redis/v9"
+	"go.uber.org/zap"
+)
+
+// zapRedisLogger adapts go-redis internal logs to zap.
+type zapRedisLogger struct {
+	logger *zap.Logger
+}
+
+// Printf adapts a go-redis log line to zap.
+// The context argument is not used.
+func (l *zapRedisLogger) Printf(_ context.Context, format string, v ...any) {
+	l.logger.Sugar().Debugf(format, v...)
+}
+
+// SetGlobalRedisLogger adapts go-redis internal logging to the provided zap logger.
+func SetGlobalRedisLogger(logger *zap.Logger) {
+	goredis.SetLogger(&zapRedisLogger{logger: logger.With(zap.String("store", "redis"))})
+}

--- a/internal/storage/authn/redis/logger_test.go
+++ b/internal/storage/authn/redis/logger_test.go
@@ -1,0 +1,45 @@
+package redis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestZapRedisLogger(t *testing.T) {
+	core, recorded := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	l := &zapRedisLogger{logger: logger}
+	l.Printf(t.Context(), "hello %s", "world")
+
+	require.Equal(t, 1, recorded.Len())
+	entry := recorded.All()[0]
+	assert.Equal(t, zapcore.DebugLevel, entry.Level)
+	assert.Equal(t, "hello world", entry.Message)
+}
+
+func TestZapRedisLogger_WithStoreField(t *testing.T) {
+	core, recorded := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	l := &zapRedisLogger{logger: logger.With(zap.String("store", "redis"))}
+	l.Printf(t.Context(), "test")
+
+	require.Equal(t, 1, recorded.Len())
+	entry := recorded.All()[0]
+	assert.Equal(t, "redis", entry.ContextMap()["store"])
+}
+
+func TestSetGlobalRedisLogger(t *testing.T) {
+	core, recorded := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	require.NotPanics(t, func() { SetGlobalRedisLogger(logger) })
+
+	assert.Empty(t, recorded.All())
+}


### PR DESCRIPTION
go-redis v9 writes connection pool and dial errors to os.Stderr via
Go's standard log package with a "redis: " prefix. Replace the global
logger with a zap adapter so these logs follow the same structured
formatting as the rest of the application.
