### PR TITLE
refactor(ui): replace Searchbox debounce with useDeferredValue in tables

### DIFF
--- a/ui/src/components/Searchbox.tsx
+++ b/ui/src/components/Searchbox.tsx
@@ -1,33 +1,13 @@
 import { SearchIcon } from 'lucide-react';
-import { useEffect, useState } from 'react';
 
 type SearchboxProps = {
   value: string;
   onChange: (value: string) => void;
-  debounce?: number;
   className?: string;
 };
 
 export default function Searchbox(props: SearchboxProps) {
-  const {
-    value: initialValue,
-    onChange,
-    debounce = 500,
-    className = ''
-  } = props;
-  const [value, setValue] = useState<string>(initialValue);
-
-  useEffect(() => {
-    setValue(initialValue);
-  }, [initialValue]);
-
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      onChange(value);
-    }, debounce);
-
-    return () => clearTimeout(timeout);
-  }, [debounce, onChange, value]);
+  const { value, onChange, className = '' } = props;
 
   return (
     <div className={`${className} flex flex-1 items-center justify-start`}>
@@ -49,7 +29,7 @@ export default function Searchbox(props: SearchboxProps) {
             placeholder="Search"
             type="search"
             value={value}
-            onChange={(e) => setValue(e.target.value)}
+            onChange={(e) => onChange(e.target.value)}
           />
         </div>
       </div>

--- a/ui/src/components/flags/FlagTable.tsx
+++ b/ui/src/components/flags/FlagTable.tsx
@@ -15,7 +15,7 @@ import {
   VariableIcon,
   XSquareIcon
 } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router';
 
@@ -246,6 +246,7 @@ export default function FlagTable(props: FlagTableProps) {
   });
 
   const [filter, setFilter] = useState<string>('');
+  const deferredFilter = useDeferredValue(filter);
 
   const sorting = useSelector(selectSorting);
 
@@ -270,7 +271,7 @@ export default function FlagTable(props: FlagTableProps) {
     data: flags,
     columns,
     state: {
-      globalFilter: filter,
+      globalFilter: deferredFilter,
       sorting,
       pagination
     },

--- a/ui/src/components/namespaces/NamespaceTable.tsx
+++ b/ui/src/components/namespaces/NamespaceTable.tsx
@@ -11,7 +11,7 @@ import {
   useReactTable
 } from '@tanstack/react-table';
 import { ArrowDownIcon, ArrowUpIcon, PencilIcon, XIcon } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useDeferredValue, useMemo, useState } from 'react';
 
 import Pagination from '~/components/Pagination';
 import Searchbox from '~/components/Searchbox';
@@ -106,6 +106,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const [filter, setFilter] = useState<string>('');
+  const deferredFilter = useDeferredValue(filter);
 
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -173,7 +174,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
     data: sortedNamespaces,
     columns,
     state: {
-      globalFilter: filter,
+      globalFilter: deferredFilter,
       sorting,
       pagination
     },

--- a/ui/src/components/segments/SegmentTable.tsx
+++ b/ui/src/components/segments/SegmentTable.tsx
@@ -8,7 +8,7 @@ import {
   useReactTable
 } from '@tanstack/react-table';
 import { AsteriskIcon, SigmaIcon } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router';
 
@@ -134,6 +134,7 @@ export default function SegmentTable(props: SegmentTableProps) {
   });
 
   const [filter, setFilter] = useState<string>('');
+  const deferredFilter = useDeferredValue(filter);
 
   const sorting = useSelector(selectSorting);
 
@@ -155,7 +156,7 @@ export default function SegmentTable(props: SegmentTableProps) {
     data: segments,
     columns,
     state: {
-      globalFilter: filter,
+      globalFilter: deferredFilter,
       sorting,
       pagination
     },


### PR DESCRIPTION
Simplify Searchbox to a pure controlled component by removing its
internal useState/useEffect debounce. The debounce responsibility
shifts to consumers, which use React 19's useDeferredValue to defer
table filtering without blocking the input.
