### PR TITLE
fix(ui): lazy init useState in MetadataForm and CopyToNamespacePanel

### DIFF
--- a/ui/src/components/flags/MetadataForm.tsx
+++ b/ui/src/components/flags/MetadataForm.tsx
@@ -109,7 +109,7 @@ export function MetadataForm({
   disabled = false,
   onErrorChange
 }: MetadataFormProps): JSX.Element {
-  const [entries, setEntries] = useState<IFlagMetadata[]>(
+  const [entries, setEntries] = useState<IFlagMetadata[]>(() =>
     objectToMetadataArray(metadata)
   );
   const [errors, setErrors] = useState<Record<number, Record<string, string>>>(

--- a/ui/src/components/panels/CopyToNamespacePanel.tsx
+++ b/ui/src/components/panels/CopyToNamespacePanel.tsx
@@ -49,10 +49,10 @@ export default function CopyToNamespacePanel(props: CopyToNamespacePanelProps) {
   );
 
   const [selectedNamespace, setSelectedNamespace] =
-    useState<SelectableNamespace>({
+    useState<SelectableNamespace>(() => ({
       ...namespaces[0],
       displayValue: namespaces[0]?.name
-    });
+    }));
 
   const handleSubmit = () => {
     return handleCopy(selectedNamespace.key);


### PR DESCRIPTION
avoid re-evaluating initializers like objectToMetadataArray on every render.
