### PR TITLE
fix(credentials): make insecure_ignore_host_key work without a known_hosts file

### DIFF
--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -1,6 +1,7 @@
 package credentials
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -8,6 +9,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/go-git/go-git/v6/plumbing/client"
+	"github.com/go-git/go-git/v6/plumbing/transport"
 	githttp "github.com/go-git/go-git/v6/plumbing/transport/http"
 	gitssh "github.com/go-git/go-git/v6/plumbing/transport/ssh"
 	"github.com/jferrl/go-githubauth"
@@ -38,6 +40,26 @@ func (s *CredentialSource) Get(name string) (*Credential, error) {
 type Credential struct {
 	logger *zap.Logger
 	config *config.CredentialConfig
+}
+
+// insecureHostKeyAuth wraps an SSH auth method whose HostKeyCallback has already been
+// set to ssh.InsecureIgnoreHostKey, guaranteeing HostKeyAlgorithms is non-empty so that
+// go-git does not fall back to reading known_hosts. See GitAuthentication for detail.
+type insecureHostKeyAuth struct {
+	*gitssh.PublicKeys
+}
+
+func (a insecureHostKeyAuth) ClientConfig(ctx context.Context, req *transport.Request) (*ssh.ClientConfig, error) {
+	cfg, err := a.PublicKeys.ClientConfig(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(cfg.HostKeyAlgorithms) == 0 {
+		cfg.HostKeyAlgorithms = ssh.SupportedAlgorithms().HostKeys
+	}
+
+	return cfg, nil
 }
 
 // GitAuthentication returns the appropriate client.Option for Git operations.
@@ -77,6 +99,26 @@ func (c *Credential) GitAuthentication() (client.Option, error) {
 		if c.config.SSH.InsecureIgnoreHostKey {
 			// nolint:gosec
 			method.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+
+			// Setting HostKeyCallback alone is not enough. go-git still reads
+			// known_hosts in order to pre-populate HostKeyAlgorithms, and returns an
+			// error when no known_hosts file exists -- even though a HostKeyCallback
+			// has been supplied:
+			//
+			//	} else if len(config.HostKeyAlgorithms) == 0 {
+			//		db, err := newKnownHostsDb()
+			//		if err != nil {
+			//			return nil, err
+			//		}
+			//
+			// (go-git plumbing/transport/ssh/ssh.go, Transport.connect)
+			//
+			// So on a host with no known_hosts file -- a container, typically --
+			// insecure_ignore_host_key still fails with "unable to find any valid
+			// known_hosts file, set SSH_KNOWN_HOSTS env variable". Pre-populating the
+			// algorithms skips that lookup. Their ordering is a negotiation preference
+			// rather than a correctness requirement, so the defaults are fine here.
+			return client.WithSSHAuth(insecureHostKeyAuth{PublicKeys: method}), nil
 		}
 
 		return client.WithSSHAuth(method), nil

--- a/internal/credentials/insecure_host_key_test.go
+++ b/internal/credentials/insecure_host_key_test.go
@@ -1,0 +1,82 @@
+package credentials
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"path/filepath"
+	"testing"
+
+	gitssh "github.com/go-git/go-git/v6/plumbing/transport/ssh"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.flipt.io/flipt/internal/config"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/go-git/go-git/v6/plumbing/transport"
+)
+
+func testPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	blk, err := ssh.MarshalPrivateKey(priv, "")
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(blk))
+}
+
+// withoutKnownHosts points HOME and SSH_KNOWN_HOSTS at locations with no known_hosts
+// file, reproducing a container environment.
+func withoutKnownHosts(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SSH_KNOWN_HOSTS", filepath.Join(t.TempDir(), "does-not-exist"))
+}
+
+// TestInsecureHostKeyAuthClientConfig asserts that insecure_ignore_host_key yields a
+// usable *ssh.ClientConfig on a host with no known_hosts file.
+//
+// go-git reads known_hosts solely to pre-populate HostKeyAlgorithms and returns an error
+// when the file is absent, even though a HostKeyCallback has been supplied. Without
+// HostKeyAlgorithms set, connecting fails with "unable to find any valid known_hosts
+// file, set SSH_KNOWN_HOSTS env variable", making insecure_ignore_host_key inoperative.
+func TestInsecureHostKeyAuthClientConfig(t *testing.T) {
+	withoutKnownHosts(t)
+
+	method, err := gitssh.NewPublicKeys("git", []byte(testPrivateKeyPEM(t)), "")
+	require.NoError(t, err)
+	// nolint:gosec
+	method.HostKeyCallback = ssh.InsecureIgnoreHostKey()
+
+	cfg, err := insecureHostKeyAuth{PublicKeys: method}.ClientConfig(t.Context(), &transport.Request{})
+	require.NoError(t, err, "ClientConfig must not require a known_hosts file")
+	assert.NotNil(t, cfg.HostKeyCallback)
+	assert.NotEmpty(t, cfg.HostKeyAlgorithms,
+		"HostKeyAlgorithms must be pre-populated so go-git does not consult known_hosts")
+}
+
+// TestGitAuthenticationSSHInsecureIgnoreHostKey covers the same case through the public
+// entry point, ensuring the wrapper is actually applied when the option is set.
+func TestGitAuthenticationSSHInsecureIgnoreHostKey(t *testing.T) {
+	withoutKnownHosts(t)
+
+	c := &Credential{
+		logger: zaptest.NewLogger(t),
+		config: &config.CredentialConfig{
+			Type: config.CredentialTypeSSH,
+			SSH: &config.SSHAuthConfig{
+				User:                  "git",
+				PrivateKeyBytes:       testPrivateKeyPEM(t),
+				InsecureIgnoreHostKey: true,
+			},
+		},
+	}
+
+	opt, err := c.GitAuthentication()
+	require.NoError(t, err)
+	require.NotNil(t, opt)
+}


### PR DESCRIPTION
## Problem

  `credentials.<name>.ssh.insecure_ignore_host_key` has no effect on a host that has no
  known_hosts file — which is the normal case for a container, and the main situation the
  option exists for. A git fetch using an SSH credential fails at startup with:

  initializing environment store: environment "x": performing initial fetch:
  unable to find any valid known_hosts file, set SSH_KNOWN_HOSTS env variable
  
  ## Cause

  Setting `HostKeyCallback` is not sufficient. go-git reads known_hosts a *second* time,
  solely to pre-populate `HostKeyAlgorithms`, and returns an error when the file is absent —
  even though a `HostKeyCallback` has already been supplied:

  ```go
  } else if len(config.HostKeyAlgorithms) == 0 {
      db, err := newKnownHostsDb()
      if err != nil {
          return nil, err
      }
      config.HostKeyAlgorithms = db.HostKeyAlgorithms(hostWithPort)
  }
```

  (go-git/plumbing/transport/ssh/ssh.go, Transport.connect)

  ssh.InsecureIgnoreHostKey() sets only the callback and never the algorithms, so that
  branch always runs and the connection is rejected before host key verification is even
  reached.

  ## Fix

  Wrap the SSH auth so HostKeyAlgorithms is pre-populated with the defaults, which skips
  the known_hosts lookup entirely. Algorithm ordering is a negotiation preference rather
  than a correctness requirement, so the defaults are safe here.

  The wrapper is applied only when insecure_ignore_host_key is set — verified
  connections keep their existing code path and continue to require known_hosts.