### PR TITLE
ci: repair the go:modernize task

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -230,12 +230,14 @@ buf lint
 """
 
 [tasks."go:modernize"]
-description = "Run Go modernize tool"
+description = "Apply modern Go idioms"
 run = """
 #!/usr/bin/env bash
 set -euo pipefail
 echo " > Running modernize..."
-go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -category=-omitzero -fix -test ./...
+# run the same modernize analyzers that CI runs, so the set of enabled
+# analyses lives only in .golangci.yml
+golangci-lint run --default=none -E modernize --fix ./...
 """
 
 [tasks."go:proto"]


### PR DESCRIPTION
## Why

`mise run go:modernize` fails on any checkout:

```
 > Running modernize...
flag provided but not defined: -category
```

The task runs the standalone modernize tool at `@latest`. gopls v0.23.0 turned modernize into a multi-analyzer checker with one boolean flag per analysis and removed `-category`, so the task exits before it examines any code. Pinning an older version does not help, because `-category` is absent from v0.22.0 as well.

CI is unaffected. It runs golangci-lint, which has the `modernize` linter enabled and disables the `omitzero` and `stringsbuilder` analyses in `.golangci.yml`. The local task and CI had drifted apart, and only the local task was broken.

## What

Run modernize through golangci-lint with only that linter enabled. The set of enabled analyses now lives only in `.golangci.yml`, so the task matches what CI enforces and cannot break again when the upstream tool changes its flags.

The task description in `CLAUDE.md` already reads "Apply modern Go idioms", so no docs change is needed.

## Test

```
$ mise run go:modernize
 > Running modernize...
0 issues.
```
