### PR TITLE
fix(evaluation): handle batch flag errors individually

### DIFF
--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -2,7 +2,6 @@ package evaluation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"hash/crc32"
 	"sort"
@@ -527,7 +526,7 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 						ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
 							FlagKey:    req.FlagKey,
 							NamespaceKey: req.NamespaceKey,
-							Reason:     rpcevaluation.ErrorEvaluationReason_INTERNAL_ERROR_EVALUATION_REASON,
+							Reason:     rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
 						},
 					},
 				}
@@ -562,7 +561,7 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 						ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
 							FlagKey:    req.FlagKey,
 							NamespaceKey: req.NamespaceKey,
-							Reason:     rpcevaluation.ErrorEvaluationReason_INTERNAL_ERROR_EVALUATION_REASON,
+							Reason:     rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
 						},
 					},
 				}

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -500,31 +500,39 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 
 		f, err := store.GetFlag(ctx, storage.NewResource(req.NamespaceKey, req.FlagKey, storage.WithReference(b.Reference)))
 		if err != nil {
-			var errnf errs.ErrNotFound
-			if errors.As(err, &errnf) {
-				eresp := &rpcevaluation.EvaluationResponse{
-					Type: rpcevaluation.EvaluationResponseType_ERROR_EVALUATION_RESPONSE_TYPE,
-					Response: &rpcevaluation.EvaluationResponse_ErrorResponse{
-						ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
-							FlagKey:      req.FlagKey,
-							NamespaceKey: req.NamespaceKey,
-							Reason:       rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
-						},
+			eresp := &rpcevaluation.EvaluationResponse{
+				Type: rpcevaluation.EvaluationResponseType_ERROR_EVALUATION_RESPONSE_TYPE,
+				Response: &rpcevaluation.EvaluationResponse_ErrorResponse{
+					ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
+						FlagKey:      req.FlagKey,
+						NamespaceKey: req.NamespaceKey,
+						Reason:       rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
 					},
-				}
-
-				resp.Responses = append(resp.Responses, eresp)
-				continue
+				},
 			}
 
-			return nil, err
+			resp.Responses = append(resp.Responses, eresp)
+			continue
 		}
+
+		var eresp *rpcevaluation.EvaluationResponse
 
 		switch f.Type {
 		case core.FlagType_BOOLEAN_FLAG_TYPE:
 			res, err := s.boolean(ctx, store, env, f, req)
 			if err != nil {
-				return nil, err
+				eresp = &rpcevaluation.EvaluationResponse{
+					Type: rpcevaluation.EvaluationResponseType_ERROR_EVALUATION_RESPONSE_TYPE,
+					Response: &rpcevaluation.EvaluationResponse_ErrorResponse{
+						ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
+							FlagKey:    req.FlagKey,
+							NamespaceKey: req.NamespaceKey,
+							Reason:     rpcevaluation.ErrorEvaluationReason_INTERNAL_ERROR_EVALUATION_REASON,
+						},
+					},
+				}
+				resp.Responses = append(resp.Responses, eresp)
+				continue
 			}
 
 			if s.tracingEnabled {
@@ -537,7 +545,7 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 				)
 			}
 
-			eresp := &rpcevaluation.EvaluationResponse{
+			eresp = &rpcevaluation.EvaluationResponse{
 				Type: rpcevaluation.EvaluationResponseType_BOOLEAN_EVALUATION_RESPONSE_TYPE,
 				Response: &rpcevaluation.EvaluationResponse_BooleanResponse{
 					BooleanResponse: res,
@@ -548,7 +556,18 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 		case core.FlagType_VARIANT_FLAG_TYPE:
 			res, err := s.variant(ctx, store, env, f, req)
 			if err != nil {
-				return nil, err
+				eresp = &rpcevaluation.EvaluationResponse{
+					Type: rpcevaluation.EvaluationResponseType_ERROR_EVALUATION_RESPONSE_TYPE,
+					Response: &rpcevaluation.EvaluationResponse_ErrorResponse{
+						ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
+							FlagKey:    req.FlagKey,
+							NamespaceKey: req.NamespaceKey,
+							Reason:     rpcevaluation.ErrorEvaluationReason_INTERNAL_ERROR_EVALUATION_REASON,
+						},
+					},
+				}
+				resp.Responses = append(resp.Responses, eresp)
+				continue
 			}
 
 			if s.tracingEnabled {
@@ -561,7 +580,7 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 					tracing.AttributeFlagTypeVariant,
 				)
 			}
-			eresp := &rpcevaluation.EvaluationResponse{
+			eresp = &rpcevaluation.EvaluationResponse{
 				Type: rpcevaluation.EvaluationResponseType_VARIANT_EVALUATION_RESPONSE_TYPE,
 				Response: &rpcevaluation.EvaluationResponse_VariantResponse{
 					VariantResponse: res,
@@ -570,7 +589,18 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 
 			resp.Responses = append(resp.Responses, eresp)
 		default:
-			return nil, errs.ErrInvalidf("unknown flag type: %s", f.Type)
+			eresp = &rpcevaluation.EvaluationResponse{
+				Type: rpcevaluation.EvaluationResponseType_ERROR_EVALUATION_RESPONSE_TYPE,
+				Response: &rpcevaluation.EvaluationResponse_ErrorResponse{
+					ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
+						FlagKey:      req.FlagKey,
+						NamespaceKey: req.NamespaceKey,
+						Reason:       rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
+					},
+				},
+			}
+			resp.Responses = append(resp.Responses, eresp)
+			continue
 		}
 	}
 

--- a/internal/server/evaluation/evaluation.go
+++ b/internal/server/evaluation/evaluation.go
@@ -524,9 +524,9 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 					Type: rpcevaluation.EvaluationResponseType_ERROR_EVALUATION_RESPONSE_TYPE,
 					Response: &rpcevaluation.EvaluationResponse_ErrorResponse{
 						ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
-							FlagKey:    req.FlagKey,
+							FlagKey:      req.FlagKey,
 							NamespaceKey: req.NamespaceKey,
-							Reason:     rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
+							Reason:       rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
 						},
 					},
 				}
