### PR TITLE
fix(http): reject invalid UTF-8 request paths

### DIFF
--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -228,25 +228,10 @@ func NewHTTPServer(
 	r.Mount("/health", runtime.NewServeMux(runtime.WithHealthEndpointAt(grpc_health_v1.NewHealthClient(conn), "/health")))
 
 	if cfg.UI.Enabled {
-		fs, err := ui.FS()
+		err := mountUI(r, logger)
 		if err != nil {
 			return nil, fmt.Errorf("mounting ui: %w", err)
 		}
-
-		// Reject malformed request paths (e.g. percent-encoded bytes that are
-		// not valid UTF-8) with a 400 before they reach the static file server,
-		// whose underlying fs.FS turns them into an unlogged 500. Scoped to the
-		// UI mount so API and other non-UI routes are unaffected.
-		r.With(validateRequestPath(logger), func(next http.Handler) http.Handler {
-			// set additional headers enabling the UI to be served securely
-			// ie: Content-Security-Policy, X-Content-Type-Options, etc.
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				for k, v := range ui.AdditionalHeaders() {
-					w.Header().Set(k, v)
-				}
-				next.ServeHTTP(w, r)
-			})
-		}).Mount("/", http.FileServer(http.FS(fs)))
 	}
 
 	server.Server = &http.Server{
@@ -279,6 +264,26 @@ func NewHTTPServer(
 	}
 
 	return server, nil
+}
+
+// mountUI configures the chi mux to serve the embedded UI filesystem at the
+// root path, applying security headers and request path validation.
+func mountUI(r *chi.Mux, logger *zap.Logger) error {
+	fs, err := ui.FS()
+	if err != nil {
+		return err
+	}
+	r.With(validateRequestPath(logger), func(next http.Handler) http.Handler {
+		// set additional headers enabling the UI to be served securely
+		// ie: Content-Security-Policy, X-Content-Type-Options, etc.
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for k, v := range ui.AdditionalHeaders() {
+				w.Header().Set(k, v)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}).Mount("/", http.FileServer(http.FS(fs)))
+	return nil
 }
 
 func crossOriginProtection(logger *zap.Logger, trustedOrigins []string) func(http.Handler) http.Handler {
@@ -326,19 +331,20 @@ func removeTrailingSlash(h http.Handler) http.Handler {
 // with no log output at any level.
 //
 // Returning 400 here keeps malformed input in the correct status class and
-// emits a debug log line so the behaviour is observable.
-//
-// See https://github.com/flipt-io/flipt/issues/6337.
+// emits a debug log line so the behavior is observable.
 func validateRequestPath(logger *zap.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !utf8.ValidString(r.URL.Path) {
-				// Log the percent-encoded form so we never emit raw invalid
-				// bytes into structured log output.
-				logger.Debug("rejecting request with invalid UTF-8 path",
-					zap.String("method", r.Method),
-					zap.String("path", r.URL.EscapedPath()),
-				)
+				if logger.Core().Enabled(zap.DebugLevel) {
+					// Log the percent-encoded form so we never emit raw invalid
+					// bytes into structured log output.
+					logger.Debug(
+						"rejecting request with invalid UTF-8 path",
+						zap.String("method", r.Method),
+						zap.String("path", r.URL.EscapedPath()),
+					)
+				}
 				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}

--- a/internal/cmd/http.go
+++ b/internal/cmd/http.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -232,7 +233,11 @@ func NewHTTPServer(
 			return nil, fmt.Errorf("mounting ui: %w", err)
 		}
 
-		r.With(func(next http.Handler) http.Handler {
+		// Reject malformed request paths (e.g. percent-encoded bytes that are
+		// not valid UTF-8) with a 400 before they reach the static file server,
+		// whose underlying fs.FS turns them into an unlogged 500. Scoped to the
+		// UI mount so API and other non-UI routes are unaffected.
+		r.With(validateRequestPath(logger), func(next http.Handler) http.Handler {
 			// set additional headers enabling the UI to be served securely
 			// ie: Content-Security-Policy, X-Content-Type-Options, etc.
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -309,6 +314,37 @@ func removeTrailingSlash(h http.Handler) http.Handler {
 		r.URL.Path = strings.TrimSuffix(r.URL.Path, "/")
 		h.ServeHTTP(w, r)
 	})
+}
+
+// validateRequestPath is HTTP middleware that rejects requests whose URL path
+// is not valid UTF-8 once percent-decoded.
+//
+// A path that cannot be decoded as valid UTF-8 is malformed client input and
+// should produce a 4xx response. Without this guard such requests reach the
+// static file server, whose underlying fs.FS rejects invalid UTF-8 names with
+// a non-"not found" error that net/http maps to a 500 Internal Server Error,
+// with no log output at any level.
+//
+// Returning 400 here keeps malformed input in the correct status class and
+// emits a debug log line so the behaviour is observable.
+//
+// See https://github.com/flipt-io/flipt/issues/6337.
+func validateRequestPath(logger *zap.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !utf8.ValidString(r.URL.Path) {
+				// Log the percent-encoded form so we never emit raw invalid
+				// bytes into structured log output.
+				logger.Debug("rejecting request with invalid UTF-8 path",
+					zap.String("method", r.Method),
+					zap.String("path", r.URL.EscapedPath()),
+				)
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 // ofrepStreamHandler returns an http.HandlerFunc that rewrites OFREP stream

--- a/internal/cmd/http_test.go
+++ b/internal/cmd/http_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,7 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/flipt/internal/config"
 	"go.flipt.io/flipt/internal/server/common"
+	"go.flipt.io/flipt/ui"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 const (
@@ -159,4 +164,158 @@ func TestOFREPStreamAlias_AcceptsOnlySSE(t *testing.T) {
 			assert.Equal(t, tt.expectedCode == http.StatusOK, called)
 		})
 	}
+}
+
+// TestValidateRequestPath covers the middleware that rejects request paths
+// which are not valid UTF-8 after percent-decoding. Such paths are malformed
+// client input and must surface as a 4xx (with a log line) rather than being
+// forwarded to handlers that turn them into an unlogged 5xx.
+//
+// See https://github.com/flipt-io/flipt/issues/6337.
+func TestValidateRequestPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string // decoded path, as set on r.URL.Path by net/http
+		wantStatus  int
+		wantReached bool
+		wantLogged  bool
+	}{
+		// valid paths pass through to the downstream handler
+		{name: "ascii root", path: "/", wantStatus: http.StatusOK, wantReached: true},
+		{name: "ascii path", path: "/nonexistent-path-12345", wantStatus: http.StatusOK, wantReached: true},
+		{name: "valid utf8 cafe", path: "/café", wantStatus: http.StatusOK, wantReached: true},
+		// invalid UTF-8 paths are rejected with 400 and never reach downstream
+		{name: "invalid lone 0xc0", path: "/\xc0", wantStatus: http.StatusBadRequest, wantLogged: true},
+		{name: "invalid lone 0xff", path: "/\xff", wantStatus: http.StatusBadRequest, wantLogged: true},
+		{name: "invalid overlong", path: "/\xe0\x80\xaf", wantStatus: http.StatusBadRequest, wantLogged: true},
+		{name: "invalid surrogate half", path: "/\xed\xa0\x80", wantStatus: http.StatusBadRequest, wantLogged: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, recorded := observer.New(zapcore.DebugLevel)
+			logger := zap.New(core)
+
+			var reached bool
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				reached = true
+				w.WriteHeader(http.StatusOK)
+			})
+			h := validateRequestPath(logger)(next)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "https://flipt.io", nil)
+			req.URL.Path = tt.path
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.wantStatus, rec.Code, "unexpected status for path %q", tt.path)
+			assert.Equal(t, tt.wantReached, reached, "downstream reached=%v for path %q", reached, tt.path)
+			if tt.wantLogged {
+				assert.NotZero(t, recorded.Len(), "expected a debug log line for invalid path %q", tt.path)
+			} else {
+				assert.Zero(t, recorded.Len(), "unexpected log line for path %q", tt.path)
+			}
+		})
+	}
+}
+
+// TestInvalidUTF8PathRejected exercises the UI mount (the chi router with the
+// static file server mounted at "/") to ensure that validateRequestPath,
+// scoped to the UI FileServer, rejects percent-encoded paths decoding to
+// invalid UTF-8 with a 400 Bad Request, while valid paths reach the file
+// server normally and non-UI (API) routes are left untouched by the guard.
+//
+// This is a regression test for https://github.com/flipt-io/flipt/issues/6337
+// where such paths produced a 500 Internal Server Error with no log output.
+func TestInvalidUTF8PathRejected(t *testing.T) {
+	core, recorded := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	fsys, err := ui.FS()
+	require.NoError(t, err)
+
+	r := chi.NewRouter()
+
+	// Non-UI routes are mounted on the root router without validateRequestPath,
+	// mirroring how API routes are mounted in NewHTTPServer. An invalid UTF-8
+	// path on such a route must reach the handler, not be rejected by the guard
+	// that is scoped to the UI FileServer below.
+	var apiReached bool
+	r.Mount("/api/v1", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		apiReached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Mirror the UI mount in internal/cmd/http.go: validateRequestPath plus a
+	// header-setting middleware wrapping the static file server, mounted as the
+	// catch-all at "/".
+	r.With(validateRequestPath(logger), func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for k, v := range ui.AdditionalHeaders() {
+				w.Header().Set(k, v)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}).Mount("/", http.FileServer(http.FS(fsys)))
+
+	s := httptest.NewServer(r)
+	t.Cleanup(s.Close)
+
+	// do sends a request preserving the raw percent-encoded path (like
+	// `curl --path-as-is`), so the server percent-decodes it itself.
+	do := func(t *testing.T, path string) *http.Response {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.URL+path, nil)
+		require.NoError(t, err)
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return res
+	}
+
+	t.Run("invalid UTF-8 UI paths return 400 and are logged", func(t *testing.T) {
+		for _, p := range []string{"/%c0", "/%c1", "/%ff", "/%e0%80%af", "/%ed%a0%80"} {
+			before := recorded.Len()
+			res := do(t, p)
+			body, _ := io.ReadAll(res.Body)
+			res.Body.Close()
+			assert.Equalf(t, http.StatusBadRequest, res.StatusCode,
+				"path %s: expected 400, got %d (body=%q)", p, res.StatusCode, string(body))
+			assert.Greater(t, recorded.Len(), before, "path %s: expected a debug log line", p)
+		}
+	})
+
+	t.Run("invalid UTF-8 on non-UI route is not intercepted", func(t *testing.T) {
+		// The guard is scoped to the UI FileServer; an invalid UTF-8 path on a
+		// non-UI route must reach that route's handler instead of being rejected
+		// with 400 by validateRequestPath.
+		apiReached = false
+		before := recorded.Len()
+		res := do(t, "/api/v1/%c0")
+		res.Body.Close()
+		assert.Equal(t, http.StatusOK, res.StatusCode,
+			"non-UI route should be reached, not rejected with 400")
+		assert.True(t, apiReached, "non-UI handler should have been reached")
+		assert.Equal(t, before, recorded.Len(),
+			"validateRequestPath must not fire for non-UI routes")
+	})
+
+	t.Run("valid unknown path returns 404 and is not logged", func(t *testing.T) {
+		before := recorded.Len()
+		res := do(t, "/nonexistent-path-12345")
+		res.Body.Close()
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+		assert.Equal(t, before, recorded.Len())
+	})
+
+	t.Run("valid utf8 unknown path returns 404", func(t *testing.T) {
+		res := do(t, "/caf%c3%a9")
+		res.Body.Close()
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+	})
+
+	t.Run("root serves index", func(t *testing.T) {
+		res := do(t, "/")
+		res.Body.Close()
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+	})
 }

