### PR TITLE
fix(build): order release preparation tasks

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -86,8 +86,11 @@ npm run lint
 
 [tasks.prep]
 description = "Prepare project for building (clean + ui:build)"
-depends = ["clean", "ui:build"]
-run = 'echo " > Prepared."'
+depends = ["clean"]
+run = """
+mise run ui:build
+echo " > Prepared."
+"""
 
 [tasks.build]
 description = "Build the project similar to a release build"


### PR DESCRIPTION
## Summary

Prevent `clean` from deleting UI assets after the Vite build during release preparation.

- Run `clean` before `ui:build` in `mise run prep`
- Eliminate the race that caused GoReleaser to fail resolving `ui/embed.go` assets

## Validation

- `mise tasks validate`
- `mise run prep`
- `go build -tags=assets ./cmd/flipt`
- Fresh code review (no findings)

`mise run test` is blocked locally by the inherited `commit.gpgSign` configuration in Git fixture tests.