### PR TITLE
fix(storage/git): use git-safe environment names for branch refs

### DIFF
--- a/internal/names/refslug.go
+++ b/internal/names/refslug.go
@@ -1,0 +1,62 @@
+package names
+
+import (
+	"strings"
+	"unicode"
+)
+
+// RefSlug returns name in a form that Git accepts as one path component of a
+// reference name (see git-check-ref-format). Each character or sequence that
+// Git does not permit is replaced with a hyphen. A name that is already valid
+// is returned unchanged, so existing branch names keep their exact form.
+//
+// Examples:
+//
+//	"Dev Playground" -> "Dev-Playground"
+//	"my/feature"     -> "my-feature"
+//	"release..1"     -> "release.-1"
+//	"production"     -> "production"
+func RefSlug(name string) string {
+	var (
+		b    strings.Builder
+		prev rune
+	)
+
+	b.Grow(len(name))
+
+	for _, r := range name {
+		switch {
+		case r < 0x20 || r == 0x7f || unicode.IsSpace(r):
+			// control characters and whitespace
+			r = '-'
+		case strings.ContainsRune("~^:?*[\\/", r):
+			// characters git rejects anywhere in a reference name
+			r = '-'
+		case r == '.' && (prev == '.' || prev == 0):
+			// no ".." and no leading "."
+			r = '-'
+		case r == '{' && prev == '@':
+			// no "@{"
+			r = '-'
+		}
+
+		b.WriteRune(r)
+		prev = r
+	}
+
+	s := b.String()
+
+	if s == "@" {
+		return "-"
+	}
+
+	if base, ok := strings.CutSuffix(s, ".lock"); ok {
+		s = base + "-lock"
+	}
+
+	if base, ok := strings.CutSuffix(s, "."); ok {
+		s = base + "-"
+	}
+
+	return s
+}

--- a/internal/names/refslug_test.go
+++ b/internal/names/refslug_test.go
@@ -1,0 +1,55 @@
+package names
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefSlug(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// names that are already valid must not change
+		{name: "simple", in: "production", want: "production"},
+		{name: "hyphens and dots", in: "my--env.v1", want: "my--env.v1"},
+		{name: "leading hyphen", in: "-env", want: "-env"},
+		{name: "unicode letters", in: "größe", want: "größe"},
+		{name: "at sign", in: "team@flipt", want: "team@flipt"},
+
+		// names with characters git does not permit
+		{name: "space", in: "Dev Playground", want: "Dev-Playground"},
+		{name: "tab and newline", in: "a\tb\nc", want: "a-b-c"},
+		{name: "slash", in: "my/feature", want: "my-feature"},
+		{name: "control character", in: "a\x01b", want: "a-b"},
+		{name: "del character", in: "a\x7fb", want: "a-b"},
+		{name: "special characters", in: "a~b^c:d?e*f[g\\h", want: "a-b-c-d-e-f-g-h"},
+		{name: "double dot", in: "release..1", want: "release.-1"},
+		{name: "triple dot", in: "a...b", want: "a.-.b"},
+		{name: "leading dot", in: ".hidden", want: "-hidden"},
+		{name: "trailing dot", in: "env.", want: "env-"},
+		{name: "at brace", in: "a@{b", want: "a@-b"},
+		{name: "only at sign", in: "@", want: "-"},
+		{name: "lock suffix", in: "env.lock", want: "env-lock"},
+		{name: "only lock suffix", in: ".lock", want: "-lock"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RefSlug(tt.in)
+			assert.Equal(t, tt.want, got)
+
+			// the slug must always form a valid git branch name in the
+			// position Flipt uses it: flipt/<environment>/<branch>
+			ref := plumbing.NewBranchReferenceName("flipt/" + got + "/branch")
+			require.NoError(t, ref.Validate(), "slug %q must be a valid reference component", got)
+
+			// the slug of a slug is the slug itself
+			assert.Equal(t, got, RefSlug(got))
+		})
+	}
+}