--- a/internal/cmd/http_test.go
+++ b/internal/cmd/http_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/flipt/internal/config"
 	"go.flipt.io/flipt/internal/server/common"
-	"go.flipt.io/flipt/ui"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
@@ -231,9 +230,6 @@ func TestInvalidUTF8PathRejected(t *testing.T) {
 	core, recorded := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 
-	fsys, err := ui.FS()
-	require.NoError(t, err)
-
 	r := chi.NewRouter()
 
 	// Non-UI routes are mounted on the root router without validateRequestPath,
@@ -246,41 +242,34 @@ func TestInvalidUTF8PathRejected(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// Mirror the UI mount in internal/cmd/http.go: validateRequestPath plus a
-	// header-setting middleware wrapping the static file server, mounted as the
-	// catch-all at "/".
-	r.With(validateRequestPath(logger), func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			for k, v := range ui.AdditionalHeaders() {
-				w.Header().Set(k, v)
-			}
-			next.ServeHTTP(w, r)
-		})
-	}).Mount("/", http.FileServer(http.FS(fsys)))
+	err := mountUI(r, logger)
+	require.NoError(t, err)
 
 	s := httptest.NewServer(r)
 	t.Cleanup(s.Close)
 
-	// do sends a request preserving the raw percent-encoded path (like
+	// fetch sends a request preserving the raw percent-encoded path (like
 	// `curl --path-as-is`), so the server percent-decodes it itself.
