### PR TITLE
fix(server): downgrade 'authentication required' gRPC log to WARN

### DIFF
--- a/internal/server/authn/middleware/grpc/middleware.go
+++ b/internal/server/authn/middleware/grpc/middleware.go
@@ -124,7 +124,7 @@ func AuthenticationRequiredUnaryInterceptor(logger *zap.Logger, o ...containers.
 
 		auth := GetAuthenticationFrom(ctx)
 		if auth == nil {
-			logger.Error("unauthenticated", zap.String("reason", "authentication required"))
+			logger.Warn("unauthenticated", zap.String("reason", "authentication required"))
 			return ctx, errUnauthenticated
 		}
 
@@ -148,7 +148,7 @@ func AuthenticationRequiredStreamInterceptor(logger *zap.Logger, o ...containers
 
 		auth := GetAuthenticationFrom(ctx)
 		if auth == nil {
-			logger.Error("unauthenticated", zap.String("reason", "authentication required"))
+			logger.Warn("unauthenticated", zap.String("reason", "authentication required"))
 			return errUnauthenticated
 		}
 


### PR DESCRIPTION
## Summary

Downgrades the "authentication required" gRPC interceptor log from `ERROR` to
`WARN`. Every unauthenticated request to the UI login flow currently emits:

```
ERROR  unauthenticated  {"server": "grpc", "reason": "authentication required"}
```

An unauthenticated request reaching the login flow is expected behavior, not an
error condition. This change touches only the two "authentication required"
paths in `internal/server/authn/middleware/grpc/middleware.go` — the
`AuthenticationRequiredUnaryInterceptor` and
`AuthenticationRequiredStreamInterceptor`. All other
`logger.Error("unauthenticated", ...)` calls (metadata not found, email not
allowed, email-matching failures, and the `authentication required for email
matching` case) are left at `ERROR`, since those represent genuinely anomalous
or misconfigured states.

## Why this matters

As reported in #6186, logging the not-logged-in case at `ERROR` produces a
false-positive ERROR line on every UI login, which trips monitoring and alerting
that watch for ERROR-level entries. Moving it to `WARN` removes the false
positive while still surfacing the event, and genuine authentication failures
continue to log at `ERROR` as before.

`go build ./...` and `go test ./internal/server/authn/middleware/grpc/...` pass.

Fixes #6186
