### PR TITLE
fix(validation): correct less-than operator from "le" to "lt" in schema

### DIFF
--- a/core/validation/flipt.cue
+++ b/core/validation/flipt.cue
@@ -115,7 +115,7 @@ close({
 	property:     string & =~"^.+$"
 	value?:       string
 	description?: string | null
-	operator:     "eq" | "neq" | "present" | "notpresent" | "le" | "lte" | "gt" | "gte"
+	operator:     "eq" | "neq" | "present" | "notpresent" | "lt" | "lte" | "gt" | "gte"
 } | {
 	type:         "NUMBER_COMPARISON_TYPE"
 	property:     string & =~"^.+$"
@@ -138,7 +138,7 @@ close({
 	property:     string & =~"^.+$"
 	value?:       string
 	description?: string | null
-	operator:     "eq" | "neq" | "present" | "notpresent" | "le" | "lte" | "gt" | "gte"
+	operator:     "eq" | "neq" | "present" | "notpresent" | "lt" | "lte" | "gt" | "gte"
 } | {
 	type:         "ENTITY_ID_COMPARISON_TYPE"
 	property:     string & =~"^.+$"

--- a/core/validation/flipt.json
+++ b/core/validation/flipt.json
@@ -270,7 +270,7 @@
                   "neq",
                   "present",
                   "notpresent",
-                  "le",
+                  "lt",
                   "lte",
                   "gt",
                   "gte",
@@ -395,7 +395,7 @@
               "neq",
               "present",
               "notpresent",
-              "le",
+              "lt",
               "lte",
               "gt",
               "gte"

--- a/core/validation/testdata/valid_constraint_lt_operator.yaml
+++ b/core/validation/testdata/valid_constraint_lt_operator.yaml
@@ -1,0 +1,16 @@
+version: "1.2"
+namespace: default
+segments:
+- key: lt-users
+  name: LT Users
+  description: Users matched with less-than comparisons.
+  match_type: ALL_MATCH_TYPE
+  constraints:
+  - type: NUMBER_COMPARISON_TYPE
+    property: age
+    operator: lt
+    value: "30"
+  - type: DATETIME_COMPARISON_TYPE
+    property: signed_up_at
+    operator: lt
+    value: "2024-01-01T00:00:00Z"

--- a/core/validation/validate_test.go
+++ b/core/validation/validate_test.go
@@ -65,6 +65,20 @@ func TestValidate_ConstraintListValues(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidate_ConstraintLTOperator(t *testing.T) {
+	const file = "testdata/valid_constraint_lt_operator.yaml"
+	f, err := os.Open(file)
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	v, err := NewFeaturesValidator()
+	require.NoError(t, err)
+
+	err = v.Validate(file, f)
+	assert.NoError(t, err)
+}
+
 func TestValidate_DefaultVariant_V3(t *testing.T) {
 	const file = "testdata/valid_default_variant_v3.yaml"
 	f, err := os.Open(file)


### PR DESCRIPTION
## Summary

Fixes a typo in the validation schema where the less-than operator for `NUMBER_COMPARISON_TYPE` and `DATETIME_COMPARISON_TYPE` constraints was listed as `le` instead of `lt`. The rest of the codebase (`rpc/flipt/operators.go` `OpLT = "lt"`, the evaluator, and its tests) uses `lt`, so any segment with a less-than constraint failed schema validation with a confusing empty-disjunction error.

Fixes #6303

## Changes

- **Modified `core/validation/flipt.cue`**: replaced `"le"` with `"lt"` in the number and datetime constraint operator lists (2 lines)
- **Modified `core/validation/flipt.json`**: same fix in the JSON Schema mirror (2 lines)
- **Added `core/validation/validate_test.go`**: `TestValidate_ConstraintLTOperator` covering `lt` constraints for both number and datetime types — fails before this fix, passes after
- **Added `core/validation/testdata/valid_constraint_lt_operator.yaml`**: fixture for the new test

## Backward Compatibility

No breaking changes: `le` was never a valid operator anywhere else in Flipt (it is not in `rpc/flipt/operators.go` and the evaluator does not handle it), so no existing valid configuration could have relied on it.

## Additional Notes

All existing validation tests pass. The new test reproduces the exact error from the issue when run against the unfixed schema.