-	do := func(t *testing.T, path string) *http.Response {
+	fetch := func(t *testing.T, path string) (int, []byte) {
 		t.Helper()
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, s.URL+path, nil)
 		require.NoError(t, err)
 		res, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
-		return res
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		err = res.Body.Close()
+		require.NoError(t, err)
+		return res.StatusCode, body
 	}
 
 	t.Run("invalid UTF-8 UI paths return 400 and are logged", func(t *testing.T) {
 		for _, p := range []string{"/%c0", "/%c1", "/%ff", "/%e0%80%af", "/%ed%a0%80"} {
 			before := recorded.Len()
-			res := do(t, p)
-			body, _ := io.ReadAll(res.Body)
-			res.Body.Close()
-			assert.Equalf(t, http.StatusBadRequest, res.StatusCode,
-				"path %s: expected 400, got %d (body=%q)", p, res.StatusCode, string(body))
-			assert.Greater(t, recorded.Len(), before, "path %s: expected a debug log line", p)
+			statusCode, body := fetch(t, p)
+			assert.Equalf(t, http.StatusBadRequest, statusCode,
+				"path %s: want 400, got %d (body=%q)", p, statusCode, string(body))
+			assert.Greater(t, recorded.Len(), before, "path %s: want a debug log line", p)
 		}
 	})
 