--- a/internal/server/environments/storage.go
+++ b/internal/server/environments/storage.go
@@ -10,6 +10,7 @@ import (
 
 	"go.flipt.io/flipt/errors"
 	"go.flipt.io/flipt/internal/common"
+	"go.flipt.io/flipt/internal/names"
 	"go.flipt.io/flipt/internal/storage"
 	"go.flipt.io/flipt/rpc/flipt"
 	"go.flipt.io/flipt/rpc/v2/environments"
@@ -184,7 +185,7 @@ func (e *EnvironmentStore) Branch(ctx context.Context, base string, branch strin
 	}
 
 	for key := range e.byKey {
-		if strings.EqualFold(key, strings.TrimSpace(branch)) {
+		if strings.EqualFold(key, names.RefSlug(strings.TrimSpace(branch))) {
 			return nil, errors.ErrAlreadyExistsf("environment: %q", branch)
 		}
 	}

--- a/internal/storage/environments/git/store.go
+++ b/internal/storage/environments/git/store.go
@@ -97,8 +97,21 @@ func NewEnvironmentFromRepo(
 func (e *Environment) Branches() []string {
 	return []string{
 		e.currentBranch,
-		fmt.Sprintf("flipt/%s/*", e.cfg.Name),
+		e.branchRef("*"),
 	}
+}
+
+// branchPrefix returns the Git branch prefix under which Flipt stores the
+// branches of this environment. The environment name is passed through
+// names.RefSlug because Git does not permit some characters (for example
+// spaces) in reference names. Names that are already valid are unchanged.
+func (e *Environment) branchPrefix() string {
+	return fmt.Sprintf("flipt/%s/", names.RefSlug(e.cfg.Name))
+}
+
+// branchRef returns the full Git branch name for a branch of this environment.
+func (e *Environment) branchRef(branch string) string {
+	return e.branchPrefix() + branch
 }
 
 func (e *Environment) Key() string {
@@ -162,18 +175,19 @@ func (e *Environment) Configuration() *rpcenvironments.EnvironmentConfiguration 
 // that is backed by the new branch.
 // The new Environment is added to the branches map and the current branch is updated.
 func (e *Environment) Branch(ctx context.Context, branch string) (serverenvs.Environment, error) {
-	var (
-		branchPrefix = fmt.Sprintf("flipt/%s/", e.cfg.Name)
-		name         = strings.TrimSpace(strings.TrimPrefix(branch, branchPrefix))
-	)
+	name := strings.TrimSpace(strings.TrimPrefix(branch, e.branchPrefix()))
 
 	if name == "" {
 		// generate a name for the branched environment if no name is provided
 		name = names.Random()
 	}
 
+	// the branch key is also a component of the Git branch name,
+	// so it must only contain characters that Git permits
+	name = names.RefSlug(name)
+
 	var (
-		branchName = fmt.Sprintf("%s%s", branchPrefix, name)
+		branchName = e.branchRef(name)
 		cfg        = *e.cfg
 	)
 
@@ -244,8 +258,7 @@ func (e *Environment) DeleteBranch(ctx context.Context, branch string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	gitBranch := fmt.Sprintf("flipt/%s/%s", e.cfg.Name, branch)
-	if err := e.repo.DeleteBranch(ctx, gitBranch); err != nil {
+	if err := e.repo.DeleteBranch(ctx, e.branchRef(branch)); err != nil {
 		return err
 	}
 
@@ -286,7 +299,7 @@ func (e *branchEnvIterator) All() iter.Seq[*branchEnvConfig] {
 			branch := strings.TrimPrefix(r.Name().String(), "refs/remotes/origin/")
 
 			// if one of our branches that we created
-			if candidate, ok := strings.CutPrefix(branch, fmt.Sprintf("flipt/%s/", e.env.cfg.Name)); ok {
+			if candidate, ok := strings.CutPrefix(branch, e.env.branchPrefix()); ok {
 				// get the name of the environment from the branch name
 				// e.g. flipt/my-env/my-branch -> my-env
 				name, _, _ := strings.Cut(candidate, "/")
@@ -732,7 +745,7 @@ func (e *Environment) RefreshEnvironment(ctx context.Context, refs map[string]st
 				zap.String("branch", branchName),
 			)
 			delete(e.branches, branchName)
-			delete(e.refs, fmt.Sprintf("flipt/%s/%s", e.cfg.Name, branchName))
+			delete(e.refs, e.branchRef(branchName))
 			result.DeletedBranchKeys = append(result.DeletedBranchKeys, branchName)
 		}
 	}

--- a/internal/storage/environments/git/store_test.go
+++ b/internal/storage/environments/git/store_test.go
@@ -3,12 +3,17 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/go-git/go-git/v6"
+	gitconfig "github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.flipt.io/flipt/errors"
@@ -878,4 +883,95 @@ func Test_Environment_Branch_WithSpaces(t *testing.T) {
 	assert.Equal(t, "spaced-branch", branchEnv.Key())
 	// The full branch name should be properly constructed
 	assert.Equal(t, "flipt/production/spaced-branch", branchEnv.(*Environment).currentBranch)
+}
+
+// newTestEnvironmentWithRemote creates a bare remote repository with one commit
+// on main, opens a bare Flipt repository against it and returns an environment
+// with the given name that is subscribed to the repository.
+func newTestEnvironmentWithRemote(t *testing.T, envName string) (*Environment, *storagegit.Repository) {
+	t.Helper()
+
+	logger := zaptest.NewLogger(t)
+	ctx := t.Context()
+
+	remoteDir := t.TempDir()
+	_, err := git.PlainInit(remoteDir, true, git.WithDefaultBranch(plumbing.NewBranchReferenceName("main")))
+	require.NoError(t, err)
+
+	bootstrapDir := t.TempDir()
+	bootstrapRepo, err := git.PlainInit(bootstrapDir, false, git.WithDefaultBranch(plumbing.NewBranchReferenceName("main")))
+	require.NoError(t, err)
+	_, err = bootstrapRepo.CreateRemote(&gitconfig.RemoteConfig{Name: "origin", URLs: []string{remoteDir}})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(bootstrapDir, "init.txt"), []byte("init"), 0o600))
+	wt, err := bootstrapRepo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add("init.txt")
+	require.NoError(t, err)
+	_, err = wt.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+	require.NoError(t, bootstrapRepo.Push(&git.PushOptions{RemoteName: "origin"}))
+
+	repo, err := storagegit.NewRepository(ctx, logger,
+		storagegit.WithFilesystemStorage(t.TempDir()),
+		storagegit.WithRemote("origin", remoteDir),
+		storagegit.WithSignature("test", "test@test.com"),
+	)
+	require.NoError(t, err)
+
+	cfg := &config.EnvironmentConfig{Name: envName, Default: true}
+	env, err := NewEnvironmentFromRepo(ctx, logger, cfg, repo, fs.NewStorage(logger), evaluation.NoopPublisher, config.TemplatesConfig{})
+	require.NoError(t, err)
+
+	repo.Subscribe(env)
+
+	return env, repo
+}
+
+// Test_Environment_NameWithSpace is a regression test for
+// https://github.com/flipt-io/flipt/issues/6491.
+//
+// The environment name is used as part of the Git branch names that Flipt
+// creates and fetches. A space is not permitted in a Git reference name
+// (see git-check-ref-format), so an environment name with a space must not
+// stop the server from starting and must not produce invalid branch names.
+func Test_Environment_NameWithSpace(t *testing.T) {
+	const envName = "Dev Playground"
+
+	t.Run("startup fetch succeeds", func(t *testing.T) {
+		env, repo := newTestEnvironmentWithRemote(t, envName)
+
+		// this is the fetch that runs when the environment store is initialized
+		require.NoError(t, repo.Fetch(t.Context()))
+
+		// the API key of the environment is still the configured name
+		assert.Equal(t, envName, env.Key())
+	})
+
+	t.Run("branches use a git-safe prefix", func(t *testing.T) {
+		env, repo := newTestEnvironmentWithRemote(t, envName)
+
+		branchEnv, err := env.Branch(t.Context(), "my feature")
+		require.NoError(t, err)
+		assert.Equal(t, "my-feature", branchEnv.Key())
+
+		gitBranch := branchEnv.(*Environment).currentBranch
+		assert.Equal(t, "flipt/Dev-Playground/my-feature", gitBranch)
+		require.NoError(t, plumbing.NewBranchReferenceName(gitBranch).Validate(),
+			"branch %q must be a valid git reference name", gitBranch)
+
+		resp, err := env.ListBranches(t.Context())
+		require.NoError(t, err)
+		require.Len(t, resp.Branches, 1)
+		assert.Equal(t, "my-feature", resp.Branches[0].Key)
+		assert.Equal(t, gitBranch, resp.Branches[0].Ref)
+		assert.Equal(t, envName, resp.Branches[0].EnvironmentKey)
+
+		// the branch now exists on the remote, so the poller fetches it
+		require.NoError(t, repo.Fetch(t.Context()))
+
+		require.NoError(t, env.DeleteBranch(t.Context(), "my-feature"))
+	})
 }

--- a/internal/storage/git/repository_test.go
+++ b/internal/storage/git/repository_test.go
@@ -1175,3 +1175,132 @@ func TestUpdateAndPush_NonFastForwardRetry(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "interfering commit", parentCommit.Message)
 }
+
+// commitAndPush writes one file in the worktree of repo, commits it and pushes
+// the current branch to origin. It returns the hash of the new commit.
+func commitAndPush(t *testing.T, repo *git.Repository, dir, file, message string) plumbing.Hash {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, file), []byte(message), 0o600))
+
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	_, err = wt.Add(file)
+	require.NoError(t, err)
+
+	hash, err := wt.Commit(message, &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@test.com", When: time.Now()},
+	})
+	require.NoError(t, err)
+	require.NoError(t, repo.Push(&git.PushOptions{RemoteName: "origin"}))
+
+	return hash
+}
+
+// TestUpdateAndPush_BranchAfterBaseAdvances_BareRepo_Shallows is a regression
+// test for https://github.com/flipt-io/flipt/issues/6478.
+//
+// A Flipt branch is created from the base branch. Then the base branch
+// advances. After the next depth=1 fetch both branch heads are shallow
+// boundaries and the branch head is the parent of the base head:
+//
+//	A---B---C  main
+//	    |
+//	    +----  flipt/main/target
+//
+// A commit D on top of B is a fast-forward of flipt/main/target and the push
+// must succeed. Older go-git releases rejected it with a false
+// "non-fast-forward update" error because B was ignored during the ancestry
+// walk (go-git/go-git#2367).
+func TestUpdateAndPush_BranchAfterBaseAdvances_BareRepo_Shallows(t *testing.T) {
+	// TODO: remove this skip once go-git includes the fix from
+	// https://github.com/go-git/go-git/pull/2373 (go-git/go-git#2367).
+	t.Skip("blocked on an upstream go-git fix, see https://github.com/flipt-io/flipt/issues/6478")
+
+	const (
+		base   = "main"
+		branch = "flipt/main/target"
+	)
+
+	remoteDir := t.TempDir()
+	remoteRepo, err := git.PlainInit(
+		remoteDir, true,
+		git.WithDefaultBranch(plumbing.NewBranchReferenceName(base)),
+	)
+	require.NoError(t, err)
+
+	// A and B: the base branch history before the Flipt branch is created.
+	bootstrapDir := t.TempDir()
+	bootstrapRepo, err := git.PlainInit(
+		bootstrapDir, false,
+		git.WithDefaultBranch(plumbing.NewBranchReferenceName(base)),
+	)
+	require.NoError(t, err)
+	_, err = bootstrapRepo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{remoteDir},
+	})
+	require.NoError(t, err)
+	commitAndPush(t, bootstrapRepo, bootstrapDir, "a.txt", "commit A")
+	branchPoint := commitAndPush(t, bootstrapRepo, bootstrapDir, "b.txt", "commit B")
+
+	// Flipt opens a bare repository, which fetches with depth=1.
+	repo, _, err := newRepository(
+		t.Context(), zap.NewNop(),
+		WithFilesystemStorage(t.TempDir()),
+		WithRemote("origin", remoteDir),
+		WithSignature("test", "test@test.com"),
+	)
+	require.NoError(t, err)
+	require.False(t, repo.isNormalRepo, "should be bare repository")
+
+	// Create the Flipt branch from B and push it to the remote.
+	require.NoError(t, repo.CreateBranchIfNotExists(t.Context(), branch, WithBase(base)))
+	branchRef, err := remoteRepo.Reference(plumbing.NewBranchReferenceName(branch), true)
+	require.NoError(t, err)
+	require.Equal(t, branchPoint, branchRef.Hash(), "branch must start at B")
+
+	// C: the base branch advances behind our back.
+	interferingDir := t.TempDir()
+	interferingRepo, err := git.PlainClone(interferingDir, &git.CloneOptions{URL: remoteDir})
+	require.NoError(t, err)
+	baseHead := commitAndPush(t, interferingRepo, interferingDir, "c.txt", "commit C")
+
+	// The storage poller fetches the base branch and all Flipt branches.
+	require.NoError(t, repo.Fetch(t.Context(), base, "flipt/main/*"))
+
+	shallows, err := repo.Storer.Shallow()
+	require.NoError(t, err)
+	require.ElementsMatch(t, []plumbing.Hash{branchPoint, baseHead}, shallows,
+		"both branch heads must be shallow boundaries")
+
+	// D: edit the Flipt branch. Its parent is B, so this is a fast-forward.
+	hash, err := repo.UpdateAndPush(t.Context(), branch, func(fs envsfs.Filesystem) (string, error) {
+		fi, err := fs.OpenFile("d.txt", os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o644)
+		if err != nil {
+			return "", err
+		}
+		if _, err := fi.Write([]byte("commit D")); err != nil {
+			return "", err
+		}
+		if err := fi.Close(); err != nil {
+			return "", err
+		}
+		return "commit D", nil
+	})
+	require.NoError(t, err, "a direct child of the branch head is a fast-forward")
+	require.False(t, hash.IsZero())
+
+	branchRef, err = remoteRepo.Reference(plumbing.NewBranchReferenceName(branch), true)
+	require.NoError(t, err)
+	assert.Equal(t, hash, branchRef.Hash(), "remote branch must point to D")
+
+	commitObj, err := remoteRepo.CommitObject(hash)
+	require.NoError(t, err)
+	assert.Equal(t, "commit D", commitObj.Message)
+	assert.Equal(t, []plumbing.Hash{branchPoint}, commitObj.ParentHashes, "D must be a child of B")
+
+	baseRef, err := remoteRepo.Reference(plumbing.NewBranchReferenceName(base), true)
+	require.NoError(t, err)
+	assert.Equal(t, baseHead, baseRef.Hash(), "base branch must be untouched")
+}


