### PR TITLE
fix(ui): guard namespace localStorage and pass envKey/nsKey in SSE events for invalidation

### DIFF
--- a/ui/jest.config.ts
+++ b/ui/jest.config.ts
@@ -134,7 +134,7 @@ export default {
   // runner: "jest-runner",
 
   // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  setupFiles: ['./jest.setup.ts'],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],

--- a/ui/jest.setup.ts
+++ b/ui/jest.setup.ts
@@ -1,0 +1,40 @@
+class MockStorage {
+  private store = new Map<string, string>();
+
+  get length(): number {
+    return this.store.size;
+  }
+
+  key(index: number): string | null {
+    const keys = Array.from(this.store.keys());
+    return keys[index] ?? null;
+  }
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+if (typeof globalThis.localStorage === 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: new MockStorage(),
+    writable: true,
+    configurable: true
+  });
+}
+
+if (typeof globalThis.fetch === 'undefined') {
+  globalThis.fetch = async () => ({ ok: true, status: 200 }) as Response;
+}

--- a/ui/src/data/hooks/useChangesStream.ts
+++ b/ui/src/data/hooks/useChangesStream.ts
@@ -47,14 +47,18 @@ export function useChangesStream({
           const streamEvent: StreamEvent = {
             type: data.type || 'message',
             timestamp: new Date().toISOString(),
-            data
+            data: { ...data, envKey: environmentKey, nsKey: namespaceKey }
           };
           dispatch(eventReceived(streamEvent));
         } catch {
           const streamEvent: StreamEvent = {
             type: 'message',
             timestamp: new Date().toISOString(),
-            data: { raw: event.data }
+            data: {
+              raw: event.data,
+              envKey: environmentKey,
+              nsKey: namespaceKey
+            }
           };
           dispatch(eventReceived(streamEvent));
         }

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options {"url": "https://test/"}
+ */
+import { flagsApi } from '~/app/flags/flagsApi';
+import { eventReceived } from '~/app/flags/streamingApi';
+import {
+  currentNamespaceChanged,
+  namespaceKey
+} from '~/app/namespaces/namespacesApi';
+import { segmentsApi } from '~/app/segments/segmentsApi';
+
+import { store } from '~/store';
+
+function spyOnApiUtil<
+  O extends Record<string, (...args: unknown[]) => unknown>,
+  M extends keyof O
+>(obj: O, method: M): { spy: jest.Mock; restore: () => void } {
+  const orig = obj[method];
+
+  if (typeof orig !== 'function') {
+    throw new Error(
+      `spyOnApiUtil: "${String(method)}" is not a function on the given object`
+    );
+  }
+
+  const spy = jest
+    .fn()
+    .mockImplementation((...args: unknown[]) => orig(...args));
+
+  for (const key of Object.getOwnPropertyNames(orig)) {
+    const descriptor = Object.getOwnPropertyDescriptor(orig, key);
+    if (descriptor && descriptor.writable) {
+      (spy as unknown as Record<string, unknown>)[key] = (
+        orig as unknown as Record<string, unknown>
+      )[key];
+    }
+  }
+
+  obj[method] = spy as unknown as O[M];
+  return {
+    spy,
+    restore: () => {
+      obj[method] = orig;
+    }
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.restoreAllMocks();
+});
+
+describe('namespace localStorage', () => {
+  it('stores namespace key in localStorage when set to a truthy value', () => {
+    store.dispatch(currentNamespaceChanged('production'));
+    expect(localStorage.getItem(namespaceKey)).toBe('production');
+  });
+
+  it('removes namespace key from localStorage when cleared', () => {
+    localStorage.setItem(namespaceKey, 'production');
+    store.dispatch(currentNamespaceChanged(''));
+    expect(localStorage.getItem(namespaceKey)).toBeNull();
+  });
+});
+
+describe('SSE cache invalidation', () => {
+  let flagSpy: jest.Mock;
+  let segmentSpy: jest.Mock;
+  let restoreFlag: () => void;
+  let restoreSegment: () => void;
+
+  beforeEach(() => {
+    const f = spyOnApiUtil(
+      flagsApi.util as Record<string, (...args: unknown[]) => unknown>,
+      'invalidateTags'
+    );
+    const s = spyOnApiUtil(
+      segmentsApi.util as Record<string, (...args: unknown[]) => unknown>,
+      'invalidateTags'
+    );
+    flagSpy = f.spy;
+    segmentSpy = s.spy;
+    restoreFlag = f.restore;
+    restoreSegment = s.restore;
+  });
+
+  afterEach(() => {
+    restoreFlag();
+    restoreSegment();
+  });
+
+  it('falls back to default/default when envKey and nsKey are not in event data', () => {
+    store.dispatch(
+      eventReceived({
+        type: 'refetchEvaluation',
+        timestamp: new Date().toISOString(),
+        data: { type: 'refetchEvaluation' }
+      })
+    );
+
+    expect(flagSpy).toHaveBeenCalledWith([
+      { type: 'Flag', id: 'default/default' }
+    ]);
+    expect(segmentSpy).toHaveBeenCalledWith([
+      { type: 'Segment', id: 'default/default' }
+    ]);
+  });
+
+  it('uses envKey and nsKey from event data when provided', () => {
+    store.dispatch(
+      eventReceived({
+        type: 'refetchEvaluation',
+        timestamp: new Date().toISOString(),
+        data: {
+          type: 'refetchEvaluation',
+          envKey: 'staging',
+          nsKey: 'email'
+        }
+      })
+    );
+
+    expect(flagSpy).toHaveBeenCalledWith([
+      { type: 'Flag', id: 'staging/email' }
+    ]);
+    expect(segmentSpy).toHaveBeenCalledWith([
+      { type: 'Segment', id: 'staging/email' }
+    ]);
+  });
+});

--- a/ui/src/store.ts
+++ b/ui/src/store.ts
@@ -75,10 +75,12 @@ listenerMiddleware.startListening({
   matcher: isAnyOf(namespacesSlice.actions.currentNamespaceChanged),
   effect: (_action, api) => {
     // save to local storage
-    localStorage.setItem(
-      namespaceKey,
-      (api.getState() as RootState).namespaces.currentNamespace
-    );
+    const ns = (api.getState() as RootState).namespaces.currentNamespace;
+    if (ns) {
+      localStorage.setItem(namespaceKey, ns);
+    } else {
+      localStorage.removeItem(namespaceKey);
+    }
   }
 });
 
@@ -137,6 +139,8 @@ listenerMiddleware.startListening({
     const eventData = action.payload.data as {
       type?: string;
       etag?: string;
+      envKey?: string;
+      nsKey?: string;
     } | null;
 
     if (eventData?.type !== 'refetchEvaluation') {
@@ -144,9 +148,8 @@ listenerMiddleware.startListening({
       return;
     }
 
-    const state = api.getState() as RootState;
-    const envKey = state.environments.currentEnvironment;
-    const nsKey = state.namespaces.currentNamespace;
+    const envKey = eventData.envKey ?? 'default';
+    const nsKey = eventData.nsKey ?? 'default';
     const tagId = envKey + '/' + nsKey;
 
     api.dispatch(flagsApi.util.invalidateTags([{ type: 'Flag', id: tagId }]));


### PR DESCRIPTION
Guard against storing null in localStorage when namespace is cleared,
using removeItem instead.  Pass envKey and nsKey in SSE event payloads
from useChangesStream so the cache invalidation listener reads them
directly instead of resolving from store state selectors.

closes #5822