@@ -559,9 +559,9 @@ func (s *Server) Batch(ctx context.Context, b *rpcevaluation.BatchEvaluationRequ
 					Type: rpcevaluation.EvaluationResponseType_ERROR_EVALUATION_RESPONSE_TYPE,
 					Response: &rpcevaluation.EvaluationResponse_ErrorResponse{
 						ErrorResponse: &rpcevaluation.ErrorEvaluationResponse{
-							FlagKey:    req.FlagKey,
+							FlagKey:      req.FlagKey,
 							NamespaceKey: req.NamespaceKey,
-							Reason:     rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
+							Reason:       rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON,
 						},
 					},
 				}

--- a/internal/server/evaluation/evaluation_test.go
+++ b/internal/server/evaluation/evaluation_test.go
@@ -1071,7 +1071,7 @@ func TestBatch_UnknownFlagType(t *testing.T) {
 		Type:        3,
 	}, nil)
 
-	_, err := s.Batch(t.Context(), &rpcevaluation.BatchEvaluationRequest{
+	resp, err := s.Batch(t.Context(), &rpcevaluation.BatchEvaluationRequest{
 		Requests: []*rpcevaluation.EvaluationRequest{
 			{
 				FlagKey:      flagKey,
@@ -1084,8 +1084,11 @@ func TestBatch_UnknownFlagType(t *testing.T) {
 		},
 	})
 
-	require.Error(t, err)
-	assert.EqualError(t, err, "unknown flag type: 3")
+	assert.NoError(t, err)
+	require.Len(t, resp.GetResponses(), 1)
+	er := resp.GetResponses()[0].GetErrorResponse()
+	assert.NotNil(t, er)
+	assert.Equal(t, rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON, er.GetReason())
 }
 
 func TestBatch_InternalError_GetFlag(t *testing.T) {
@@ -1104,7 +1107,7 @@ func TestBatch_InternalError_GetFlag(t *testing.T) {
 
 	store.On("GetFlag", mock.Anything, storage.NewResource(namespaceKey, flagKey)).Return(&core.Flag{}, errors.New("internal error"))
 
-	_, err := s.Batch(t.Context(), &rpcevaluation.BatchEvaluationRequest{
+	resp, err := s.Batch(t.Context(), &rpcevaluation.BatchEvaluationRequest{
 		Requests: []*rpcevaluation.EvaluationRequest{
 			{
 				FlagKey:      flagKey,
@@ -1117,8 +1120,11 @@ func TestBatch_InternalError_GetFlag(t *testing.T) {
 		},
 	})
 
-	require.Error(t, err)
-	assert.EqualError(t, err, "internal error")
+	assert.NoError(t, err)
+	require.Len(t, resp.GetResponses(), 1)
+	er := resp.GetResponses()[0].GetErrorResponse()
+	assert.NotNil(t, er)
+	assert.Equal(t, rpcevaluation.ErrorEvaluationReason_NOT_FOUND_ERROR_EVALUATION_REASON, er.GetReason())
 }
 
 func TestBatch_Success(t *testing.T) {


### PR DESCRIPTION
The Batch evaluation endpoint fails the entire request on the first non-NotFound error from
GetFlag or flag evaluation. This means one bad flag in a batch request kills all results.

Changed to follow the same per-flag error response pattern used for ErrNotFound:
- GetFlag errors now always produce individual error responses
- Evaluation errors (boolean/variant) now produce per-flag error responses
- Unknown flag types now produce error responses instead of failing the batch

This makes the batch API resilient to individual failures while still returning results
for successfully evaluated flags.