### PR TITLE
fix(ui): add canBeUndone prop to DeletePanel for variant deletions

### DIFF
--- a/ui/src/components/panels/DeletePanel.tsx
+++ b/ui/src/components/panels/DeletePanel.tsx
@@ -17,6 +17,7 @@ type DeletePanelProps = {
   setOpen: (open: boolean) => void;
   handleDelete: (...args: string[]) => Promise<any>;
   panelType: string;
+  canBeUndone?: boolean;
   onSuccess?: () => void;
   onError?: () => void;
 };
@@ -27,6 +28,7 @@ export default function DeletePanel(props: DeletePanelProps) {
     setOpen,
     panelType,
     panelMessage,
+    canBeUndone,
     onSuccess,
     handleDelete,
     onError
@@ -43,8 +45,9 @@ export default function DeletePanel(props: DeletePanelProps) {
         <DialogHeader>
           <DialogTitle>Delete {panelType}</DialogTitle>
           <DialogDescription>
-            This action is <span className="underline">destructive</span> and
-            cannot be undone.
+            {canBeUndone
+              ? 'You can cancel and the changes will be restored.'
+              : 'This action is <span className="underline">destructive</span> and cannot be undone.'}
           </DialogDescription>
         </DialogHeader>
         <div className="my-2">{panelMessage}</div>

--- a/ui/src/components/variants/Variants.tsx
+++ b/ui/src/components/variants/Variants.tsx
@@ -57,6 +57,7 @@ export default function Variants({ variants }: VariantsProps) {
           </>
         }
         panelType="Variant"
+        canBeUndone
         setOpen={setShowDeleteVariantModal}
         handleDelete={() => {
           try {


### PR DESCRIPTION
DeletePanel now accepts an optional canBeUndone prop. When true, the dialog shows a non-destructive message instead of 'destructive and cannot be undone'.

Variant deletions within an unsaved flag are reversible by canceling the changes, but the generic DeletePanel always showed the irreversible warning. This mismatch confused users (issue #6405).

Variants.tsx now passes canBeUndone when opening the variant delete modal.