### PR TITLE
feat(ui): show flags referencing segment

### DIFF
--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -26,26 +26,34 @@ import CopyToNamespacePanel from '~/components/panels/CopyToNamespacePanel';
 import DeletePanel from '~/components/panels/DeletePanel';
 import SegmentForm from '~/components/segments/SegmentForm';
 
-import { IFlag } from '~/types/Flag';
-
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
 import { flagsReferencingSegment } from '~/utils/segmentReferences';
 
 function ReferencedFlags({
-  flags,
-  isLoading,
+  environmentKey,
   namespaceKey,
   segmentKey
 }: {
-  flags: IFlag[];
-  isLoading: boolean;
+  environmentKey: string;
   namespaceKey: string;
   segmentKey: string;
 }) {
+  const { data, isLoading, isError, error } = useListFlagsQuery({
+    environmentKey: environmentKey,
+    namespaceKey: namespaceKey
+  });
+
+  const { setError } = useError();
+  useEffect(() => {
+    if (error) {
+      setError(error);
+    }
+  }, [error, setError]);
+
   const referencingFlags = useMemo(
-    () => flagsReferencingSegment(flags, segmentKey),
-    [flags, segmentKey]
+    () => flagsReferencingSegment(data?.flags || [], segmentKey),
+    [data?.flags, segmentKey]
   );
 
   return (
@@ -71,9 +79,14 @@ function ReferencedFlags({
           <div className="text-sm text-muted-foreground">Loading flags</div>
         )}
 
-        {!isLoading && referencingFlags.length === 0 && (
+        {!isLoading && referencingFlags.length === 0 && !isError && (
           <div className="text-sm text-muted-foreground p-3 border rounded-lg">
             No flags reference this segment
+          </div>
+        )}
+        {!isLoading && isError && (
+          <div className="text-sm text-muted-foreground p-3 border rounded-lg">
+            Unable to load flag references
           </div>
         )}
 
@@ -135,15 +148,6 @@ export default function Segment() {
     { skip: skipRefetch.current }
   );
 
-  const {
-    data: flagsData,
-    error: flagsError,
-    isLoading: isLoadingFlags
-  } = useListFlagsQuery({
-    environmentKey: environment.key,
-    namespaceKey: namespace.key
-  });
-
   const [deleteSegment] = useDeleteSegmentMutation();
   const [copySegment] = useCopySegmentMutation();
 
@@ -152,12 +156,6 @@ export default function Segment() {
       setError(error);
     }
   }, [error, isError, setError]);
-
-  useEffect(() => {
-    if (flagsError) {
-      setError(flagsError);
-    }
-  }, [flagsError, setError]);
 
   if (isLoading || !segment) {
     return <Loading />;
@@ -269,8 +267,7 @@ export default function Segment() {
       </div>
 
       <ReferencedFlags
-        flags={flagsData?.flags || []}
-        isLoading={isLoadingFlags}
+        environmentKey={environment.key}
         namespaceKey={namespace.key}
         segmentKey={segment.key}
       />

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -26,7 +26,7 @@ import CopyToNamespacePanel from '~/components/panels/CopyToNamespacePanel';
 import DeletePanel from '~/components/panels/DeletePanel';
 import SegmentForm from '~/components/segments/SegmentForm';
 
-import { IFlag, flagTypeToLabel } from '~/types/Flag';
+import { IFlag } from '~/types/Flag';
 
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
@@ -49,49 +49,51 @@ function ReferencedFlags({
   );
 
   return (
-    <section className="mt-8 space-y-3">
+    <section className="mt-8 space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold">Referenced Flags</h2>
+        <div className="sm:flex-auto">
+          <h3 className="font-medium leading-6 text-gray-900 dark:text-gray-100">
+            Referenced Flags
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Flags that reference this segment (in rules or rollouts). Changing
+            constraints may affect how these flags evaluate.
+          </p>
+        </div>
+
         <Badge variant="outlinemuted">
           {isLoading ? 'Loading' : referencingFlags.length}
         </Badge>
       </div>
 
-      <div className="overflow-hidden rounded-lg border dark:border-gray-700">
+      <div className="overflow-hidden">
         {isLoading && (
-          <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
-            <FlagIcon className="h-4 w-4" />
-            Loading flags
-          </div>
+          <div className="text-sm text-muted-foreground">Loading flags</div>
         )}
 
         {!isLoading && referencingFlags.length === 0 && (
-          <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
-            <FlagIcon className="h-4 w-4" />
+          <div className="text-sm text-muted-foreground p-3 border rounded-lg">
             No flags reference this segment
           </div>
         )}
 
         {!isLoading && referencingFlags.length > 0 && (
-          <div className="divide-y dark:divide-gray-700">
+          <div className="flex flex-wrap gap-2">
             {referencingFlags.map((flag) => (
-              <Link
+              <Badge
+                variant="secondary"
+                className="font-normal"
+                title={flag.name + ' | ' + flag.key}
                 key={flag.key}
-                to={`/namespaces/${namespaceKey}/flags/${flag.key}`}
-                className="flex items-center justify-between gap-4 p-4 text-sm transition-colors hover:bg-accent"
               >
-                <span className="min-w-0">
-                  <span className="block truncate font-medium">
-                    {flag.name}
-                  </span>
-                  <span className="block truncate text-muted-foreground">
-                    {flag.key}
-                  </span>
-                </span>
-                <Badge variant="outlinemuted">
-                  {flagTypeToLabel(flag.type)}
-                </Badge>
-              </Link>
+                <Link
+                  to={`/namespaces/${namespaceKey}/flags/${flag.key}`}
+                  className="flex items-center justify-between gap-2 text-sm transition-colors hover:bg-accent"
+                >
+                  <FlagIcon className="h-4 w-4" />{' '}
+                  <span className="max-w-24 truncate">{flag.name}</span>
+                </Link>
+              </Badge>
             ))}
           </div>
         )}

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -1,12 +1,13 @@
-import { FilesIcon, Trash2Icon } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { FilesIcon, FlagIcon, Trash2Icon } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate, useParams } from 'react-router';
+import { Link, useNavigate, useParams } from 'react-router';
 
 import {
   selectCurrentEnvironment,
   selectRevision
 } from '~/app/environments/environmentsApi';
+import { useListFlagsQuery } from '~/app/flags/flagsApi';
 import {
   selectCurrentNamespace,
   selectNamespaces
@@ -25,8 +26,79 @@ import CopyToNamespacePanel from '~/components/panels/CopyToNamespacePanel';
 import DeletePanel from '~/components/panels/DeletePanel';
 import SegmentForm from '~/components/segments/SegmentForm';
 
+import { IFlag, flagTypeToLabel } from '~/types/Flag';
+
 import { useError } from '~/data/hooks/error';
 import { useSuccess } from '~/data/hooks/success';
+import { flagsReferencingSegment } from '~/utils/segmentReferences';
+
+function ReferencedFlags({
+  flags,
+  isLoading,
+  namespaceKey,
+  segmentKey
+}: {
+  flags: IFlag[];
+  isLoading: boolean;
+  namespaceKey: string;
+  segmentKey: string;
+}) {
+  const referencingFlags = useMemo(
+    () => flagsReferencingSegment(flags, segmentKey),
+    [flags, segmentKey]
+  );
+
+  return (
+    <section className="mt-8 space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold">Referenced Flags</h2>
+        <Badge variant="outlinemuted">
+          {isLoading ? 'Loading' : referencingFlags.length}
+        </Badge>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border dark:border-gray-700">
+        {isLoading && (
+          <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+            <FlagIcon className="h-4 w-4" />
+            Loading flags
+          </div>
+        )}
+
+        {!isLoading && referencingFlags.length === 0 && (
+          <div className="flex items-center gap-2 p-4 text-sm text-muted-foreground">
+            <FlagIcon className="h-4 w-4" />
+            No flags reference this segment
+          </div>
+        )}
+
+        {!isLoading && referencingFlags.length > 0 && (
+          <div className="divide-y dark:divide-gray-700">
+            {referencingFlags.map((flag) => (
+              <Link
+                key={flag.key}
+                to={`/namespaces/${namespaceKey}/flags/${flag.key}`}
+                className="flex items-center justify-between gap-4 p-4 text-sm transition-colors hover:bg-accent"
+              >
+                <span className="min-w-0">
+                  <span className="block truncate font-medium">
+                    {flag.name}
+                  </span>
+                  <span className="block truncate text-muted-foreground">
+                    {flag.key}
+                  </span>
+                </span>
+                <Badge variant="outlinemuted">
+                  {flagTypeToLabel(flag.type)}
+                </Badge>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
 
 export default function Segment() {
   let { segmentKey } = useParams();
@@ -61,6 +133,15 @@ export default function Segment() {
     { skip: skipRefetch.current }
   );
 
+  const {
+    data: flagsData,
+    error: flagsError,
+    isLoading: isLoadingFlags
+  } = useListFlagsQuery({
+    environmentKey: environment.key,
+    namespaceKey: namespace.key
+  });
+
   const [deleteSegment] = useDeleteSegmentMutation();
   const [copySegment] = useCopySegmentMutation();
 
@@ -69,6 +150,12 @@ export default function Segment() {
       setError(error);
     }
   }, [error, isError, setError]);
+
+  useEffect(() => {
+    if (flagsError) {
+      setError(flagsError);
+    }
+  }, [flagsError, setError]);
 
   if (isLoading || !segment) {
     return <Loading />;
@@ -178,6 +265,13 @@ export default function Segment() {
       <div className="mt-5">
         <SegmentForm segment={segment} />
       </div>
+
+      <ReferencedFlags
+        flags={flagsData?.flags || []}
+        isLoading={isLoadingFlags}
+        namespaceKey={namespace.key}
+        segmentKey={segment.key}
+      />
     </>
   );
 }

--- a/ui/src/utils/segmentReferences.test.ts
+++ b/ui/src/utils/segmentReferences.test.ts
@@ -1,0 +1,104 @@
+import { FlagType, IFlag } from '~/types/Flag';
+import { RolloutType } from '~/types/Rollout';
+
+import {
+  flagReferencesSegment,
+  flagsReferencingSegment
+} from './segmentReferences';
+
+const baseFlag = (key: string): IFlag => ({
+  key,
+  name: key,
+  type: FlagType.BOOLEAN,
+  enabled: true,
+  description: ''
+});
+
+describe('flagReferencesSegment', () => {
+  it('returns true when a flag rule references the segment', () => {
+    const flag = {
+      ...baseFlag('checkout'),
+      rules: [
+        {
+          segments: ['beta-users'],
+          distributions: []
+        }
+      ]
+    };
+
+    expect(flagReferencesSegment(flag, 'beta-users')).toBe(true);
+  });
+
+  it('returns true when a rollout references the segment', () => {
+    const flag = {
+      ...baseFlag('pricing'),
+      rollouts: [
+        {
+          type: RolloutType.SEGMENT,
+          segment: {
+            segments: ['internal-users'],
+            value: true
+          }
+        }
+      ]
+    };
+
+    expect(flagReferencesSegment(flag, 'internal-users')).toBe(true);
+  });
+
+  it('returns false when the segment is not referenced', () => {
+    const flag = {
+      ...baseFlag('search'),
+      rules: [
+        {
+          segments: ['other-segment'],
+          distributions: []
+        }
+      ],
+      rollouts: [
+        {
+          type: RolloutType.SEGMENT,
+          segment: {
+            segments: ['another-segment'],
+            value: true
+          }
+        }
+      ]
+    };
+
+    expect(flagReferencesSegment(flag, 'beta-users')).toBe(false);
+  });
+});
+
+describe('flagsReferencingSegment', () => {
+  it('filters flags to only those referencing the segment', () => {
+    const flags = [
+      {
+        ...baseFlag('checkout'),
+        rules: [
+          {
+            segments: ['beta-users'],
+            distributions: []
+          }
+        ]
+      },
+      baseFlag('pricing'),
+      {
+        ...baseFlag('search'),
+        rollouts: [
+          {
+            type: RolloutType.SEGMENT,
+            segment: {
+              segments: ['beta-users'],
+              value: true
+            }
+          }
+        ]
+      }
+    ];
+
+    expect(
+      flagsReferencingSegment(flags, 'beta-users').map((f) => f.key)
+    ).toEqual(['checkout', 'search']);
+  });
+});

--- a/ui/src/utils/segmentReferences.ts
+++ b/ui/src/utils/segmentReferences.ts
@@ -17,5 +17,7 @@ export function flagsReferencingSegment(
   flags: IFlag[],
   segmentKey: string
 ): IFlag[] {
-  return flags.filter((flag) => flagReferencesSegment(flag, segmentKey));
+  return flags
+    .filter((flag) => flagReferencesSegment(flag, segmentKey))
+    .sort((a, b) => a.key.localeCompare(b.key));
 }

--- a/ui/src/utils/segmentReferences.ts
+++ b/ui/src/utils/segmentReferences.ts
@@ -1,0 +1,21 @@
+import { IFlag } from '~/types/Flag';
+
+export function flagReferencesSegment(
+  flag: IFlag,
+  segmentKey: string
+): boolean {
+  return (
+    flag.rules?.some((rule) => rule.segments?.includes(segmentKey)) ||
+    flag.rollouts?.some((rollout) =>
+      rollout.segment?.segments?.includes(segmentKey)
+    ) ||
+    false
+  );
+}
+
+export function flagsReferencingSegment(
+  flags: IFlag[],
+  segmentKey: string
+): IFlag[] {
+  return flags.filter((flag) => flagReferencesSegment(flag, segmentKey));
+}

--- a/ui/src/utils/segmentReferences.ts
+++ b/ui/src/utils/segmentReferences.ts
@@ -4,13 +4,10 @@ export function flagReferencesSegment(
   flag: IFlag,
   segmentKey: string
 ): boolean {
-  return (
-    flag.rules?.some((rule) => rule.segments?.includes(segmentKey)) ||
+  return (flag.rules?.some((rule) => rule.segments?.includes(segmentKey)) ||
     flag.rollouts?.some((rollout) =>
       rollout.segment?.segments?.includes(segmentKey)
-    ) ||
-    false
-  );
+    )) as boolean;
 }
 
 export function flagsReferencingSegment(


### PR DESCRIPTION
## Summary
- add a Referenced Flags section to the segment detail page
- include flags that reference the segment from rules or segment rollouts
- link each referenced flag for faster cleanup before deleting a segment

Fixes #6115

## Tests
- npm test -- --runInBand
- npm run lint
- npm run build