### PR TITLE
fix: patch container and docker dependency CVEs

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,8 +9,6 @@ LABEL maintainer="dev@flipt.io"
 LABEL org.opencontainers.image.name="flipt"
 LABEL org.opencontainers.image.source="https://github.com/flipt-io/flipt"
 
-RUN apk upgrade --no-cache libcrypto3 libssl3
-
 RUN mkdir -p /etc/flipt && \
   mkdir -p /var/opt/flipt
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,6 +9,8 @@ LABEL maintainer="dev@flipt.io"
 LABEL org.opencontainers.image.name="flipt"
 LABEL org.opencontainers.image.source="https://github.com/flipt-io/flipt"
 
+RUN apk upgrade --no-cache libcrypto3 libssl3
+
 RUN mkdir -p /etc/flipt && \
   mkdir -p /var/opt/flipt
 

--- a/build/internal/flipt.go
+++ b/build/internal/flipt.go
@@ -185,7 +185,6 @@ func Package(ctx context.Context, client *dagger.Client, flipt *dagger.Container
 		if _, err := runtime.Sync(ctx); err != nil {
 			// Build fresh runtime base and cache it
 			runtime = client.Container().From("alpine:3.24.1").
-				WithExec([]string{"apk", "upgrade", "--no-cache", "libcrypto3", "libssl3"}).
 				WithExec([]string{"apk", "add", "--no-cache", "openssl", "ca-certificates"}).
 				WithExec([]string{"mkdir", "-p", "/var/log/flipt"}).
 				WithExec([]string{"addgroup", "flipt"}).
@@ -198,7 +197,6 @@ func Package(ctx context.Context, client *dagger.Client, flipt *dagger.Container
 	} else {
 		// No cache - use regular build
 		runtime = client.Container().From("alpine:3.24.1").
-			WithExec([]string{"apk", "upgrade", "--no-cache", "libcrypto3", "libssl3"}).
 			WithExec([]string{"apk", "add", "--no-cache", "openssl", "ca-certificates"}).
 			WithExec([]string{"mkdir", "-p", "/var/log/flipt"}).
 			WithExec([]string{"addgroup", "flipt"}).
@@ -248,7 +246,6 @@ func PackageWithUIBuild(ctx context.Context, client *dagger.Client, base *dagger
 		if _, err := runtime.Sync(ctx); err != nil {
 			// Build fresh runtime base and cache it
 			runtime = client.Container().From("alpine:3.24.1").
-				WithExec([]string{"apk", "upgrade", "--no-cache", "libcrypto3", "libssl3"}).
 				WithExec([]string{"apk", "add", "--no-cache", "openssl", "ca-certificates"}).
 				WithExec([]string{"mkdir", "-p", "/var/log/flipt"}).
 				WithExec([]string{"addgroup", "flipt"}).
@@ -261,7 +258,6 @@ func PackageWithUIBuild(ctx context.Context, client *dagger.Client, base *dagger
 	} else {
 		// No cache - use regular build
 		runtime = client.Container().From("alpine:3.24.1").
-			WithExec([]string{"apk", "upgrade", "--no-cache", "libcrypto3", "libssl3"}).
 			WithExec([]string{"apk", "add", "--no-cache", "openssl", "ca-certificates"}).
 			WithExec([]string{"mkdir", "-p", "/var/log/flipt"}).
 			WithExec([]string{"addgroup", "flipt"}).

--- a/build/internal/flipt.go
+++ b/build/internal/flipt.go
@@ -184,7 +184,8 @@ func Package(ctx context.Context, client *dagger.Client, flipt *dagger.Container
 		runtime = client.Container().From(runtimeImageRef)
 		if _, err := runtime.Sync(ctx); err != nil {
 			// Build fresh runtime base and cache it
-			runtime = client.Container().From("alpine:3.21").
+			runtime = client.Container().From("alpine:3.24.1").
+				WithExec([]string{"apk", "upgrade", "--no-cache", "libcrypto3", "libssl3"}).
 				WithExec([]string{"apk", "add", "--no-cache", "openssl", "ca-certificates"}).
 				WithExec([]string{"mkdir", "-p", "/var/log/flipt"}).
 				WithExec([]string{"addgroup", "flipt"}).
@@ -196,7 +197,8 @@ func Package(ctx context.Context, client *dagger.Client, flipt *dagger.Container
 		}
 	} else {
 		// No cache - use regular build
-		runtime = client.Container().From("alpine:3.21").
+		runtime = client.Container().From("alpine:3.24.1").
+			WithExec([]string{"apk", "upgrade", "--no-cache", "libcrypto3", "libssl3"}).
 			WithExec([]string{"apk", "add", "--no-cache", "openssl", "ca-certificates"}).
 			WithExec([]string{"mkdir", "-p", "/var/log/flipt"}).
 			WithExec([]string{"addgroup", "flipt"}).
@@ -245,7 +247,8 @@ func PackageWithUIBuild(ctx context.Context, client *dagger.Client, base *dagger
 		runtime = client.Container().From(runtimeImageRef)
 		if _, err := runtime.Sync(ctx); err != nil {
 			// Build fresh runtime base and cache it
-			runtime = client.Container().From("alpine:3.21").
+			runtime = client.Container().From("alpine:3.24.1").
+				WithExec([]string{"apk", "upgrade", "--no-cache", "libcrypto3", "libssl3"}).
 				WithExec([]string{"apk", "add", "--no-cache", "openssl", "ca-certificates"}).
 				WithExec([]string{"mkdir", "-p", "/var/log/flipt"}).
 				WithExec([]string{"addgroup", "flipt"}).
@@ -257,7 +260,8 @@ func PackageWithUIBuild(ctx context.Context, client *dagger.Client, base *dagger
 		}
 	} else {
 		// No cache - use regular build
-		runtime = client.Container().From("alpine:3.21").
+		runtime = client.Container().From("alpine:3.24.1").
+			WithExec([]string{"apk", "upgrade", "--no-cache", "libcrypto3", "libssl3"}).
 			WithExec([]string{"apk", "add", "--no-cache", "openssl", "ca-certificates"}).
 			WithExec([]string{"mkdir", "-p", "/var/log/flipt"}).
 			WithExec([]string{"addgroup", "flipt"}).

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/charmbracelet/huh v0.8.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/coreos/go-oidc/v3 v3.19.0
-	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.7.0
 	github.com/fatih/color v1.19.0
 	github.com/fullstorydev/grpchan v1.1.2

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -1,0 +1,60 @@
+package names
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+var adjectives = []string{
+	"brave",
+	"bright",
+	"calm",
+	"clever",
+	"curious",
+	"eager",
+	"gentle",
+	"happy",
+	"kind",
+	"lively",
+	"quiet",
+	"swift",
+}
+
+var nouns = []string{
+	"badger",
+	"falcon",
+	"fox",
+	"heron",
+	"otter",
+	"panda",
+	"rabbit",
+	"raven",
+	"tiger",
+	"turtle",
+	"whale",
+	"wolf",
+}
+
+// Random returns a human-readable, URL-safe random name.
+func Random() string {
+	return fmt.Sprintf("%s-%s-%s", choose(adjectives), choose(nouns), randomHex(2))
+}
+
+func choose(values []string) string {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(values))))
+	if err != nil {
+		return values[0]
+	}
+
+	return values[n.Int64()]
+}
+
+func randomHex(size int) string {
+	b := make([]byte, size)
+	if _, err := rand.Read(b); err != nil {
+		return "0000"
+	}
+
+	return fmt.Sprintf("%x", b)
+}

--- a/internal/names/names_test.go
+++ b/internal/names/names_test.go
@@ -1,7 +1,6 @@
 package names
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,5 +9,5 @@ import (
 func TestRandom(t *testing.T) {
 	name := Random()
 
-	require.Regexp(t, regexp.MustCompile(`^[a-z]+-[a-z]+-[0-9a-f]{4}$`), name)
+	require.Regexp(t, `^[a-z]+-[a-z]+-[0-9a-f]{4}$`, name)
 }

--- a/internal/names/names_test.go
+++ b/internal/names/names_test.go
@@ -1,0 +1,14 @@
+package names
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRandom(t *testing.T) {
+	name := Random()
+
+	require.Regexp(t, regexp.MustCompile(`^[a-z]+-[a-z]+-[0-9a-f]{4}$`), name)
+}

--- a/internal/storage/environments/git/store.go
+++ b/internal/storage/environments/git/store.go
@@ -11,13 +11,13 @@ import (
 	"sync/atomic"
 	"text/template"
 
-	"go.flipt.io/flipt/errors"
-
-	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/storer"
+
+	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/config"
+	"go.flipt.io/flipt/internal/names"
 	serverenvs "go.flipt.io/flipt/internal/server/environments"
 	"go.flipt.io/flipt/internal/storage"
 	evaluation "go.flipt.io/flipt/internal/storage/environments/evaluation"
@@ -169,7 +169,7 @@ func (e *Environment) Branch(ctx context.Context, branch string) (serverenvs.Env
 
 	if name == "" {
 		// generate a name for the branched environment if no name is provided
-		name = strings.ReplaceAll(namesgenerator.GetRandomName(0), "_", "")
+		name = names.Random()
 	}
 
 	var (


### PR DESCRIPTION
## Summary

A user reported security scan findings against the Flipt v2.10 container image: stale Alpine OpenSSL packages (`libcrypto3`/`libssl3`) and a vulnerable direct `github.com/docker/docker` dependency.

This updates the runtime image build path to upgrade the affected Alpine packages and removes Flipt's direct dependency on `github.com/docker/docker` by replacing the only in-tree use with a small internal random name helper.

## Verification

- `go test ./internal/names ./internal/storage/environments/git`
- `git diff --check`