### PR TITLE
fix(validation): correct less-than operator from "le" to "lt" in schema

### DIFF
--- a/core/validation/flipt.cue
+++ b/core/validation/flipt.cue
@@ -98,7 +98,7 @@ close({
 	property:     string & =~"^.+$"
 	value?:       string
 	description?: string
-	operator:     "eq" | "neq" | "present" | "notpresent" | "le" | "lte" | "gt" | "gte" | "isoneof" | "isnotoneof"
+	operator:     "eq" | "neq" | "present" | "notpresent" | "lt" | "lte" | "gt" | "gte" | "isoneof" | "isnotoneof"
 } | {
 	type:         "BOOLEAN_COMPARISON_TYPE"
 	property:     string & =~"^.+$"
@@ -110,7 +110,7 @@ close({
 	property:     string & =~"^.+$"
 	value?:       string
 	description?: string
-	operator:     "eq" | "neq" | "present" | "notpresent" | "le" | "lte" | "gt" | "gte"
+	operator:     "eq" | "neq" | "present" | "notpresent" | "lt" | "lte" | "gt" | "gte"
 } | {
 	type:         "ENTITY_ID_COMPARISON_TYPE"
 	property:     string & =~"^.+$"

--- a/core/validation/flipt.json
+++ b/core/validation/flipt.json
@@ -167,7 +167,7 @@
               "neq",
               "present",
               "notpresent",
-              "le",
+              "lt",
               "lte",
               "gt",
               "gte",
@@ -212,7 +212,7 @@
               "neq",
               "present",
               "notpresent",
-              "le",
+              "lt",
               "lte",
               "gt",
               "gte"

--- a/core/validation/testdata/valid_constraint_lt_operator.yaml
+++ b/core/validation/testdata/valid_constraint_lt_operator.yaml
@@ -1,0 +1,16 @@
+version: "1.2"
+namespace: default
+segments:
+- key: lt-users
+  name: LT Users
+  description: Users matched with less-than comparisons.
+  match_type: ALL_MATCH_TYPE
+  constraints:
+  - type: NUMBER_COMPARISON_TYPE
+    property: age
+    operator: lt
+    value: "30"
+  - type: DATETIME_COMPARISON_TYPE
+    property: signed_up_at
+    operator: lt
+    value: "2024-01-01T00:00:00Z"

--- a/core/validation/validate_test.go
+++ b/core/validation/validate_test.go
@@ -51,6 +51,20 @@ func TestValidate_Segments_V2(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidate_ConstraintLTOperator(t *testing.T) {
+	const file = "testdata/valid_constraint_lt_operator.yaml"
+	f, err := os.Open(file)
+	require.NoError(t, err)
+
+	defer f.Close()
+
+	v, err := NewFeaturesValidator()
+	require.NoError(t, err)
+
+	err = v.Validate(file, f)
+	assert.NoError(t, err)
+}
+
 func TestValidate_DefaultVariant_V3(t *testing.T) {
 	const file = "testdata/valid_default_variant_v3.yaml"
 	f, err := os.Open(file)


### PR DESCRIPTION
The CUE schema (and the JSON Schema mirror) listed the less-than
operator for NUMBER_COMPARISON_TYPE and DATETIME_COMPARISON_TYPE
constraints as "le" instead of "lt". The rest of the codebase
(rpc/flipt/operators.go OpLT, the evaluator, and its tests) uses
"lt", so any segment with a less-than constraint failed schema
validation with a confusing empty-disjunction error, e.g.:

    segments.0.constraints.0: 4 errors in empty disjunction:
    segments.0.constraints.0.type: conflicting values
    "STRING_COMPARISON_TYPE" and "NUMBER_COMPARISON_TYPE" ...

Note the asymmetry prior to this change: the schema allowed gt and
gte on the greater-than side, but le and lte on the less-than side.

- Replace "le" with "lt" in flipt.cue for number and datetime
  constraint operators
- Same fix in the flipt.json JSON Schema
- Add TestValidate_ConstraintLTOperator covering lt constraints for
  both number and datetime types (fails before this fix, passes after)

 same as #6304 but for v1