### PR DESCRIPTION
## Why

Flipt v2.12.0 fails to start when an environment name contains a space (#6491):

```
initializing environment store: invalid ref-prefix "refs/heads/flipt/Dev Playground/": contains whitespace or control character
```

The environment name is used as a component of the Git branch names Flipt creates and fetches (`flipt/<environment>/<branch>`). Git does not permit spaces and some other characters in reference names. Older go-git versions were lenient, and go-git v6.0.0-alpha.5 now rejects the ref prefix during fetch.

Downgrading go-git is not an option. The current code depends on packages that only exist in alpha.5, and the other go-git regression (#6478) is present in every tagged v6 version.

## What

- Add `names.RefSlug`. It replaces only the characters and sequences that Git rejects with `-`. Names that are already valid are returned unchanged, so this is a no-op for existing users.
- The environment store builds every branch name through one helper, `branchPrefix()`, which applies the slug. Branch keys passed to the API get the same treatment, for example `my feature` becomes `my-feature`.
- The environment key exposed by the API and UI is still the configured name, for example `Dev Playground`.
- The duplicate-branch check in the server layer compares against the slug.

Branches with a space could never be pushed to a real Git server, so there is no data to migrate.

## Tests

- `TestRefSlug`: table test that also validates every result with go-git's reference validator.
- `Test_Environment_NameWithSpace`: regression test for #6491. It fails on the `v2` branch and passes here. It covers the startup fetch, branch creation, listing, a second fetch, and deletion.
- `TestUpdateAndPush_BranchAfterBaseAdvances_BareRepo_Shallows`: regression test for #6478. It reproduces the false `non-fast-forward update` error and passes with go-git/go-git#2373 applied. It is skipped with a TODO until we bump go-git to a version that includes that fix.

Fixes #6491
Refs #6478