@@ -290,9 +279,8 @@ func TestInvalidUTF8PathRejected(t *testing.T) {
 		// with 400 by validateRequestPath.
 		apiReached = false
 		before := recorded.Len()
-		res := do(t, "/api/v1/%c0")
-		res.Body.Close()
-		assert.Equal(t, http.StatusOK, res.StatusCode,
+		statusCode, _ := fetch(t, "/api/v1/%c0")
+		assert.Equal(t, http.StatusOK, statusCode,
 			"non-UI route should be reached, not rejected with 400")
 		assert.True(t, apiReached, "non-UI handler should have been reached")
 		assert.Equal(t, before, recorded.Len(),
@@ -301,21 +289,18 @@ func TestInvalidUTF8PathRejected(t *testing.T) {
 
 	t.Run("valid unknown path returns 404 and is not logged", func(t *testing.T) {
 		before := recorded.Len()
-		res := do(t, "/nonexistent-path-12345")
-		res.Body.Close()
-		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+		statusCode, _ := fetch(t, "/nonexistent-path-12345")
+		assert.Equal(t, http.StatusNotFound, statusCode)
 		assert.Equal(t, before, recorded.Len())
 	})
 
 	t.Run("valid utf8 unknown path returns 404", func(t *testing.T) {
-		res := do(t, "/caf%c3%a9")
-		res.Body.Close()
-		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+		statusCode, _ := fetch(t, "/caf%c3%a9")
+		assert.Equal(t, http.StatusNotFound, statusCode)
 	})
 
 	t.Run("root serves index", func(t *testing.T) {
-		res := do(t, "/")
-		res.Body.Close()
-		assert.Equal(t, http.StatusOK, res.StatusCode)
+		statusCode, _ := fetch(t, "/")
+		assert.Equal(t, http.StatusOK, statusCode)
 	})
 }


### PR DESCRIPTION
## Summary

Requests whose percent-decoded path contains invalid UTF-8 can reach the UI/static-file handler and surface as an unlogged 500. These are malformed client requests, so the server should reject them before downstream handlers.

This adds request-path validation middleware that returns 400 for invalid UTF-8 paths and logs the rejected request at debug level using the escaped path. Valid UTF-8 paths continue through the existing router unchanged.

## Tests

Added unit and full-router regression coverage for:
- lone invalid bytes
- overlong UTF-8 sequences
- surrogate-half encodings
- valid ASCII and multibyte UTF-8 paths
- normal 404/root behavior through the full UI mount

Verified with:
- `go test ./internal/cmd -run 'TestValidateRequestPath|TestInvalidUTF8PathRejected' -count=1`\n- `git diff --check`\n\n
 
 
Fixes #6337