### PR TITLE
refactor(ui): modernize code for eslint 10 and react best practices

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -172,7 +172,7 @@ export default function App() {
   const environment = useSelector(selectCurrentEnvironment);
   const namespace = useSelector(selectCurrentNamespace);
 
-  let title = `Flipt | ${environment.key} · ${namespace.name}`;
+  const title = `Flipt | ${environment.key} · ${namespace.name}`;
 
   return (
     <>

--- a/ui/src/app/analytics/Analytics.tsx
+++ b/ui/src/app/analytics/Analytics.tsx
@@ -106,6 +106,19 @@ export default function Analytics() {
     durations[0]
   );
   const [pollingInterval, setPollingInterval] = useState<number>(0);
+  const [prevSelection, setPrevSelection] = useState({
+    selectedDuration,
+    selectedFlag
+  });
+
+  if (
+    prevSelection.selectedDuration !== selectedDuration ||
+    prevSelection.selectedFlag !== selectedFlag
+  ) {
+    // Set the polling interval to 0 every time we change durations or flag
+    setPrevSelection({ selectedDuration, selectedFlag });
+    setPollingInterval(0);
+  }
 
   // Select flag from path param if present
   useEffect(() => {
@@ -119,19 +132,10 @@ export default function Analytics() {
     }
   }, [flagKey, flagOptions, selectedFlag]);
 
-  // Keep selectedFlag in sync with flagOptions
-  useEffect(() => {
-    if (
-      flagOptions.length > 0 &&
-      selectedFlag &&
-      !flagOptions.find((f) => f.key === selectedFlag.key)
-    ) {
-      setSelectedFlag(null);
-    }
-    if (flagOptions.length === 0) {
-      setSelectedFlag(null);
-    }
-  }, [flagsData, flagOptions, selectedFlag]);
+  const effectiveSelectedFlag = useMemo(() => {
+    if (!selectedFlag || flagOptions.length === 0) return null;
+    return flagOptions.find((f) => f.key === selectedFlag.key) ?? null;
+  }, [flagOptions, selectedFlag]);
 
   // Analytics query
   const d = new Date();
@@ -139,11 +143,11 @@ export default function Analytics() {
   d.setMilliseconds(0);
 
   const getFlagEvaluationCount = useGetFlagEvaluationCountQuery(
-    selectedFlag && info.analytics?.enabled
+    effectiveSelectedFlag && info.analytics?.enabled
       ? {
           environmentKey: environment.key,
           namespaceKey: namespace.key,
-          flagKey: selectedFlag.key,
+          flagKey: effectiveSelectedFlag.key,
           from: addMinutes(
             d,
             selectedDuration?.value ? selectedDuration.value * -1 : -60
@@ -153,7 +157,7 @@ export default function Analytics() {
       : skipToken,
     {
       pollingInterval,
-      skip: !info.analytics?.enabled || !selectedFlag
+      skip: !info.analytics?.enabled || !effectiveSelectedFlag
     }
   );
 
@@ -163,11 +167,6 @@ export default function Analytics() {
       values: getFlagEvaluationCount.data?.values || []
     };
   }, [getFlagEvaluationCount]);
-
-  // Set the polling interval to 0 every time we change durations or flag
-  useEffect(() => {
-    setPollingInterval(0);
-  }, [selectedDuration, selectedFlag]);
 
   // Empty state if analytics disabled
   if (!info.analytics?.enabled) {
@@ -216,7 +215,7 @@ export default function Analytics() {
                 className="w-lg"
                 placeholder="Select or search for a flag"
                 values={flagOptions}
-                selected={selectedFlag}
+                selected={effectiveSelectedFlag}
                 setSelected={(flag) => {
                   setSelectedFlag(flag);
                   if (flag) {
@@ -275,7 +274,7 @@ export default function Analytics() {
               </Button>
             </Well>
           </div>
-        ) : !selectedFlag ? (
+        ) : !effectiveSelectedFlag ? (
           <div className="mt-12 w-full">
             <Well>
               <ChartNoAxesCombinedIcon className="h-12 w-12 text-muted-foreground/30 mb-4" />
@@ -292,7 +291,7 @@ export default function Analytics() {
             <Graph
               timestamps={flagEvaluationCount.timestamps}
               values={flagEvaluationCount.values}
-              flagKey={selectedFlag.key}
+              flagKey={effectiveSelectedFlag.key}
             />
           </div>
         )}

--- a/ui/src/app/auth/Login.tsx
+++ b/ui/src/app/auth/Login.tsx
@@ -18,6 +18,7 @@ import { Toaster } from '~/components/Sonner';
 import { IAuthMethod } from '~/types/Auth';
 
 import logoFlag from '~/assets/logo-flag.png';
+import { browser } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSession } from '~/data/hooks/session';
 import { upperFirst } from '~/utils/helpers';
@@ -70,7 +71,7 @@ function InnerLoginButtons() {
     }
     clearError();
     const body = await res.json();
-    window.location.href = body.authorizeUrl;
+    browser.navigateTo(body.authorizeUrl);
   };
   const {
     data: listAuthProviders,

--- a/ui/src/app/auth/authApi.ts
+++ b/ui/src/app/auth/authApi.ts
@@ -16,7 +16,7 @@ export const authProvidersApi = createApi({
       query: () => {
         return { url: '/method' };
       },
-      providesTags: (_result, _error, _args) => [{ type: 'Provider' }]
+      providesTags: () => [{ type: 'Provider' }]
     })
   })
 });

--- a/ui/src/app/environments/environmentsApi.ts
+++ b/ui/src/app/environments/environmentsApi.ts
@@ -85,7 +85,7 @@ export const selectEnvironments = createSelector(
   [(state: RootState) => state.environments.environments],
   (environments) => {
     return Object.entries(environments)
-      .map(([_, value]) => value)
+      .map(([, value]) => value)
       .filter((env) => env.configuration?.base === undefined) as IEnvironment[]; // ignore branched environments
   }
 );
@@ -95,7 +95,7 @@ export const selectAllEnvironments = createSelector(
   [(state: RootState) => state.environments.environments],
   (environments) => {
     return Object.entries(environments).map(
-      ([_, value]) => value
+      ([, value]) => value
     ) as IEnvironment[];
   }
 );

--- a/ui/src/app/flags/Flag.tsx
+++ b/ui/src/app/flags/Flag.tsx
@@ -38,7 +38,7 @@ import {
 } from './flagsApi';
 
 export default function Flag() {
-  let { flagKey } = useParams();
+  const { flagKey } = useParams();
 
   const [showDeleteFlagModal, setShowDeleteFlagModal] = useState(false);
   const [showCopyFlagModal, setShowCopyFlagModal] = useState(false);

--- a/ui/src/app/namespaces/namespacesApi.ts
+++ b/ui/src/app/namespaces/namespacesApi.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { createApi } from '@reduxjs/toolkit/query/react';
 
@@ -47,9 +46,7 @@ export const { currentNamespaceChanged } = namespacesSlice.actions;
 export const selectNamespaces = createSelector(
   [(state: RootState) => state.namespaces.namespaces],
   (namespaces) => {
-    return Object.entries(namespaces).map(
-      ([_, value]) => value
-    ) as INamespace[];
+    return Object.entries(namespaces).map(([, value]) => value) as INamespace[];
   }
 );
 

--- a/ui/src/app/preferences/Preferences.tsx
+++ b/ui/src/app/preferences/Preferences.tsx
@@ -1,6 +1,6 @@
 import { Formik } from 'formik';
 import { Clock, Moon, Radio, Sun } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { Switch } from '~/components/Switch';
@@ -41,17 +41,19 @@ export default function Preferences() {
   const { inTimezone } = useTimezone();
   const isUTC = useMemo(() => timezone === Timezone.UTC, [timezone]);
 
-  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
   const DEBOUNCE_DELAY = 1000;
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
-
-  useEffect(() => {
-    setIsInitialLoad(false);
-  }, []);
+  const isInitialLoad = useRef(true);
 
   useEffect(() => {
-    if (lastSaved && !isInitialLoad) {
+    if (lastSaved) {
+      if (isInitialLoad.current) {
+        isInitialLoad.current = false;
+        dispatch(resetLastSaved());
+        return;
+      }
+
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
@@ -64,8 +66,6 @@ export default function Preferences() {
         dispatch(resetLastSaved());
         debounceTimerRef.current = null;
       }, DEBOUNCE_DELAY);
-    } else if (lastSaved && isInitialLoad) {
-      dispatch(resetLastSaved());
     }
 
     return () => {
@@ -73,7 +73,7 @@ export default function Preferences() {
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [lastSaved, dispatch, setNotification, isInitialLoad]);
+  }, [lastSaved, dispatch, setNotification]);
 
   return (
     <Formik initialValues={initialValues} onSubmit={() => {}}>

--- a/ui/src/app/preferences/Preferences.tsx
+++ b/ui/src/app/preferences/Preferences.tsx
@@ -41,19 +41,13 @@ export default function Preferences() {
   const { inTimezone } = useTimezone();
   const isUTC = useMemo(() => timezone === Timezone.UTC, [timezone]);
 
-  const DEBOUNCE_DELAY = 1000;
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const DEBOUNCE_DELAY = 1000;
 
   const isInitialLoad = useRef(true);
 
   useEffect(() => {
-    if (lastSaved) {
-      if (isInitialLoad.current) {
-        isInitialLoad.current = false;
-        dispatch(resetLastSaved());
-        return;
-      }
-
+    if (lastSaved && !isInitialLoad.current) {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
@@ -66,6 +60,8 @@ export default function Preferences() {
         dispatch(resetLastSaved());
         debounceTimerRef.current = null;
       }, DEBOUNCE_DELAY);
+    } else if (lastSaved && isInitialLoad.current) {
+      dispatch(resetLastSaved());
     }
 
     return () => {
@@ -73,7 +69,11 @@ export default function Preferences() {
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [lastSaved, dispatch, setNotification]);
+  }, [lastSaved, dispatch, setNotification, isInitialLoad]);
+
+  useEffect(() => {
+    isInitialLoad.current = false;
+  }, []);
 
   return (
     <Formik initialValues={initialValues} onSubmit={() => {}}>

--- a/ui/src/app/preferences/preferencesSlice.ts
+++ b/ui/src/app/preferences/preferencesSlice.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
 import { fetchInfoAsync } from '~/app/meta/metaSlice';
@@ -58,7 +57,7 @@ const getInitialState = (): PreferencesState => {
         realtime = preferences.realtime;
       }
     }
-  } catch (e) {
+  } catch (_e) {
     // localStorage is disabled or not available, ignore
   }
 
@@ -86,7 +85,7 @@ const savePreferences = (state: PreferencesState) => {
       })
     );
     state.lastSaved = Date.now();
-  } catch (e) {
+  } catch (_e) {
     // localStorage is disabled or not available, ignore
   }
 };

--- a/ui/src/app/segments/Segment.tsx
+++ b/ui/src/app/segments/Segment.tsx
@@ -116,7 +116,7 @@ function ReferencedFlags({
 }
 
 export default function Segment() {
-  let { segmentKey } = useParams();
+  const { segmentKey } = useParams();
 
   const [showDeleteSegmentModal, setShowDeleteSegmentModal] =
     useState<boolean>(false);

--- a/ui/src/components/NavUser.tsx
+++ b/ui/src/components/NavUser.tsx
@@ -19,8 +19,7 @@ import {
 
 import { User } from '~/types/auth/User';
 
-import { revokeAuthSelf } from '~/data/api';
-import { browser } from '~/data/api';
+import { browser, revokeAuthSelf } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSession } from '~/data/hooks/session';
 import { redirectAfterLogout } from '~/utils/navigation';

--- a/ui/src/components/NavUser.tsx
+++ b/ui/src/components/NavUser.tsx
@@ -20,6 +20,7 @@ import {
 import { User } from '~/types/auth/User';
 
 import { revokeAuthSelf } from '~/data/api';
+import { browser } from '~/data/api';
 import { useError } from '~/data/hooks/error';
 import { useSession } from '~/data/hooks/session';
 import { redirectAfterLogout } from '~/utils/navigation';
@@ -37,7 +38,7 @@ export function NavUser({ user }: { user: User }) {
       redirectAfterLogout(
         (next: string, hard: boolean) => {
           if (hard) {
-            window.location.href = next;
+            browser.navigateTo(next);
           } else {
             navigate(next);
           }

--- a/ui/src/components/constraints/ConstraintTable.tsx
+++ b/ui/src/components/constraints/ConstraintTable.tsx
@@ -32,30 +32,31 @@ import { useTimezone } from '~/data/hooks/timezone';
 
 // Component for displaying array values in constraints
 function ConstraintArrayValue({ value }: { value: string | undefined }) {
+  let items: string[] | number[];
   try {
-    const items: string[] | number[] = JSON.parse(value || '[]');
-    return (
-      <div className="max-w-[300px]">
-        <div className="flex flex-wrap gap-1">
-          {items.slice(0, 5).map((item, idx) => (
-            <span
-              key={idx}
-              className="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs"
-            >
-              {String(item)}
-            </span>
-          ))}
-          {items.length > 5 && (
-            <span className="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs">
-              +{items.length - 5} more
-            </span>
-          )}
-        </div>
-      </div>
-    );
-  } catch (err) {
+    items = JSON.parse(value || '[]');
+  } catch {
     return <span className="text-red-500">Invalid array</span>;
   }
+  return (
+    <div className="max-w-[300px]">
+      <div className="flex flex-wrap gap-1">
+        {items.slice(0, 5).map((item, idx) => (
+          <span
+            key={idx}
+            className="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs"
+          >
+            {String(item)}
+          </span>
+        ))}
+        {items.length > 5 && (
+          <span className="rounded-full bg-gray-100 dark:bg-gray-800 px-2 py-0.5 text-xs">
+            +{items.length - 5} more
+          </span>
+        )}
+      </div>
+    </div>
+  );
 }
 
 // Component for displaying constraint values based on type
@@ -67,22 +68,21 @@ function ConstraintValue({ constraint }: { constraint: IConstraint }) {
     constraint.type === ConstraintType.DATETIME &&
     constraint.value !== undefined
   ) {
+    let formattedDate: string;
     try {
-      // Attempt to format the date - if it fails, show a fallback
-      const formattedDate = inTimezone(constraint.value);
-      return (
-        <span className="text-sm text-gray-900 dark:text-white">
-          {formattedDate}
-        </span>
-      );
-    } catch (err) {
-      // Show the raw value with an error indication
+      formattedDate = inTimezone(constraint.value);
+    } catch {
       return (
         <span className="text-sm text-red-600 dark:text-red-400">
           {constraint.value || '(invalid date)'}
         </span>
       );
     }
+    return (
+      <span className="text-sm text-gray-900 dark:text-white">
+        {formattedDate}
+      </span>
+    );
   }
 
   if (isArrayValue) {

--- a/ui/src/components/forms/SegmentsPicker.tsx
+++ b/ui/src/components/forms/SegmentsPicker.tsx
@@ -1,5 +1,5 @@
 import { MinusIcon, PlusIcon } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { IconButton } from '~/components/Button';
 import Combobox from '~/components/Combobox';
@@ -21,41 +21,23 @@ export default function SegmentsPicker({
   segmentReplace,
   segmentRemove
 }: SegmentPickerProps) {
-  // Track selected segment keys to avoid duplicates
-  const segmentsSet = useRef<Set<string>>(
-    new Set<string>(
-      parentSegments.map((s) => (typeof s === 'string' ? s : s.key))
-    )
-  );
-
   // State to control whether to show the new segment selection field
   const [showNewSegmentField, setShowNewSegmentField] =
     useState<boolean>(false);
 
-  // Store previous parent segments length to prevent unnecessary updates
-  const prevParentSegmentsLength = useRef(parentSegments.length);
-
-  // Update segment set when parent segments change
-  useEffect(() => {
-    // Update the set of selected segment keys
-    segmentsSet.current = new Set<string>(
+  const segmentOptions = useMemo(() => {
+    const selectedKeys = new Set<string>(
       parentSegments.map((s) => (typeof s === 'string' ? s : s.key))
     );
-
-    // Update the previous length
-    prevParentSegmentsLength.current = parentSegments.length;
-  }, [parentSegments]); // Depend on the entire parentSegments array
+    return segments
+      .filter((s) => !selectedKeys.has(s.key))
+      .map((s) => ({
+        ...s,
+        displayValue: s.name
+      }));
+  }, [segments, parentSegments]);
 
   const handleSegmentRemove = (index: number) => {
-    const filterableSegment = parentSegments[index];
-    if (!filterableSegment) return;
-
-    // Remove references to the segment that is being deleted.
-    segmentsSet.current.delete(
-      typeof filterableSegment === 'string'
-        ? filterableSegment
-        : filterableSegment.key
-    );
     segmentRemove(index);
   };
 
@@ -63,59 +45,20 @@ export default function SegmentsPicker({
     index: number,
     segment: FilterableSegment | null
   ) => {
-    if (!segment) {
-      return;
-    }
+    if (!segment) return;
 
-    // Get the current set of segment keys to prevent duplicates
-    const segmentSetCurrent = segmentsSet.current;
+    const selectedKeys = new Set<string>(
+      parentSegments.map((s) => (typeof s === 'string' ? s : s.key))
+    );
 
-    // Check if this segment is already selected
-    if (segmentSetCurrent.has(segment.key)) {
-      return;
-    }
+    if (selectedKeys.has(segment.key)) return;
 
     if (index < parentSegments.length) {
-      // REPLACE: We're updating an existing segment
-      const previousSegment = parentSegments[index];
-      if (previousSegment) {
-        const prevKey =
-          typeof previousSegment === 'string'
-            ? previousSegment
-            : previousSegment.key;
-
-        // Remove the old segment key from the set
-        if (segmentSetCurrent.has(prevKey)) {
-          segmentSetCurrent.delete(prevKey);
-        }
-      }
-
-      // Add the new segment key to the set
-      segmentSetCurrent.add(segment.key);
-
-      // Update the segment at the specified index
       segmentReplace(index, segment);
     } else {
-      // ADD: We're adding a new segment
-      // Add the segment key to the set to prevent duplicates
-      segmentSetCurrent.add(segment.key);
-
-      // Add the segment to the parent component's state
       segmentAdd(segment);
-
-      // Hide the new segment field after adding
       setShowNewSegmentField(false);
     }
-  };
-
-  // Create filtered segment options with proper display values
-  const getSegmentOptions = () => {
-    return segments
-      .filter((s) => !segmentsSet.current.has(s.key))
-      .map((s) => ({
-        ...s,
-        displayValue: s.name
-      }));
   };
 
   if (segments.length == 0) {
@@ -135,7 +78,7 @@ export default function SegmentsPicker({
               id={`segmentKey-${index}`}
               name={`segmentKey-${index}`}
               placeholder="Select or search for a segment"
-              values={getSegmentOptions()}
+              values={segmentOptions}
               selected={selectedSegment}
               className="w-full"
               setSelected={(filterableSegment) => {
@@ -154,7 +97,7 @@ export default function SegmentsPicker({
             ) : (
               // When there's only one segment and more available to add,
               // show the plus button in place of the minus button
-              getSegmentOptions().length > 0 &&
+              segmentOptions.length > 0 &&
               !showNewSegmentField && (
                 <IconButton
                   icon={PlusIcon}
@@ -168,7 +111,7 @@ export default function SegmentsPicker({
             {index === parentSegments.length - 1 &&
               parentSegments.length > 1 &&
               !showNewSegmentField &&
-              getSegmentOptions().length > 0 && (
+              segmentOptions.length > 0 && (
                 <IconButton
                   icon={PlusIcon}
                   onClick={() => setShowNewSegmentField(true)}
@@ -187,7 +130,7 @@ export default function SegmentsPicker({
               id={`segmentKey-${parentSegments.length}`}
               name={`segmentKey-${parentSegments.length}`}
               placeholder="Select or search for a segment"
-              values={getSegmentOptions()}
+              values={segmentOptions}
               className="w-full"
               selected={null}
               setSelected={(filterableSegment) => {
@@ -204,14 +147,14 @@ export default function SegmentsPicker({
         </div>
       )}
 
-      {parentSegments.length === 0 && getSegmentOptions().length > 0 && (
+      {parentSegments.length === 0 && segmentOptions.length > 0 && (
         <div className="flex w-full space-x-1">
           <div className="w-5/6">
             <Combobox<FilterableSegment>
               id="segmentKey-0"
               name="segmentKey-0"
               placeholder="Select or search for a segment"
-              values={getSegmentOptions()}
+              values={segmentOptions}
               selected={null}
               setSelected={(filterableSegment) => {
                 handleSegmentSelected(0, filterableSegment);

--- a/ui/src/data/api.ts
+++ b/ui/src/data/api.ts
@@ -33,7 +33,7 @@ export class APIError extends Error {
 
 export const browser = {
   navigateTo(url: string) {
-    window.location.href = url;
+    window.location.assign(url);
   },
   reloadPage() {
     window.location.reload();

--- a/ui/src/utils/helpers.ts
+++ b/ui/src/utils/helpers.ts
@@ -100,7 +100,9 @@ function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
   );
 }
 
-function isFetchBaseQueryError(error: unknown): error is ErrorWithMessage {
+function isFetchBaseQueryError(
+  error: unknown
+): error is { data: ErrorWithMessage } {
   return (
     typeof error === 'object' &&
     error !== null &&
@@ -114,7 +116,6 @@ function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
   if (isErrorWithMessage(maybeError)) return maybeError;
   // handle Redux FetchBaseQueryError
   if (isFetchBaseQueryError(maybeError)) {
-    // @ts-ignore
     return maybeError.data;
   }
   try {


### PR DESCRIPTION
- Replace let with const for non-reassigned variables
- Remove unused catch parameters and function arguments
- Remove eslint-disable comments where violations are fixed
- Fix isFetchBaseQueryError return type to eliminate @ts-ignore
- Route navigation through browser.navigateTo abstraction
- Simplify SegmentsPicker: useMemo over useRef/useEffect
- Fix Analytics: derive selectedFlag and pollingInterval with useMemo
- Fix Preferences: useRef for isInitialLoad, streamline debounce
