### PR TITLE
fix(authz): authorize v2 create RPCs as create

### DIFF
--- a/internal/server/authz/middleware/grpc/middleware.go
+++ b/internal/server/authz/middleware/grpc/middleware.go
@@ -58,6 +58,16 @@ func WithServerSkipsAuthorization(server any) containers.Option[InterceptorOptio
 
 var errUnauthorized = errors.ErrUnauthorizedf("permission denied")
 
+func authorizationRequest(fullMethod string, request flipt.Request) flipt.Request {
+	switch fullMethod {
+	case environments.EnvironmentsService_CreateNamespace_FullMethodName,
+		environments.EnvironmentsService_CreateResource_FullMethodName:
+		request.Action = flipt.ActionCreate
+	}
+
+	return request
+}
+
 func AuthorizationRequiredInterceptor(logger *zap.Logger, policyVerifier authz.Verifier, o ...containers.Option[InterceptorOptions]) grpc.UnaryServerInterceptor {
 	var opts InterceptorOptions
 	containers.ApplyAll(&opts, o...)
@@ -82,6 +92,8 @@ func AuthorizationRequiredInterceptor(logger *zap.Logger, policyVerifier authz.V
 		}
 
 		for _, request := range requester.Request() {
+			request = authorizationRequest(info.FullMethod, request)
+
 			allowed, err := policyVerifier.IsAllowed(ctx, map[string]any{
 				"request":        request,
 				"authentication": auth,

--- a/internal/server/authz/middleware/grpc/middleware.go
+++ b/internal/server/authz/middleware/grpc/middleware.go
@@ -58,6 +58,8 @@ func WithServerSkipsAuthorization(server any) containers.Option[InterceptorOptio
 
 var errUnauthorized = errors.ErrUnauthorizedf("permission denied")
 
+// authorizationRequest derives the action from the RPC method because create and
+// update RPCs share the same protobuf request messages.
 func authorizationRequest(fullMethod string, request flipt.Request) flipt.Request {
 	switch fullMethod {
 	case environments.EnvironmentsService_CreateNamespace_FullMethodName,

--- a/internal/server/authz/middleware/grpc/middleware_test.go
+++ b/internal/server/authz/middleware/grpc/middleware_test.go
@@ -56,6 +56,55 @@ var adminAuth = &authrpc.Authentication{
 	},
 }
 
+func TestAuthorizationActionForCreateAndUpdateMethods(t *testing.T) {
+	tests := []struct {
+		name       string
+		fullMethod string
+		req        flipt.Requester
+		want       flipt.Request
+	}{
+		{
+			name:       "create namespace",
+			fullMethod: environments.EnvironmentsService_CreateNamespace_FullMethodName,
+			req:        &environments.UpdateNamespaceRequest{EnvironmentKey: "default", Key: "namespace"},
+			want:       flipt.NewRequest(flipt.ScopeEnvironment, flipt.ActionCreate, flipt.WithEnvironment("default"), flipt.WithNamespace("namespace")),
+		},
+		{
+			name:       "update namespace",
+			fullMethod: environments.EnvironmentsService_UpdateNamespace_FullMethodName,
+			req:        &environments.UpdateNamespaceRequest{EnvironmentKey: "default", Key: "namespace"},
+			want:       flipt.NewRequest(flipt.ScopeEnvironment, flipt.ActionUpdate, flipt.WithEnvironment("default"), flipt.WithNamespace("namespace")),
+		},
+		{
+			name:       "create resource",
+			fullMethod: environments.EnvironmentsService_CreateResource_FullMethodName,
+			req:        &environments.UpdateResourceRequest{EnvironmentKey: "default", NamespaceKey: "namespace"},
+			want:       flipt.NewRequest(flipt.ScopeNamespace, flipt.ActionCreate, flipt.WithEnvironment("default"), flipt.WithNamespace("namespace")),
+		},
+		{
+			name:       "update resource",
+			fullMethod: environments.EnvironmentsService_UpdateResource_FullMethodName,
+			req:        &environments.UpdateResourceRequest{EnvironmentKey: "default", NamespaceKey: "namespace"},
+			want:       flipt.NewRequest(flipt.ScopeNamespace, flipt.ActionUpdate, flipt.WithEnvironment("default"), flipt.WithNamespace("namespace")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policyVerifier := &mockPolicyVerifier{isAllowed: true}
+			ctx := authmiddlewaregrpc.ContextWithAuthentication(t.Context(), adminAuth)
+			info := &grpc.UnaryServerInfo{Server: &mockServer{}, FullMethod: tt.fullMethod}
+
+			_, err := AuthorizationRequiredInterceptor(zap.NewNop(), policyVerifier)(ctx, tt.req, info, func(context.Context, any) (any, error) {
+				return nil, nil
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, policyVerifier.input["request"])
+		})
+	}
+}
+
 func TestAuthorizationRequiredInterceptor(t *testing.T) {
 	tests := []struct {
 		name                             string


### PR DESCRIPTION
## Summary
- map CreateNamespace and CreateResource gRPC calls to the `create` authorization action
- retain `update` authorization for the corresponding update calls
- add interceptor coverage for all four create/update RPC method names

Create and update RPCs intentionally share protobuf request shapes, so the request type cannot distinguish their authorization intent. The interceptor derives that action from the invoked RPC full method, avoiding a breaking protobuf/client API change while covering direct gRPC and REST gateway requests.

## Verification
- `go test ./internal/server/authz/middleware/grpc`
- `mise run fmt`
- `mise run lint`

Fixes #6397